### PR TITLE
WIP | Ayr 447/sandbox deployment in ci

### DIFF
--- a/.github/workflows/deploy_to_sandbox.yml
+++ b/.github/workflows/deploy_to_sandbox.yml
@@ -1,0 +1,37 @@
+name: Deploy to Sandbox
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  unit_test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Build GOV.UK Frontend assets
+      run: sh ./build.sh
+
+    - name: Install Node dependencies
+      run: npm install
+
+    - name: Build CSS
+      run: npm run build
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.11
+
+    - name: Install Poetry
+      run: pip install poetry
+
+    - name: Install only prod python dependencies
+      run: poetry install --without dev --sync
+
+    - name: Run Pytest tests
+      run: poetry run zappa update sandbox


### PR DESCRIPTION
## Changes in this PR

- Added deploy_to_sandbox GH action workflow


Note:  Still need to decide on what AWS profile we can use to run Zappa in GH actions. Will speak with @ben-cerium about this. Once confirmed, will set the env var for it in the repo.

## JIRA ticket

https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?assignee=63b4326678aabbefa9d4400d&selectedIssue=AYR-447

