### PR TITLE
Upload coverage report to covecov when unit test GH action runs

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -34,4 +34,10 @@ jobs:
       run: npm run build
 
     - name: Run Pytest tests
-      run: AWS_DEFAULT_REGION=eu-west-2 poetry run pytest --cov=app/main  --cov-report term-missing  -vvv app/tests/
+      run: AWS_DEFAULT_REGION=eu-west-2 poetry run pytest --cov=app/main  --cov-report term-missing  -rsa -vvv app/tests/
+
+    - name: Generate coverage XML
+      run: poetry run coverage xml
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0%


### PR DESCRIPTION
## Changes in this PR

- Upload coverage report to covecov when unit test GH action runs
- Set codecov config

Once this is merged in, all subsequent PRs will have the coverage reports created in our test GH Action uploaded to codecov which will then be able to compare against previous runs (specifically against latest run on main) and error if the coverage has reduced, to encourage tests to be added for any new codepaths!

Note: codecov is free for public repos and we use it for various caselaw repos. We also use codeclimate there due to other code inspection it does but I think codecov is sufficient for us for now given all of our other checks in this repo already.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-477?atlOrigin=eyJpIjoiZGIyMmQzYTI0ZWU4NDgzZTljYmUzZTUxNjBjMzA0ODEiLCJwIjoiaiJ9