### PR TITLE
Add djlint to precommit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,12 @@ repos:
     -   id: check-added-large-files
     -   id: check-merge-conflict
 
+- repo: https://github.com/Riverside-Healthcare/djLint
+  rev: v1.33.0
+  hooks:
+    - id: djlint-reformat
+      args: ["--no-function-formatting"]
+
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,7 @@ repos:
   hooks:
     - id: djlint-reformat
       args: ["--no-function-formatting"]
+    - id: djlint
 
 -   repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,243 +1,243 @@
 {% extends 'govuk_frontend_jinja/template.html' %}
-
-{%- from 'govuk_frontend_jinja/components/cookie-banner/macro.html' import govukCookieBanner-%}
-{%- from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary-%}
+{%- from 'govuk_frontend_jinja/components/cookie-banner/macro.html' import govukCookieBanner -%}
+{%- from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary -%}
 {%- from 'govuk_frontend_jinja/components/notification-banner/macro.html' import govukNotificationBanner -%}
 {%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
-
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
-
-{% block pageTitle %}{{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}{{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block head %}
-  <meta name="description" content="{{config['SERVICE_NAME']}}">
-  <meta name="keywords" content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
-  <meta name="author" content="{{config['DEPARTMENT_NAME']}}">
-  <!--[if gt IE 8]><!--><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-4.7.0.min.css') }}" /><!--<![endif]-->
-  <!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-ie8-4.7.0.min.css') }}" /><![endif]-->
-   <!-- custom css stylesheet -->
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='poc-search.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='index.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='signed-out.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='footer.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='header.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='record.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='browse.css') }}" />
-   <link rel="stylesheet" type="text/css" src="{{ url_for('static', filename='pagination.css') }}" />
-   <!-- custom css stylesheet end -->
-  {% assets "css" %}<link href="{{ ASSET_URL }}" rel="stylesheet">{% endassets %}
+    <meta name="description" content="{{ config['SERVICE_NAME'] }}">
+    <meta name="keywords"
+          content="GOV.UK, govuk, gov, government, uk, frontend, ui, user interface, jinja, python, flask, port, template, templating, macro, component, design system, html, forms, wtf, wtforms, widget, widgets, demo, example">
+    <meta name="author" content="{{ config['DEPARTMENT_NAME'] }}">
+    <!--[if gt IE 8]><!-->
+    <link rel="stylesheet"
+          type="text/css"
+          href="{{ url_for('static', filename='govuk-frontend-4.7.0.min.css') }}" />
+    <!--<![endif]-->
+    <!--[if IE 8]><link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='govuk-frontend-ie8-4.7.0.min.css') }}" /><![endif]-->
+    <!-- custom css stylesheet -->
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='poc-search.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='index.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='signed-out.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='footer.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='header.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='record.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='browse.css') }}" />
+    <link rel="stylesheet"
+          type="text/css"
+          src="{{ url_for('static', filename='pagination.css') }}" />
+    <!-- custom css stylesheet end -->
+    {% assets "css" %}
+        <link href="{{ ASSET_URL }}" rel="stylesheet">
+    {% endassets %}
 {% endblock %}
-
 {% block bodyStart %}
-  {% if "cookies_policy" not in request.cookies %}
-    {% set html %}
-      <p class="govuk-body">We use some essential cookies to make this service work.</p>
-      <p class="govuk-body">We’d like to set additional cookies so we can remember your settings, understand how people use the service and make improvements.</p>
-    {% endset %}
-
-    {% set acceptHtml %}
-      <p class="govuk-body">You’ve accepted additional cookies. You can <a class="govuk-link" href="{{ url_for('main.cookies') }}">change your cookie settings</a> at any time.</p>
-    {% endset %}
-
-    {% set rejectHtml %}
-      <p class="govuk-body">You’ve rejected additional cookies. You can <a class="govuk-link" href="{{ url_for('main.cookies') }}">change your cookie settings</a> at any time.</p>
-    {% endset %}
-
-    {{ govukCookieBanner({
-      'ariaLabel': "Cookies on " + config['SERVICE_NAME'],
-      'attributes': {
+    {% if "cookies_policy" not in request.cookies %}
+        {% set html %}
+            <p class="govuk-body">We use some essential cookies to make this service work.</p>
+            <p class="govuk-body">
+                We’d like to set additional cookies so we can remember your settings, understand how people use the service and make
+                improvements.
+            </p>
+        {% endset %}
+        {% set acceptHtml %}
+            <p class="govuk-body">
+                You’ve accepted additional cookies. You can <a class="govuk-link" href="{{ url_for('main.cookies') }}">change your
+                cookie settings</a> at any time.
+            </p>
+        {% endset %}
+        {% set rejectHtml %}
+            <p class="govuk-body">
+                You’ve rejected additional cookies. You can <a class="govuk-link" href="{{ url_for('main.cookies') }}">change your
+                cookie settings</a> at any time.
+            </p>
+        {% endset %}
+        {{ govukCookieBanner({
+        'ariaLabel': "Cookies on " + config['SERVICE_NAME'],
+        'attributes': {
         'id': "cookie-banner"
-      },
-      'messages': [
+        },
+        'messages': [
         {
-          'attributes': {
-            'id': "default-message"
-          },
-          'headingText': "Cookies on " + config['SERVICE_NAME'],
-          'html': html,
-          'actions': [
-            {
-              'attributes': {
-                'id': "accept-cookies"
-              },
-              'text': "Accept additional cookies",
-              'type': "button",
-              'name': "cookies",
-              'value': "accept"
-            },
-            {
-              'attributes': {
-                'id': "reject-cookies"
-              },
-              'text': "Reject additional cookies",
-              'type': "button",
-              'name': "cookies",
-              'value': "reject"
-            },
-            {
-              'text': "View cookies",
-              'href': url_for('main.cookies')
-            }
-          ]
+        'attributes': {
+        'id': "default-message"
+        },
+        'headingText': "Cookies on " + config['SERVICE_NAME'],
+        'html': html,
+        'actions': [
+        {
+        'attributes': {
+        'id': "accept-cookies"
+        },
+        'text': "Accept additional cookies",
+        'type': "button",
+        'name': "cookies",
+        'value': "accept"
         },
         {
-          'attributes': {
-            'id': "accepted-message"
-          },
-          'html': acceptHtml,
-          'role': "alert",
-          'hidden': true,
-          'actions': [
-            {
-              'attributes': {
-                'id': "accepted-hide"
-              },
-              'text': "Hide this message"
-            }
-          ]
+        'attributes': {
+        'id': "reject-cookies"
+        },
+        'text': "Reject additional cookies",
+        'type': "button",
+        'name': "cookies",
+        'value': "reject"
         },
         {
-          'attributes': {
-            'id': "rejected-message"
-          },
-          'html': rejectHtml,
-          'role': "alert",
-          'hidden': true,
-          'actions': [
-            {
-              'attributes': {
-                'id': "rejected-hide"
-              },
-              'text': "Hide this message"
-            }
-          ]
+        'text': "View cookies",
+        'href': url_for("main.cookies")
         }
-      ]
-    }) }}
-  {% endif %}
-{% endblock %}
-
-{% block header %}
-<header class="govuk-header" role="banner" data-module="govuk-header">
-  <div class="govuk-header__container govuk-header__container--ayr govuk-width-container">
-    <div class="govuk-header__logo">
-      <a href="/" class="govuk-header__link govuk-header__link--homepage">
-        <span class="govuk-header__logotype-text govuk-header__logotype--ayr">Access Your Records (AYR)</span>
-        </a>
-      </div>
-      <div class="govuk-header__content govuk-header__content--tna">
-       Delivered by
-      <a href="https://www.nationalarchives.gov.uk/" class="govuk-header__link
-      govuk-header__link--tna"> The National Archives</a>
-    </div>
-  </div>
-</header>
-{% endblock %}
-
-{% block beforeContent %}
-
-<div class="govuk-phase-banner banner__container">
-  <div>
-    <p class="govuk-phase-banner__content">
-      <strong class="govuk-tag govuk-phase-banner__content__tag">
-        Beta
-      </strong>
-      <span class="govuk-phase-banner__text">
-       Help us to improve this service by completing our <a class="govuk-link" target="blank" href="#">feedback survey (opens in a new tab)</a>
-      </span>
-    </p>
-  </div>
-  {% if authenticated_view %}
-    <div class="sign-out">
-      <a class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-19" href="/sign-out">Sign out</a>
-    </div>
-  {% endif %}
-</div>
-
-{% endblock %}
-
-{% block content %}
-  {% if form and form.errors %}
-    {{ govukErrorSummary(wtforms_errors(form)) }}
-  {% endif %}
-
-  {% with messages = get_flashed_messages(with_categories=true) %}
-    {% if messages %}
-      {% for category, message in messages %}
-          {{ govukNotificationBanner({'type': category, 'html': message}) }}
-      {% endfor %}
+        ]
+        },
+        {
+        'attributes': {
+        'id': "accepted-message"
+        },
+        'html': acceptHtml,
+        'role': "alert",
+        'hidden': true,
+        'actions': [
+        {
+        'attributes': {
+        'id': "accepted-hide"
+        },
+        'text': "Hide this message"
+        }
+        ]
+        },
+        {
+        'attributes': {
+        'id': "rejected-message"
+        },
+        'html': rejectHtml,
+        'role': "alert",
+        'hidden': true,
+        'actions': [
+        {
+        'attributes': {
+        'id': "rejected-hide"
+        },
+        'text': "Hide this message"
+        }
+        ]
+        }
+        ]
+        }) }}
     {% endif %}
-  {% endwith %}
 {% endblock %}
-
+{% block header %}
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+        <div class="govuk-header__container govuk-header__container--ayr govuk-width-container">
+            <div class="govuk-header__logo">
+                <a href="/" class="govuk-header__link govuk-header__link--homepage">
+                    <span class="govuk-header__logotype-text govuk-header__logotype--ayr">Access Your Records (AYR)</span>
+                </a>
+            </div>
+            <div class="govuk-header__content govuk-header__content--tna">
+                Delivered by
+                <a href="https://www.nationalarchives.gov.uk/"
+                   class="govuk-header__link govuk-header__link--tna">The
+                National Archives</a>
+            </div>
+        </div>
+    </header>
+{% endblock %}
+{% block beforeContent %}
+    <div class="govuk-phase-banner banner__container">
+        <div>
+            <p class="govuk-phase-banner__content">
+                <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
+                <span class="govuk-phase-banner__text">
+                    Help us to improve this service by completing our <a class="govuk-link" target="blank" href="#">feedback
+                survey (opens in a new tab)</a>
+            </span>
+        </p>
+    </div>
+    {% if authenticated_view %}
+        <div class="sign-out">
+            <a class="govuk-body govuk-!-font-weight-bold govuk-!-font-size-19"
+               href="/sign-out">Sign out</a>
+        </div>
+    {% endif %}
+</div>
+{% endblock %}
+{% block content %}
+    {% if form and form.errors %}{{ govukErrorSummary(wtforms_errors(form) ) }}{% endif %}
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}{{ govukNotificationBanner({'type': category, 'html': message}) }}{% endfor %}
+        {% endif %}
+    {% endwith %}
+{% endblock %}
 {% block footer %}
-<footer class="govuk-footer" role="contentinfo">
-<div class="govuk-width-container">
-    <div class="govuk-footer__meta">
-      <div class="govuk-footer__link">
-        <img class="govuk-footer__tna-logo"
-        src="{{url_for('static', filename='image/the-national-archives-logo.svg')}}" alt="The National Archives Logo">
-    </div>
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <h2 class="govuk-visually-hidden">Support links</h2>
-        <ul class="govuk-footer__inline-list">
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="#">
-              How to use this service
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="{{ url_for('main.terms_of_use')}}">
-              Terms of use
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="{{ url_for('main.privacy')}}">
-              Privacy
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="{{ url_for('main.cookies')}}">
-              Cookies policy
-            </a>
-          </li>
-          <li class="govuk-footer__inline-list-item">
-            <a class="govuk-footer__link" href="{{ url_for('main.accessibility')}}">
-              Accessibility
-            </a>
-          </li>
-        </ul>
-        <svg
-          aria-hidden="true"
-          focusable="false"
-          class="govuk-footer__licence-logo"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 483.2 195.7"
-          height="17"
-          width="41">
-          <path
-            fill="currentColor"
-            d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-        </svg>
-        <span class="govuk-footer__licence-description">
-          All content is available under the
-          <a
-            class="govuk-footer__link"
-            href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-            rel="license">Open Government Licence v3.0</a>, except where otherwise stated
-        </span>
-      </div>
-
-    </div>
-
-   </div>
-</footer>
+    <footer class="govuk-footer" role="contentinfo">
+        <div class="govuk-width-container">
+            <div class="govuk-footer__meta">
+                <div class="govuk-footer__link">
+                    <img class="govuk-footer__tna-logo"
+                         src="{{ url_for('static', filename='image/the-national-archives-logo.svg') }}"
+                         alt="The National Archives Logo">
+                </div>
+                <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                    <h2 class="govuk-visually-hidden">Support links</h2>
+                    <ul class="govuk-footer__inline-list">
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="#">How to use this service</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="{{ url_for('main.terms_of_use') }}">Terms of use</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="{{ url_for('main.privacy') }}">Privacy</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="{{ url_for('main.cookies') }}">Cookies policy</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="{{ url_for('main.accessibility') }}">Accessibility</a>
+                        </li>
+                    </ul>
+                    <svg aria-hidden="true"
+                         focusable="false"
+                         class="govuk-footer__licence-logo"
+                         xmlns="http://www.w3.org/2000/svg"
+                         viewBox="0 0 483.2 195.7"
+                         height="17"
+                         width="41">
+                        <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+                    </svg>
+                    <span class="govuk-footer__licence-description">
+                        All content is available under the
+                        <a class="govuk-footer__link"
+                           href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+                           rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+                    </span>
+                </div>
+            </div>
+        </div>
+    </footer>
 {% endblock %}
-
 {% block bodyEnd %}
-  <!--[if gt IE 8]><!-->
-  <script src="{{ url_for('static', filename='govuk-frontend-4.7.0.min.js') }}"> </script>
-  <script>window.GOVUKFrontend.initAll()</script>
-  <!--<![endif]-->
-  {% assets "js" %}<script type="text/javascript" src="{{ ASSET_URL }}"></script>{% endassets %}
+    <!--[if gt IE 8]><!-->
+    <script src="{{ url_for('static', filename='govuk-frontend-4.7.0.min.js') }}"> </script>
+    <script>window.GOVUKFrontend.initAll()</script>
+    <!--<![endif]-->
+    {% assets "js" %}
+        <script type="text/javascript" src="{{ ASSET_URL }}"></script>
+    {% endassets %}
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -190,6 +190,8 @@
             <div class="govuk-footer__meta">
                 <div class="govuk-footer__link">
                     <img class="govuk-footer__tna-logo"
+                         height="100px"
+                         width="100px"
                          src="{{ url_for('static', filename='image/the-national-archives-logo.svg') }}"
                          alt="The National Archives Logo">
                 </div>

--- a/app/templates/main/400.html
+++ b/app/templates/main/400.html
@@ -1,15 +1,12 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}Server Error – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Server Error – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Server Error</h1>
-        <p class="govuk-body">If you typed the web address, check it is correct.</p>
-        <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Server Error</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/404.html
+++ b/app/templates/main/404.html
@@ -1,15 +1,12 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}Page not found – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Page not found – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Page not found</h1>
-        <p class="govuk-body">If you typed the web address, check it is correct.</p>
-        <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Page not found</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/429.html
+++ b/app/templates/main/429.html
@@ -1,15 +1,12 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}Too many requests – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Too many requests – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, there is a problem</h1>
-        <p class="govuk-body">There have been too many attempts to access this page.</p>
-        <p class="govuk-body">Try again later.</p>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Sorry, there is a problem</h1>
+            <p class="govuk-body">There have been too many attempts to access this page.</p>
+            <p class="govuk-body">Try again later.</p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/500.html
+++ b/app/templates/main/500.html
@@ -1,15 +1,12 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}Sorry, there is a problem with the service – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Sorry, there is a problem with the service – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
-        <p class="govuk-body">Try again later.</p>
-        <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
+            <p class="govuk-body">Try again later.</p>
+            <p class="govuk-body">We saved your answers. They will be available for 30 days.</p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/503.html
+++ b/app/templates/main/503.html
@@ -1,14 +1,11 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}Sorry, the service is unavailable – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Sorry, the service is unavailable – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
-        <p class="govuk-body">You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Sorry, the service is unavailable</h1>
+            <p class="govuk-body">You will be able to use the service from 9am on Monday 19&nbsp;November&nbsp;2018.</p>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/accessibility.html
+++ b/app/templates/main/accessibility.html
@@ -176,7 +176,7 @@
             </p>
             <p class="govuk-body">
                 We’ve assessed the cost of fixing the issues with navigation and accessing information, and
-                with interactive tools and transactions. We believe that doing so now would be a <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/7/made"
+                with interactive tools and transactions. We believe that doing so now would be a <a href="https://www.legislation.gov.uk/uksi/2018/952/regulation/7/made"
     class="govuk-link">disproportionate burden</a> within
                 the meaning of the accessibility regulations. We will make another assessment when the supplier contract is up for
                 renewal, likely to be in [rough timing].
@@ -192,7 +192,7 @@
                 September 2020, we plan to either fix these or replace them with accessible HTML pages.
             </p>
             <p class="govuk-body">
-                The accessibility regulations <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
+                The accessibility regulations <a href="https://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
     class="govuk-link">do not require us to fix PDFs or other documents published
                 before 23 September 2018</a> if they’re not essential to providing our services. For example, we do not plan to fix
                 [example of non-essential document].
@@ -200,7 +200,7 @@
             <p class="govuk-body">Any new PDFs or Word documents we publish will meet accessibility standards.</p>
             <h3 class="govuk-heading-s">Live video</h3>
             <p class="govuk-body">
-                We do not plan to add captions to live video streams because live video is <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
+                We do not plan to add captions to live video streams because live video is <a href="https://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
     class="govuk-link">exempt from meeting
                 the accessibility regulations</a>.
             </p>

--- a/app/templates/main/accessibility.html
+++ b/app/templates/main/accessibility.html
@@ -1,260 +1,240 @@
 {% extends "base.html" %}
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-{% block pageTitle %}Accessibility statement – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Accessibility statement – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block beforeContent %}
-  {{ super() }}
-  {{ govukBackLink({
-    'text': "Back",
-    'href': url_for('main.index')
-  }) }}
-{% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
     {{ super() }}
-    <h1 class="govuk-heading-xl">Accessibility statement for {{config['SERVICE_NAME']}}</h1>
-
-    {{ govukInsetText({
-      'text': "Note: start with a brief explanation of which websites or mobile apps the statement covers.
-
-      You can have a single accessibility statement that covers multiple domains, or a separate statement for each domain or subdomain. As long as the user can access relevant accessibility information easily from any page on your website."
-    }) }}
-
-    <p class="govuk-body">This accessibility statement applies to {{config['SERVICE_URL']}}.</p>
-
-    {{ govukInsetText({
-      'text': "Note: use this section to make a brief, general statement about what the website allows disabled users to do. Base it on the evaluation covered in detail in the ‘Technical information about this website’s accessibility’ section. If you’re not confident that something is accurate, leave it out. If you’re not confident enough to say anything specific here, leave this section out completely."
-    }) }}
-
-    <p class="govuk-body">This website is run by {{config['DEPARTMENT_NAME']}}. We want as many people as possible to be able
-      to use this website. For example, that means you should be able to:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>change colours, contrast levels and fonts</li>
-      <li>zoom in up to 300% without the text spilling off the screen</li>
-      <li>navigate most of the website using just a keyboard</li>
-      <li>navigate most of the website using speech recognition software</li>
-      <li>listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and
-        VoiceOver)</li>
-    </ul>
-    <p class="govuk-body">We’ve also made the website text as simple as possible to understand.</p>
-    <p class="govuk-body"><a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to use if you have a disability.</p>
-
-    <h3 class="govuk-heading-m">How accessible this website is</h3>
-
-    {{ govukInsetText({
-      'text': "Note: use this section to provide information that a disabled user can act on - for example, avoid a particular section of the website, or request an alternative version rather than waste time trying to make it work with their assistive technology. Try to list in order of most impact to least impact."
-    }) }}
-
-    <p class="govuk-body">We know some parts of this website are not fully accessible:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>the text will not reflow in a single column when you change the size of the browser window</li>
-      <li>you cannot modify the line height or spacing of text</li>
-      <li>most older PDF documents are not fully accessible to screen reader software</li>
-      <li>live video streams do not have captions</li>
-      <li>some of our online forms are difficult to navigate using just a keyboard</li>
-      <li>you cannot skip to the main content when using a screen reader</li>
-      <li>there’s a limit to how far you can magnify the map on our ‘contact us’ page</li>
-    </ul>
-
-    <h3 class="govuk-heading-m">Feedback and contact information</h3>
-
-    <p class="govuk-body">If you need information on this website in a different format like accessible PDF, large
-      print, easy read, audio recording or braille:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>email {{config['CONTACT_EMAIL']}}</li>
-      <li>call {{config['CONTACT_PHONE']}}</li>
-      <li>[add any other contact details]</li>
-    </ul>
-    <p class="govuk-body">We’ll consider your request and get back to you in [number] days.</p>
-    <p class="govuk-body">If you cannot view the map on our ‘contact us’ page, call or email us [add link to contact
-      details page] for directions.</p>
-
-    <h3 class="govuk-heading-m">Reporting accessibility problems with this website</h3>
-
-    <p class="govuk-body">We’re always looking to improve the accessibility of this website. If you find any problems
-      not listed on this page or think we’re not meeting accessibility requirements, contact: [provide both details of
-      how to report these issues to your organisation, and contact details for the unit or person responsible for
-      dealing with these reports].</p>
-
-    <h3 class="govuk-heading-m">Enforcement procedure</h3>
-
-    <p class="govuk-body">The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
-      Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility
-      regulations’). If you’re not happy with how we respond to your complaint, <a class="govuk-link"
-        href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and
-        Support Service (EASS)</a>.</p>
-
-    {{ govukInsetText({
-      'text': "Note: if your organisation is based in Northern Ireland, refer users who want to complain to the Equalities Commission for Northern Ireland (ECNI) instead of the EASS and EHRC."
-    }) }}
-
-    <h2 class="govuk-heading-l">Contacting us by phone or visiting us in person</h2>
-
-    <p class="govuk-body">We provide a text relay service for people who are D/deaf, hearing impaired or have a speech
-      impediment.</p>
-    <p class="govuk-body">Our offices have audio induction loops, or if you contact us before your visit we can arrange
-      a British Sign Language (BSL) interpreter.</p>
-    <p class="govuk-body">Find out how to contact us [add link to contact details page].</p>
-
-    <h2 class="govuk-heading-l">Technical information about this website’s accessibility</h2>
-
-    {{ govukInsetText({
-      'text': "Note: this form of wording is legally required, so do not change it."
-    }) }}
-
-    <p class="govuk-body">{{config['DEPARTMENT_NAME']}} is committed to making its website accessible, in accordance with the
-      Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.</p>
-
-    <h3 class="govuk-heading-m">Compliance status</h3>
-
-    {{ govukInsetText({
-      'html': "Note: say that the website is fully compliant if the website meets WCAG 2.1 AA standard in full. Say that it’s partially compliant if it meets most requirements of the WCAG 2.1 AA standard. If it does not meet most requirements of the WCAG 2.1 AA standard, say that it’s not compliant.<br><br>
-
-      If your website is either partially compliant or not compliant WCAG 2.1 AA standard, you’ll need to explain why. This will be due to one or both of the following:
-      <ul>
-        <li>non-compliances - this means the content in question is in scope of the regulations, but there’s an accessibility problem with it</li>
-        <li>an exemption - this means the inaccessible content is out of scope of the regulations, or it’d be a disproportionate burden for you to make it accessible</li>
-      </ul><br>
-      There’s a legally required way of expressing the compliance status of your website, so do not change it. The 3 options are as follows:"
-    }) }}
-
-    <p class="govuk-body">This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA
-      standard.</p>
-    <p class="govuk-body">This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a>
-      AA standard, due to [insert one of the following: ‘the non-compliances’, ‘the exemptions’ or ‘the non-compliances
-      and exemptions’] listed below.</p>
-    <p class="govuk-body">This website is not compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA
-      standard. The [insert one of the following: ‘non-compliances’, ‘exemptions’ or ‘non-compliances and exemptions’]
-      are listed below.</p>
-
-    {{ govukInsetText({
-      'text': "Note: delete the options that do not apply."
-    }) }}
-
-    <h2 class="govuk-heading-l">Non-accessible content</h2>
-
-    {{ govukInsetText({
-      'html': "Note: if the website is fully compliant with the WCAG 2.1 AA standard, you can leave the ‘Non-accessible content’ section out.<br><br>
-
-      Otherwise, do not change the ‘Non-accessible content’ heading or the ‘The content listed below is non-accessible for the following reasons’ sentence - they’re legally required.<br><br>
-
-      Do not change the ‘Non-compliance with the accessibility regulations’, ‘Disproportionate burden’ and ‘Content that’s not within the scope of the accessibility regulations’ subheadings: they’re also legally required.<br><br>
-
-      But if you need to list a lot of problems, you can break these subsections up with further subheadings - for example, ‘Navigation and accessing information’ or ‘Interactive tools and transactions’."
-    }) }}
-
-    <p class="govuk-body">The content listed below is non-accessible for the following reasons.</p>
-
-    <h3 class="govuk-heading-m">Non-compliance with the accessibility regulations</h3>
-
-    {{ govukInsetText({
-      'html': "Note: In this subsection, list:<br>
-      <ul>
-        <li>accessibility problems</li>
-        <li>which of the WCAG 2.1 AA success criteria the problem fails on</li>
-        <li>when you plan to fix the problem</li>
-      </ul><br>
-      Do not include any problems where you’re claiming disproportionate burden, or where the problem is outside the scope of the accessibility regulations (those should go in the subsections below)."
-    }) }}
-
-    <p class="govuk-body">Some images do not have a text alternative, so people using a screen reader cannot access the
-      information. This fails WCAG 2.1 success criterion 1.1.1 (non-text content).</p>
-
-    <p class="govuk-body">We plan to add text alternatives for all images by September 2020. When we publish new content
-      we’ll make sure our use of images meets accessibility standards.</p>
-
-    <h3 class="govuk-heading-m">Disproportionate burden</h3>
-
-    {{ govukInsetText({
-      'html': "Note: in this subsection list accessibility problems you’re claiming would be a disproportionate burden to fix<br><br>
-
-      Bear in mind that something which is a disproportionate burden now will not necessarily be a disproportionate burden forever. If the circumstances change, your ability to claim disproportionate burden may change too."
-    }) }}
-
-    <h3 class="govuk-heading-s">Navigation and accessing information</h3>
-
-    <p class="govuk-body">There’s no way to skip the repeated content in the page header (for example, a ‘skip to main
-      content’ option).</p>
-
-    <p class="govuk-body">It’s not always possible to change the device orientation from horizontal to vertical without
-      making it more difficult to view the content.</p>
-
-    <p class="govuk-body">It’s not possible for users to change text size without some of the content overlapping.</p>
-
-    <h3 class="govuk-heading-s">Interactive tools and transactions</h3>
-
-    <p class="govuk-body">Some of our interactive forms are difficult to navigate using a keyboard. For example, because
-      some form controls are missing a ‘label’ tag.</p>
-
-    <p class="govuk-body">Our forms are built and hosted through third party software and ‘skinned’ to look like our
-      website.</p>
-
-    <p class="govuk-body">We’ve assessed the cost of fixing the issues with navigation and accessing information, and
-      with interactive tools and transactions. We believe that doing so now would be a <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/7/made" class="govuk-link">disproportionate burden</a> within
-      the meaning of the accessibility regulations. We will make another assessment when the supplier contract is up for
-      renewal, likely to be in [rough timing].</p>
-
-    <h3 class="govuk-heading-m">Content that’s not within the scope of the accessibility regulations</h3>
-
-    {{ govukInsetText({
-      'text': "Note: in this subsection list accessibility problems that fall outside the scope of the accessibility regulations."
-    }) }}
-
-    <h3 class="govuk-heading-s">PDFs and other documents</h3>
-
-    <p class="govuk-body">Some of our PDFs and Word documents are essential to providing our services. For example, we
-      have PDFs with information on how users can access our services, and forms published as Word documents. By
-      September 2020, we plan to either fix these or replace them with accessible HTML pages.</p>
-
-    <p class="govuk-body">The accessibility regulations <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made" class="govuk-link">do not require us to fix PDFs or other documents published
-      before 23 September 2018</a> if they’re not essential to providing our services. For example, we do not plan to fix
-      [example of non-essential document].</p>
-
-    <p class="govuk-body">Any new PDFs or Word documents we publish will meet accessibility standards.</p>
-
-    <h3 class="govuk-heading-s">Live video</h3>
-
-    <p class="govuk-body">We do not plan to add captions to live video streams because live video is <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made" class="govuk-link">exempt from meeting
-      the accessibility regulations</a>.</p>
-
-    <h2 class="govuk-heading-l">What we’re doing to improve accessibility</h2>
-
-    {{ govukInsetText({
-      'text': "Note: publishing an accessibility roadmap is optional. It’s a good idea to publish one if you want to be specific about the order you’re planning to tackle accessibility issues, and there’s no space to do so in the accessibility statement itself."
-    }) }}
-
-    <p class="govuk-body">Our accessibility roadmap [add link to roadmap] shows how and when we plan to improve
-      accessibility on this website.</p>
-
-    <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
-
-    {{ govukInsetText({
-      'text': "Note: the wording about when the statement was prepared is legally required, so do not change it."
-    }) }}
-
-    <p class="govuk-body">This statement was prepared on [date when it was first published]. It was last reviewed on
-      [date when it was last reviewed].</p>
-
-    <p class="govuk-body">This website was last tested on [date]. The test was carried out by [add name of organisation
-      that carried out test, or indicate that you did your own testing].</p>
-
-    <p class="govuk-body">We used this approach to deciding on a sample of pages to test [add link to explanation of how
-      you decided which pages to test].</p>
-
-    {{ govukInsetText({
-      'text': "Note: you do not have to use this approach to sampling, but you should link to a full explanation of what you tested and how you chose it. If you get a third party auditor to test your website for you, they should include sampling details in test report - so you can just to link to that."
-    }) }}
-
-    <p class="govuk-body">You can read the full accessibility test report [add link to report].</p>
-
-    {{ govukInsetText({
-      'text': "Note: publishing the test report is optional, but doing so may allow you to make your accessibility statement shorter and more focused."
-    }) }}
-  </div>
-</div>
+    {{ govukBackLink({"text": "Back", "href": "main.index"}) }}
+{% endblock %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ super() }}
+            <h1 class="govuk-heading-xl">Accessibility statement for {{ config['SERVICE_NAME'] }}</h1>
+            {{ govukInsetText({
+            'text': "Note: start with a brief explanation of which websites or mobile apps the statement covers.
+            You can have a single accessibility statement that covers multiple domains, or a separate statement for each domain or subdomain. As long as the user can access relevant accessibility information easily from any page on your website."
+            }) }}
+            <p class="govuk-body">This accessibility statement applies to {{ config['SERVICE_URL'] }}.</p>
+            {{ govukInsetText({
+            "text": "Note: use this section to make a brief, general statement about what the website allows disabled users to do. Base it on the evaluation covered in detail in the ‘Technical information about this website’s accessibility’ section. If you’re not confident that something is accurate, leave it out. If you’re not confident enough to say anything specific here, leave this section out completely."
+            }) }}
+            <p class="govuk-body">
+                This website is run by {{ config['DEPARTMENT_NAME'] }}. We want as many people as possible to be able
+                to use this website. For example, that means you should be able to:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>change colours, contrast levels and fonts</li>
+                <li>zoom in up to 300% without the text spilling off the screen</li>
+                <li>navigate most of the website using just a keyboard</li>
+                <li>navigate most of the website using speech recognition software</li>
+                <li>
+                    listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and
+                    VoiceOver)
+                </li>
+            </ul>
+            <p class="govuk-body">We’ve also made the website text as simple as possible to understand.</p>
+            <p class="govuk-body">
+                <a class="govuk-link" href="https://mcmw.abilitynet.org.uk/">AbilityNet</a> has advice on making your device easier to use if you have a disability.
+            </p>
+            <h3 class="govuk-heading-m">How accessible this website is</h3>
+            {{ govukInsetText({
+            "text": "Note: use this section to provide information that a disabled user can act on - for example, avoid a particular section of the website, or request an alternative version rather than waste time trying to make it work with their assistive technology. Try to list in order of most impact to least impact."
+            }) }}
+            <p class="govuk-body">We know some parts of this website are not fully accessible:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>the text will not reflow in a single column when you change the size of the browser window</li>
+                <li>you cannot modify the line height or spacing of text</li>
+                <li>most older PDF documents are not fully accessible to screen reader software</li>
+                <li>live video streams do not have captions</li>
+                <li>some of our online forms are difficult to navigate using just a keyboard</li>
+                <li>you cannot skip to the main content when using a screen reader</li>
+                <li>there’s a limit to how far you can magnify the map on our ‘contact us’ page</li>
+            </ul>
+            <h3 class="govuk-heading-m">Feedback and contact information</h3>
+            <p class="govuk-body">
+                If you need information on this website in a different format like accessible PDF, large
+                print, easy read, audio recording or braille:
+            </p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>email {{ config['CONTACT_EMAIL'] }}</li>
+                <li>call {{ config['CONTACT_PHONE'] }}</li>
+                <li>[add any other contact details]</li>
+            </ul>
+            <p class="govuk-body">We’ll consider your request and get back to you in [number] days.</p>
+            <p class="govuk-body">
+                If you cannot view the map on our ‘contact us’ page, call or email us [add link to contact
+                details page] for directions.
+            </p>
+            <h3 class="govuk-heading-m">Reporting accessibility problems with this website</h3>
+            <p class="govuk-body">
+                We’re always looking to improve the accessibility of this website. If you find any problems
+                not listed on this page or think we’re not meeting accessibility requirements, contact: [provide both details of
+                how to report these issues to your organisation, and contact details for the unit or person responsible for
+                dealing with these reports].
+            </p>
+            <h3 class="govuk-heading-m">Enforcement procedure</h3>
+            <p class="govuk-body">
+                The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector
+                Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the ‘accessibility
+                regulations’). If you’re not happy with how we respond to your complaint, <a class="govuk-link" href="https://www.equalityadvisoryservice.com/">contact the Equality Advisory and
+                Support Service (EASS)</a>.
+            </p>
+            {{ govukInsetText({
+            "text": "Note: if your organisation is based in Northern Ireland, refer users who want to complain to the Equalities Commission for Northern Ireland (ECNI) instead of the EASS and EHRC."
+            }) }}
+            <h2 class="govuk-heading-l">Contacting us by phone or visiting us in person</h2>
+            <p class="govuk-body">
+                We provide a text relay service for people who are D/deaf, hearing impaired or have a speech
+                impediment.
+            </p>
+            <p class="govuk-body">
+                Our offices have audio induction loops, or if you contact us before your visit we can arrange
+                a British Sign Language (BSL) interpreter.
+            </p>
+            <p class="govuk-body">Find out how to contact us [add link to contact details page].</p>
+            <h2 class="govuk-heading-l">Technical information about this website’s accessibility</h2>
+            {{ govukInsetText({"text": "Note: this form of wording is legally required, so do not change it."}) }}
+            <p class="govuk-body">
+                {{ config['DEPARTMENT_NAME'] }} is committed to making its website accessible, in accordance with the
+                Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+            </p>
+            <h3 class="govuk-heading-m">Compliance status</h3>
+            {{ govukInsetText({
+            'html': "Note: say that the website is fully compliant if the website meets WCAG 2.1 AA standard in full. Say that it’s partially compliant if it meets most requirements of the WCAG 2.1 AA standard. If it does not meet most requirements of the WCAG 2.1 AA standard, say that it’s not compliant.<br><br>
+            If your website is either partially compliant or not compliant WCAG 2.1 AA standard, you’ll need to explain why. This will be due to one or both of the following:
+            <ul>
+                <li>non-compliances - this means the content in question is in scope of the regulations, but there’s an accessibility problem with it</li>
+                <li>an exemption - this means the inaccessible content is out of scope of the regulations, or it’d be a disproportionate burden for you to make it accessible</li>
+            </ul><br>
+            There’s a legally required way of expressing the compliance status of your website, so do not change it. The 3 options are as follows:"
+            }) }}
+            <p class="govuk-body">
+                This website is fully compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA
+                standard.
+            </p>
+            <p class="govuk-body">
+                This website is partially compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a>
+                AA standard, due to [insert one of the following: ‘the non-compliances’, ‘the exemptions’ or ‘the non-compliances
+                and exemptions’] listed below.
+            </p>
+            <p class="govuk-body">
+                This website is not compliant with the <a href="https://www.w3.org/TR/WCAG21/" class="govuk-link">Web Content Accessibility Guidelines version 2.1</a> AA
+                standard. The [insert one of the following: ‘non-compliances’, ‘exemptions’ or ‘non-compliances and exemptions’]
+                are listed below.
+            </p>
+            {{ govukInsetText({"text": "Note: delete the options that do not apply."}) }}
+            <h2 class="govuk-heading-l">Non-accessible content</h2>
+            {{ govukInsetText({
+            'html': "Note: if the website is fully compliant with the WCAG 2.1 AA standard, you can leave the ‘Non-accessible content’ section out.<br><br>
+            Otherwise, do not change the ‘Non-accessible content’ heading or the ‘The content listed below is non-accessible for the following reasons’ sentence - they’re legally required.<br><br>
+            Do not change the ‘Non-compliance with the accessibility regulations’, ‘Disproportionate burden’ and ‘Content that’s not within the scope of the accessibility regulations’ subheadings: they’re also legally required.<br><br>
+            But if you need to list a lot of problems, you can break these subsections up with further subheadings - for example, ‘Navigation and accessing information’ or ‘Interactive tools and transactions’."
+            }) }}
+            <p class="govuk-body">The content listed below is non-accessible for the following reasons.</p>
+            <h3 class="govuk-heading-m">Non-compliance with the accessibility regulations</h3>
+            {{ govukInsetText({
+            'html': "Note: In this subsection, list:<br>
+            <ul>
+                <li>accessibility problems</li>
+                <li>which of the WCAG 2.1 AA success criteria the problem fails on</li>
+                <li>when you plan to fix the problem</li>
+            </ul><br>
+            Do not include any problems where you’re claiming disproportionate burden, or where the problem is outside the scope of the accessibility regulations (those should go in the subsections below)."
+            }) }}
+            <p class="govuk-body">
+                Some images do not have a text alternative, so people using a screen reader cannot access the
+                information. This fails WCAG 2.1 success criterion 1.1.1 (non-text content).
+            </p>
+            <p class="govuk-body">
+                We plan to add text alternatives for all images by September 2020. When we publish new content
+                we’ll make sure our use of images meets accessibility standards.
+            </p>
+            <h3 class="govuk-heading-m">Disproportionate burden</h3>
+            {{ govukInsetText({
+            'html': "Note: in this subsection list accessibility problems you’re claiming would be a disproportionate burden to fix<br><br>
+            Bear in mind that something which is a disproportionate burden now will not necessarily be a disproportionate burden forever. If the circumstances change, your ability to claim disproportionate burden may change too."
+            }) }}
+            <h3 class="govuk-heading-s">Navigation and accessing information</h3>
+            <p class="govuk-body">
+                There’s no way to skip the repeated content in the page header (for example, a ‘skip to main
+                content’ option).
+            </p>
+            <p class="govuk-body">
+                It’s not always possible to change the device orientation from horizontal to vertical without
+                making it more difficult to view the content.
+            </p>
+            <p class="govuk-body">It’s not possible for users to change text size without some of the content overlapping.</p>
+            <h3 class="govuk-heading-s">Interactive tools and transactions</h3>
+            <p class="govuk-body">
+                Some of our interactive forms are difficult to navigate using a keyboard. For example, because
+                some form controls are missing a ‘label’ tag.
+            </p>
+            <p class="govuk-body">
+                Our forms are built and hosted through third party software and ‘skinned’ to look like our
+                website.
+            </p>
+            <p class="govuk-body">
+                We’ve assessed the cost of fixing the issues with navigation and accessing information, and
+                with interactive tools and transactions. We believe that doing so now would be a <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/7/made"
+    class="govuk-link">disproportionate burden</a> within
+                the meaning of the accessibility regulations. We will make another assessment when the supplier contract is up for
+                renewal, likely to be in [rough timing].
+            </p>
+            <h3 class="govuk-heading-m">Content that’s not within the scope of the accessibility regulations</h3>
+            {{ govukInsetText({
+            "text": "Note: in this subsection list accessibility problems that fall outside the scope of the accessibility regulations."
+            }) }}
+            <h3 class="govuk-heading-s">PDFs and other documents</h3>
+            <p class="govuk-body">
+                Some of our PDFs and Word documents are essential to providing our services. For example, we
+                have PDFs with information on how users can access our services, and forms published as Word documents. By
+                September 2020, we plan to either fix these or replace them with accessible HTML pages.
+            </p>
+            <p class="govuk-body">
+                The accessibility regulations <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
+    class="govuk-link">do not require us to fix PDFs or other documents published
+                before 23 September 2018</a> if they’re not essential to providing our services. For example, we do not plan to fix
+                [example of non-essential document].
+            </p>
+            <p class="govuk-body">Any new PDFs or Word documents we publish will meet accessibility standards.</p>
+            <h3 class="govuk-heading-s">Live video</h3>
+            <p class="govuk-body">
+                We do not plan to add captions to live video streams because live video is <a href="http://www.legislation.gov.uk/uksi/2018/952/regulation/4/made"
+    class="govuk-link">exempt from meeting
+                the accessibility regulations</a>.
+            </p>
+            <h2 class="govuk-heading-l">What we’re doing to improve accessibility</h2>
+            {{ govukInsetText({
+            "text": "Note: publishing an accessibility roadmap is optional. It’s a good idea to publish one if you want to be specific about the order you’re planning to tackle accessibility issues, and there’s no space to do so in the accessibility statement itself."
+            }) }}
+            <p class="govuk-body">
+                Our accessibility roadmap [add link to roadmap] shows how and when we plan to improve
+                accessibility on this website.
+            </p>
+            <h2 class="govuk-heading-l">Preparation of this accessibility statement</h2>
+            {{ govukInsetText({
+            "text": "Note: the wording about when the statement was prepared is legally required, so do not change it."
+            }) }}
+            <p class="govuk-body">
+                This statement was prepared on [date when it was first published]. It was last reviewed on
+                [date when it was last reviewed].
+            </p>
+            <p class="govuk-body">
+                This website was last tested on [date]. The test was carried out by [add name of organisation
+                that carried out test, or indicate that you did your own testing].
+            </p>
+            <p class="govuk-body">
+                We used this approach to deciding on a sample of pages to test [add link to explanation of how
+                you decided which pages to test].
+            </p>
+            {{ govukInsetText({
+            "text": "Note: you do not have to use this approach to sampling, but you should link to a full explanation of what you tested and how you chose it. If you get a third party auditor to test your website for you, they should include sampling details in test report - so you can just to link to that."
+            }) }}
+            <p class="govuk-body">You can read the full accessibility test report [add link to report].</p>
+            {{ govukInsetText({
+            "text": "Note: publishing the test report is optional, but doing so may allow you to make your accessibility statement shorter and more focused."
+            }) }}
+        </div>
+    </div>
 {% endblock %}

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -1,391 +1,356 @@
 {% extends "base.html" %}
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-{% block pageTitle %}Browse – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-
+{% block pageTitle %}Browse – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block content %}
-<div class="govuk-grid-row browse__page">
-  {{ super() }}
-
-  <div class="search__container govuk-grid-column-full">
-    <div class="search__container__content">
-      <p class="govuk-body search__heading">Search for digital records</p>
-      <form method="POST" action="{{ url_for('main.poc_search') }}">
-        {{ form.csrf_token }}
-        <div class="govuk-form-group govuk-form-group__search-form">
-          <label for="searchInput"></label>
-          <input class="govuk-input govuk-!-width-three-quarters" id="searchInput" name="query" type="text">
-          <button class="govuk-button govuk-button__search-button" data-module="govuk-button" type="submit">Search</button>
-        </div>
-        <p class="govuk-body-s">Search using a record metadata term, for example – transferring body, series,
-          consignment
-          ref etc.</p>
-      </form>
-    </div>
-  </div>
-    {% if results %}
-      <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-      <p class="govuk-body browse__body">You are viewing</p>
-      <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
-      <div class="govuk-form-group sort-container__form">
-        <div class="browse__sort-container">
-          <label class="govuk-label" for="sort">
-            Sort by
-          </label>
-          <select class="govuk-select govuk-select__sort-container-select" id="sort" name="sort">
-            <option value="body-a">Transferring body (A to Z)</option>
-            <option value="body-b" selected>Transferring body (Z to A)</option>
-            <option value="series-a">Series (A to Z)</option>
-            <option value="series-b">Series (Z to A)</option>
-            <option value="date-first">Date record transferred (most recent first)</option>
-            <option value="date-last">Date record transferred (oldest first)</option>
-          </select>
-          <button class="govuk-button govuk-button__sort-container-update-button" id="sort-update-button" data-module="govuk-button">
-            Apply
-          </button>
-        </div>
-      </div>
-
-      <div class="govuk-width-container">
-
-      <!-- FILTERS -->
-      <div class="govuk-grid-column-one-third filters-form">
-
-        <div class="browse-filter-container">
-          <div class="browse-filter__header">
-            <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
-            <img src="{{ url_for('static', filename='image/filter-icon.svg') }}" class="browse-filter__icon"
-              alt="filter-icon">
-          </div>
-          <p class="govuk-body browse__body">Transferring body</p>
-          <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-            <label class="govuk-label" for="browse_filter_transferring_body"></label>
-            <select class="govuk-select govuk-select__filters-form-transferring-body-select" id="browse_filter_transferring_body" name="sort">
-              <option value="all" selected>Choose one...</option>
-              <option value="arts">Arts Council England</option>
-              <option value="food_standards_agency">Food Standards Agency</option>
-              <option value="foreign_office">Foreign Office</option>
-            </select>
-          </div>
-        </div>
-
-        <div class="filters-form__series__container">
-          <p class="govuk-body browse__body">Series</p>
-          <div class="govuk-form-group filters-form__group filters-form__series-group">
-            <label class="govuk-label" for="browse_filter_series"></label>
-            <input class="govuk-input filters-form__series--input" id="browse_filter_series" name="width10" type="text">
-          </div>
-        </div>
-
-        <div class="filters-form__consignment-ref__container">
-          <p class="govuk-body browse__body">Consignment <abbr title="reference">ref</abbr></p>
-          <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
-            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
-            <input class="govuk-input filters-form__consignment-ref--input" id="browse_filter_consignment-ref" name="width10" type="text">
-          </div>
-        </div>
-
-        <div class="filters-form__date__container">
-          <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
-            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
-              <div class="govuk-date-input" id="date-from">
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date-from-day"
-                      name="date-from-day" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-from-day">
-                      (DD)
-                    </label>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date-from-month"
-                      name="date-from-month" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-from-month">
-                      (MM)
-                    </label>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-from-year"
-                      name="date-from-year" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-from-year">
-                      (YYYY)
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-
-          <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
-            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
-            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
-              <div class="govuk-date-input" id="date-to">
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date-to-day"
-                      name="date-to-day" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-to-day">
-                      (DD)
-                    </label>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-2" id="date-to-month"
-                      name="date-to-month" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-to-month">
-                      (MM)
-                    </label>
-                  </div>
-                </div>
-                <div class="govuk-date-input__item">
-                  <div class="govuk-form-group">
-                    <input class="govuk-input govuk-date-input__input govuk-input--width-4" id="date-to-year"
-                      name="date-to-year" type="text" inputmode="numeric">
-                    <label class="govuk-label govuk-date-input__label filters-form__date__label" for="date-to-year">
-                      (YYYY)
-                    </label>
-                  </div>
-                </div>
-              </div>
-            </fieldset>
-          </div>
-
-
-          <div class="filters-form__buttons">
-            <button type="button" class="govuk-button govuk-button__filters-form-apply-button" data-module="govuk-button">
-              Apply filters
-            </button>
-            <button type="button" class="govuk-button__filters-form-clear-button" data-module="govuk-button">
-              Clear all filters
-            </button>
-          </div>
-        </div>
-      </div>
-      <!-- END FILTERS -->
-    {% endif %}
-
-    <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
-      <!-- Table Heading -->
-      {% if browse_type == "browse" %}
-        {% if results %}
-          {% if num_records_found > 0 %}
-            <dl class="govuk-summary-list browse-grid__list">
-              <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
-                <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">
-                  Transferring body
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key">
-                  Series
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Last record transferred
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Records held
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Consignments within series
-                </dt>
-              </div>
-              <!-- Table Content -->
-              {% for record in results %}
-                <div class="govuk-summary-list__row">
-                  <dd class="govuk-summary-list__value browse__table__large-width">
-                    <a href="{{url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">
-                      {{ record["transferring_body"] }}
-                    </a>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body">
-                      <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">
-                        {{ record["series"] }}
-                      </a></p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_in_series"] }}</p>
-                  </dd>
-                </div>
-              {% endfor %}
-            </dl>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-
-      {% if browse_type == "transferring_body" %}
-        {% if results %}
-          {% if num_records_found > 0 %}
-            <dl class="govuk-summary-list browse-grid__list">
-              <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
-                <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">
-                  Transferring body
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key">
-                  Series
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Last record transferred
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Records held
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Consignments within series
-                </dt>
-              </div>
-              <!-- Table Content -->
-              {% for record in results %}
-                <div class="govuk-summary-list__row">
-                  <dd class="govuk-summary-list__value browse__table__large-width">
-                    <p class="govuk-body browse__body">
-                      {{ record["transferring_body"] }}
+    <div class="govuk-grid-row browse__page">
+        {{ super() }}
+        <div class="search__container govuk-grid-column-full">
+            <div class="search__container__content">
+                <p class="govuk-body search__heading">Search for digital records</p>
+                <form method="post" action="{{ url_for('main.poc_search') }}">
+                    {{ form.csrf_token }}
+                    <div class="govuk-form-group govuk-form-group__search-form">
+                        <label for="searchInput"></label>
+                        <input class="govuk-input govuk-!-width-three-quarters"
+                               id="searchInput"
+                               name="query"
+                               type="text">
+                        <button class="govuk-button govuk-button__search-button"
+                                data-module="govuk-button"
+                                type="submit">Search</button>
+                    </div>
+                    <p class="govuk-body-s">
+                        Search using a record metadata term, for example – transferring body, series,
+                        consignment
+                        ref etc.
                     </p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body">
-                      <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">
-                        {{ record["series"] }}
-                      </a></p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
-                  </dd>
-                  <dd class="govuk-summary-list__value">
-                    <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_in_series"] }}</p>
-                  </dd>
+                </form>
+            </div>
+        </div>
+        {% if results %}
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
+            <div class="govuk-form-group sort-container__form">
+                <div class="browse__sort-container">
+                    <label class="govuk-label" for="sort">Sort by</label>
+                    <select class="govuk-select govuk-select__sort-container-select"
+                            id="sort"
+                            name="sort">
+                        <option value="body-a">Transferring body (A to Z)</option>
+                        <option value="body-b" selected>Transferring body (Z to A)</option>
+                        <option value="series-a">Series (A to Z)</option>
+                        <option value="series-b">Series (Z to A)</option>
+                        <option value="date-first">Date record transferred (most recent first)</option>
+                        <option value="date-last">Date record transferred (oldest first)</option>
+                    </select>
+                    <button class="govuk-button govuk-button__sort-container-update-button"
+                            id="sort-update-button"
+                            data-module="govuk-button">Apply</button>
                 </div>
-              {% endfor %}
-          </dl>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-
-      {% if browse_type == "series" %}
-        {% if results %}
-          {% if num_records_found > 0 %}
-            <dl class="govuk-summary-list browse-grid__list">
-              <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
-                <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">
-                  Transferring body
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key">
-                  Series
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Consignment transferred
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Records in consignment
-                </dt>
-                <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">
-                  Consignment reference
-                </dt>
-              </div>
-
-              <!-- Table Content -->
-              {% for record in results %}
-              <div class="govuk-summary-list__row">
-                <dd class="govuk-summary-list__value browse__table__large-width">
-                  <p class="govuk-body browse__body">
-                    {{ record["transferring_body"] }}
-                  </p>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <p class="govuk-body browse__body">
-                      {{ record["series"] }}
-                    </p>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <a href="{{ url_for('main.browse', consignment_id=record['consignment_id']) }}">
-                  <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_reference"] }}</p>
-                </a>
-                </dd>
-              </div>
-              {% endfor %}
-            </dl>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-
-      {% if browse_type == "consignment" %}
-        {% if results %}
-          {% if num_records_found > 0 %}
-            <dl class="govuk-summary-list browse-grid__list">
-              <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
-                <dt class="govuk-summary-list__key govuk-summary-list__key__left">
-                  Last modified
-                </dt>
-                <dt class="govuk-summary-list__key govuk-summary-list__key__left">
-                  Filename
-                </dt>
-                <dt class="govuk-summary-list__key govuk-summary-list__key__left">
-                  Status
-                </dt>
-                <dt class="govuk-summary-list__key govuk-summary-list__key__left">
-                  Closure start date
-                </dt>
-                <dt class="govuk-summary-list__key govuk-summary-list__key__left">
-                  Closure period
-                </dt>
-              </div>
-
-              <!-- Table Content -->
-              {% for record in results %}
-              <div class="govuk-summary-list__row">
-                <dd class="govuk-summary-list__value">
-                    {{ record[2]|format_datetime}}
-                </dd>
-                <dd class="govuk-summary-list__value">
-                    <a href="{{ url_for('main.record', record_id=record[0]) }}">
-                      {{ record[1] }}
-                    </a>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <strong class="govuk-tag {{ 'govuk-tag--green' if record[3] == 'Open' else 'govuk-tag--red' }}">
-                    {{ record[3] }}
-                  </strong>
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  {{ record[4]|format_datetime}}
-                </dd>
-                <dd class="govuk-summary-list__value">
-                  <p class="govuk-body browse__body">{% if record[5] %} {{ record[5] }} years {% else %} - {% endif %}</p>
-                </dd>
-              </div>
-              {% endfor %}
-            </dl>
-          {% endif %}
-        {% endif %}
-      {% endif %}
-
-      <!-- PAGINATION -->
-      {% with view_name='main.browse' %}
-        {% include "pagination.html" %}
-      {% endwith %}
+            </div>
+            <div class="govuk-width-container">
+                <!-- FILTERS -->
+                <div class="govuk-grid-column-one-third filters-form">
+                    <div class="browse-filter-container">
+                        <div class="browse-filter__header">
+                            <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                            <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                                 class="browse-filter__icon"
+                                 alt="filter-icon">
+                        </div>
+                        <p class="govuk-body browse__body">Transferring body</p>
+                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                                    id="browse_filter_transferring_body"
+                                    name="sort">
+                                <option value="all" selected>Choose one...</option>
+                                <option value="arts">Arts Council England</option>
+                                <option value="food_standards_agency">Food Standards Agency</option>
+                                <option value="foreign_office">Foreign Office</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="filters-form__series__container">
+                        <p class="govuk-body browse__body">Series</p>
+                        <div class="govuk-form-group filters-form__group filters-form__series-group">
+                            <label class="govuk-label" for="browse_filter_series"></label>
+                            <input class="govuk-input filters-form__series--input"
+                                   id="browse_filter_series"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__consignment-ref__container">
+                        <p class="govuk-body browse__body">
+                            Consignment <abbr title="reference">ref</abbr>
+                        </p>
+                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                            <input class="govuk-input filters-form__consignment-ref--input"
+                                   id="browse_filter_consignment-ref"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__date__container">
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                                <div class="govuk-date-input" id="date-from">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-day"
+                                                   name="date-from-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-month"
+                                                   name="date-from-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-from-year"
+                                                   name="date-from-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                                <div class="govuk-date-input" id="date-to">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-day"
+                                                   name="date-to-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-month"
+                                                   name="date-to-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-to-year"
+                                                   name="date-to-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="filters-form__buttons">
+                            <button type="button"
+                                    class="govuk-button govuk-button__filters-form-apply-button"
+                                    data-module="govuk-button">Apply filters</button>
+                            <button type="button"
+                                    class="govuk-button__filters-form-clear-button"
+                                    data-module="govuk-button">Clear all filters</button>
+                        </div>
+                    </div>
+                </div>
+                <!-- END FILTERS -->
+            {% endif %}
+            <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+                <!-- Table Heading -->
+                {% if browse_type == "browse" %}
+                    {% if results %}
+                        {% if num_records_found > 0 %}
+                            <dl class="govuk-summary-list browse-grid__list">
+                                <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
+                                    <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">Transferring body</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key">Series</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Last record transferred</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Records held</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Consignments within series</dt>
+                                </div>
+                                <!-- Table Content -->
+                                {% for record in results %}
+                                    <div class="govuk-summary-list__row">
+                                        <dd class="govuk-summary-list__value browse__table__large-width">
+                                            <a href="{{ url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">
+                                                {{ record["transferring_body"] }}
+                                            </a>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body">
+                                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
+                                            </p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_in_series"] }}</p>
+                                        </dd>
+                                    </div>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
+                {% if browse_type == "transferring_body" %}
+                    {% if results %}
+                        {% if num_records_found > 0 %}
+                            <dl class="govuk-summary-list browse-grid__list">
+                                <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
+                                    <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">Transferring body</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key">Series</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Last record transferred</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Records held</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Consignments within series</dt>
+                                </div>
+                                <!-- Table Content -->
+                                {% for record in results %}
+                                    <div class="govuk-summary-list__row">
+                                        <dd class="govuk-summary-list__value browse__table__large-width">
+                                            <p class="govuk-body browse__body">{{ record["transferring_body"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body">
+                                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
+                                            </p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_in_series"] }}</p>
+                                        </dd>
+                                    </div>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
+                {% if browse_type == "series" %}
+                    {% if results %}
+                        {% if num_records_found > 0 %}
+                            <dl class="govuk-summary-list browse-grid__list">
+                                <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
+                                    <dt class="govuk-summary-list__key browse-grid__key browse-grid__key__transferring-body">Transferring body</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key">Series</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Consignment transferred</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Records in consignment</dt>
+                                    <dt class="govuk-summary-list__key browse-grid__key browse__table__right-align">Consignment reference</dt>
+                                </div>
+                                <!-- Table Content -->
+                                {% for record in results %}
+                                    <div class="govuk-summary-list__row">
+                                        <dd class="govuk-summary-list__value browse__table__large-width">
+                                            <p class="govuk-body browse__body">{{ record["transferring_body"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body">{{ record["series"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["last_record_transferred"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body browse__table__right-align">{{ record["records_held"] }}</p>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <a href="{{ url_for('main.browse', consignment_id=record['consignment_id']) }}">
+                                                <p class="govuk-body browse__body browse__table__right-align">{{ record["consignment_reference"] }}</p>
+                                            </a>
+                                        </dd>
+                                    </div>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
+                {% if browse_type == "consignment" %}
+                    {% if results %}
+                        {% if num_records_found > 0 %}
+                            <dl class="govuk-summary-list browse-grid__list">
+                                <div class="govuk-summary-list__row govuk-summary-list__row__browse-grid-list">
+                                    <dt class="govuk-summary-list__key govuk-summary-list__key__left">Last modified</dt>
+                                    <dt class="govuk-summary-list__key govuk-summary-list__key__left">Filename</dt>
+                                    <dt class="govuk-summary-list__key govuk-summary-list__key__left">Status</dt>
+                                    <dt class="govuk-summary-list__key govuk-summary-list__key__left">Closure start date</dt>
+                                    <dt class="govuk-summary-list__key govuk-summary-list__key__left">Closure period</dt>
+                                </div>
+                                <!-- Table Content -->
+                                {% for record in results %}
+                                    <div class="govuk-summary-list__row">
+                                        <dd class="govuk-summary-list__value">
+                                            {{ record[2]|format_datetime }}
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <a href="{{ url_for('main.record', record_id=record[0]) }}">{{ record[1] }}</a>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <strong class="govuk-tag {{ 'govuk-tag--green' if record[3] == 'Open' else 'govuk-tag--red' }}">
+                                                {{ record[3] }}
+                                            </strong>
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            {{ record[4]|format_datetime }}
+                                        </dd>
+                                        <dd class="govuk-summary-list__value">
+                                            <p class="govuk-body browse__body">
+                                                {% if record[5] %}
+                                                    {{ record[5] }} years
+                                                {% else %}
+                                                    -
+                                                {% endif %}
+                                            </p>
+                                        </dd>
+                                    </div>
+                                {% endfor %}
+                            </dl>
+                        {% endif %}
+                    {% endif %}
+                {% endif %}
+                <!-- PAGINATION -->
+                {% with view_name='main.browse' %}
+                    {% include "pagination.html" %}
+                {% endwith %}
+            </div>
+        </div>
     </div>
-  </div>
-</div>
 {% endblock %}

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -57,6 +57,8 @@
                         <div class="browse-filter__header">
                             <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
                             <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                                 height="32px"
+                                 width="32px"
                                  class="browse-filter__icon"
                                  alt="filter-icon">
                         </div>

--- a/app/templates/main/cookies.html
+++ b/app/templates/main/cookies.html
@@ -1,79 +1,146 @@
 {% extends "base.html" %}
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/table/macro.html' import govukTable -%}
-
-{% block pageTitle %}{%- if form.errors %}Error: {% endif -%}Cookies – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-{% block beforeContent %}
-  {{ super() }}
-  {{ govukBackLink({
-    'text': "Back",
-    'href': url_for('main.index')
-  }) }}
+{% block pageTitle %}
+    {%- if form.errors %}Error:
+    {% endif -%}
+    Cookies – {{ config['SERVICE_NAME'] }} – GOV.UK
 {% endblock %}
-
-{% block content %}
-<div class="govuk-grid-row">
-  <div class="govuk-grid-column-two-thirds">
+{% block beforeContent %}
     {{ super() }}
-    <h1 class="govuk-heading-l">Cookies</h1>
-    <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.
-    </p>
-    <p class="govuk-body">We use cookies to make {{config['SERVICE_NAME']}} work and collect information about how you use our
-      service.</p>
-
-    <h2 class="govuk-heading-m">Essential cookies</h2>
-    <p class="govuk-body">Essential cookies keep your information secure while you use {{config['SERVICE_NAME']}}. We do not need
-      to ask permission to use them.</p>
-    {{ govukTable(
-      {
-        'head': [{'text': 'Name'}, {'text': 'Purpose'}, {'text': 'Expires'}],
-        'rows': [
-          [{'text': 'cookie_policy'}, {'text': 'Saves your cookie consent settings'}, {'text': '1 year'}],
-          [{'text': 'session'}, {'text': 'Temporary storage'}, {'text': 'Session'}]
-        ]
-      }
-    )}}
-
-    <h2 class="govuk-heading-m">Functional cookies</h2>
-    <p class="govuk-body">Functional cookies allow you to take advantage of some functionality, for example remembering
-      settings between visits. The service will work without them.</p>
-    {{ govukTable(
-      {
-        'head': [{'text': 'Name'}, {'text': 'Purpose'}, {'text': 'Expires'}],
-        'rows': [
-          [{'text': 'foo'}, {'text': 'bar'}, {'text': 'baz'}]
-        ]
-      }
-    )}}
-
-    <h2 class="govuk-heading-m">Analytics cookies</h2>
-    <p class="govuk-body">With your permission, we use Google Analytics to collect data about how you use {{config['SERVICE_NAME']}}. This
-      information helps us to improve our service.</p>
-    <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
-    <p class="govuk-body">Google Analytics stores anonymised information about:</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li>how you got to {{config['SERVICE_NAME']}}</li>
-      <li>the pages you visit on {{config['SERVICE_NAME']}} and how long you spend on them</li>
-      <li>any errors you see while using {{config['SERVICE_NAME']}}</li>
-    </ul>
-    {{ govukTable(
-      {
-        'head': [{'text': 'Name'}, {'text': 'Purpose'}, {'text': 'Expires'}],
-        'rows': [
-          [{'text': 'foo'}, {'text': 'bar'}, {'text': 'baz'}]
-        ]
-      }
-    )}}
-
-    <h2 class="govuk-heading-m">Change your cookie settings</h2>
-    <form action="" method="post" novalidate>
-      {{ form.csrf_token }}
-      {{ form.functional }}
-      {{ form.analytics }}
-      {{ form.save }}
-    </form>
-  </div>
-</div>
+    {{ govukBackLink({
+    'text': "Back",
+    'href': url_for("main.index")
+    }) }}
+{% endblock %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ super() }}
+            <h1 class="govuk-heading-l">Cookies</h1>
+            <p class="govuk-body">Cookies are small files saved on your phone, tablet or computer when you visit a website.</p>
+            <p class="govuk-body">
+                We use cookies to make {{ config['SERVICE_NAME'] }} work and collect information about how you use our
+                service.
+            </p>
+            <h2 class="govuk-heading-m">Essential cookies</h2>
+            <p class="govuk-body">
+                Essential cookies keep your information secure while you use {{ config['SERVICE_NAME'] }}. We do not need
+                to ask permission to use them.
+            </p>
+            {{ govukTable({
+            "head": [
+            {
+            "text": "Name"
+            },
+            {
+            "text": "Purpose"
+            },
+            {
+            "text": "Expires"
+            }
+            ],
+            "rows": [
+            [
+            {
+            "text": "cookie_policy"
+            },
+            {
+            "text": "Saves your cookie consent settings"
+            },
+            {
+            "text": "1 year"
+            }
+            ],
+            [
+            {
+            "text": "session"
+            },
+            {
+            "text": "Temporary storage"
+            },
+            {
+            "text": "Session"
+            }
+            ]
+            ]
+            }) }}
+            <h2 class="govuk-heading-m">Functional cookies</h2>
+            <p class="govuk-body">
+                Functional cookies allow you to take advantage of some functionality, for example remembering
+                settings between visits. The service will work without them.
+            </p>
+            {{ govukTable({
+            "head": [
+            {
+            "text": "Name"
+            },
+            {
+            "text": "Purpose"
+            },
+            {
+            "text": "Expires"
+            }
+            ],
+            "rows": [
+            [
+            {
+            "text": "foo"
+            },
+            {
+            "text": "bar"
+            },
+            {
+            "text": "baz"
+            }
+            ]
+            ]
+            }) }}
+            <h2 class="govuk-heading-m">Analytics cookies</h2>
+            <p class="govuk-body">
+                With your permission, we use Google Analytics to collect data about how you use {{ config['SERVICE_NAME'] }}. This
+                information helps us to improve our service.
+            </p>
+            <p class="govuk-body">Google is not allowed to use or share our analytics data with anyone.</p>
+            <p class="govuk-body">Google Analytics stores anonymised information about:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>how you got to {{ config['SERVICE_NAME'] }}</li>
+                <li>the pages you visit on {{ config['SERVICE_NAME'] }} and how long you spend on them</li>
+                <li>any errors you see while using {{ config['SERVICE_NAME'] }}</li>
+            </ul>
+            {{ govukTable({
+            "head": [
+            {
+            "text": "Name"
+            },
+            {
+            "text": "Purpose"
+            },
+            {
+            "text": "Expires"
+            }
+            ],
+            "rows": [
+            [
+            {
+            "text": "foo"
+            },
+            {
+            "text": "bar"
+            },
+            {
+            "text": "baz"
+            }
+            ]
+            ]
+            }) }}
+            <h2 class="govuk-heading-m">Change your cookie settings</h2>
+            <form action="" method="post" novalidate>
+                {{ form.csrf_token }}
+                {{ form.functional }}
+                {{ form.analytics }}
+                {{ form.save }}
+            </form>
+        </div>
+    </div>
 {% endblock %}

--- a/app/templates/main/how-to-use-this-service.html
+++ b/app/templates/main/how-to-use-this-service.html
@@ -1,13 +1,4 @@
 {% extends "base.html" %}
-
-{% block pageTitle %}How to use this service – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-{% block beforeContent %}
-  {{ super() }}
-
-{% endblock %}
-{% block content %}
-
-<h1 class="govuk-heading-l">How to use this service</h1>
-
-{% endblock %}
+{% block pageTitle %}How to use this service – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block beforeContent %}{{ super() }}{% endblock %}
+{% block content %}<h1 class="govuk-heading-l">How to use this service</h1>{% endblock %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -1,31 +1,37 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-{% block pageTitle %}Start page – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-{% block beforeContent %}
-  {{ super() }}
-
-{% endblock %}
-
+{% block pageTitle %}Start page – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block beforeContent %}{{ super() }}{% endblock %}
 {% block content %}
-
-<div class="govuk-width-container">
-    <main class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l govuk-heading-l--start">Access your records</h1>
-          <p class="govuk-body govuk-body--start">Use this service to access digital records at The National Archives.</p>
-          <a href="{{ url_for('main.sign_in') }}" role="button" draggable="false" class="govuk-button govuk-button--start" data-module="govuk-button">Start now
-            <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
-              <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
-            </svg></a>
-            <div class="govuk-!-padding-bottom-7"></div>
-            <h2 class="govuk-heading-m govuk-heading-m--start">Before you start</h2>
-            <p class="govuk-body govuk-body--start">This service is in private beta. Please refer to our <a href="{{ url_for('main.how_to_use') }}" class="govuk-link">How to use this service</a> page
-                for information about using Access Your Records.</p>
-        </div>
-      </div>
-    </main>
-  </div>
-  {% endblock %}
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-l govuk-heading-l--start">Access your records</h1>
+                    <p class="govuk-body govuk-body--start">Use this service to access digital records at The National Archives.</p>
+                    <a href="{{ url_for("main.sign_in") }}"
+                       role="button"
+                       draggable="false"
+                       class="govuk-button govuk-button--start"
+                       data-module="govuk-button">Start now
+                        <svg class="govuk-button__start-icon"
+                             xmlns="http://www.w3.org/2000/svg"
+                             width="17.5"
+                             height="19"
+                             viewBox="0 0 33 40"
+                             aria-hidden="true"
+                             focusable="false">
+                            <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />
+                        </svg>
+                    </a>
+                    <div class="govuk-!-padding-bottom-7"></div>
+                    <h2 class="govuk-heading-m govuk-heading-m--start">Before you start</h2>
+                    <p class="govuk-body govuk-body--start">
+                        This service is in private beta. Please refer to our <a href="{{ url_for("main.how_to_use") }}" class="govuk-link">How to use this service</a> page
+                        for information about using Access Your Records.
+                    </p>
+                </div>
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -38,7 +38,7 @@
                         </li>
                     {% endif %}
                 {% else %}
-                    <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
+                    <li class="govuk-pagination__item govuk-pagination__item--ellipses">⋯</li>
                 {% endif %}
             {% endfor %}
         </ul>

--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -1,54 +1,65 @@
 {% if results.pages > 1 %}
-<nav class="govuk-pagination govuk-pagination--centred" role="navigation" aria-label="Pagination">
-    {% if results.has_prev == True %}
-    <div class="govuk-pagination__prev">
-        <a class="govuk-link govuk-pagination__link" href="{{ url_for(view_name, page=current_page-1, query=query) }}"
-            rel="prev">
-            <svg class="govuk-pagination__icon govuk-pagination__icon--prev" xmlns="http://www.w3.org/2000/svg"
-                height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                <path
-                    d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
-                </path>
-            </svg>
-            <span class="govuk-pagination__link-title">Previous<span class="govuk-visually-hidden">
-                    page</span></span></a>
-                </div>
+    <nav class="govuk-pagination govuk-pagination--centred"
+         role="navigation"
+         aria-label="Pagination">
+        {% if results.has_prev == True %}
+            <div class="govuk-pagination__prev">
+                <a class="govuk-link govuk-pagination__link"
+                   href="{{ url_for(view_name, page=current_page-1, query=query) }}"
+                   rel="prev">
+                    <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
+                         xmlns="http://www.w3.org/2000/svg"
+                         height="13"
+                         width="15"
+                         aria-hidden="true"
+                         focusable="false"
+                         viewBox="0 0 15 13">
+                        <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
+                        </path>
+                    </svg>
+                    <span class="govuk-pagination__link-title">Previous <span class="govuk-visually-hidden">page</span></span></a>
+            </div>
+        {% endif %}
+        <ul class="govuk-pagination__list">
+            {% for page in results.iter_pages(left_edge=1, left_current=1, right_current=1, right_edge=1) %}
+                {% if page %}
+                    {% if page != current_page %}
+                        <li class="govuk-pagination__item">
+                            <a class="govuk-link govuk-pagination__link"
+                               href="{{ url_for(view_name, page=page, query=query) }}"
+                               aria-label="Page {{ page }}">{{ page }}</a>
+                        </li>
+                    {% else %}
+                        <li class="govuk-pagination__item govuk-pagination__item--current">
+                            <a class="govuk-link govuk-pagination__link"
+                               href="{{ url_for(view_name, page=page, query=query) }}"
+                               aria-label="Page {{ page }}"
+                               aria-current="page">{{ page }}</a>
+                        </li>
+                    {% endif %}
+                {% else %}
+                    <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
                 {% endif %}
-    <ul class="govuk-pagination__list">
-        {% for page in results.iter_pages(left_edge=1, left_current=1, right_current=1, right_edge=1) %}
-        {% if page %}
-        {% if page != current_page %}
-        <li class="govuk-pagination__item">
-            <a class="govuk-link govuk-pagination__link" href="{{ url_for(view_name, page=page, query=query) }}"
-                aria-label="Page {{page}}">
-                {{ page }}
-            </a>
-        </li>
-        {% else %}
-        <li class="govuk-pagination__item govuk-pagination__item--current">
-            <a class="govuk-link govuk-pagination__link" href="{{ url_for(view_name, page=page, query=query) }}"
-                aria-label="Page {{page}}" aria-current="page">
-                {{ page }}
-            </a>
-        </li>
+            {% endfor %}
+        </ul>
+        {% if results.has_next == True %}
+            <div class="govuk-pagination__next">
+                <a class="govuk-link govuk-pagination__link"
+                   href="{{ url_for(view_name, page=current_page+1, query=query) }}"
+                   rel="next">
+                    <span class="govuk-pagination__link-title">Next <span class="govuk-visually-hidden">page</span></span>
+                    <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+                         xmlns="http://www.w3.org/2000/svg"
+                         height="13"
+                         width="15"
+                         aria-hidden="true"
+                         focusable="false"
+                         viewBox="0 0 15 13">
+                        <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
+                        </path>
+                    </svg>
+                </a>
+            </div>
         {% endif %}
-        {% else %}
-        <li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>
-        {% endif %}
-        {% endfor %}
-    </ul>
-    {% if results.has_next == True %}
-    <div class="govuk-pagination__next">
-        <a class="govuk-link govuk-pagination__link" href="{{ url_for(view_name, page=current_page+1, query=query) }}"
-            rel="next">
-            <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden"> page</span></span>
-            <svg class="govuk-pagination__icon govuk-pagination__icon--next" xmlns="http://www.w3.org/2000/svg"
-                height="13" width="15" aria-hidden="true" focusable="false" viewBox="0 0 15 13">
-                <path
-                    d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z">
-                </path>
-            </svg></a>
-        </div>
-        {% endif %}
-</nav>
-{% endif%}
+    </nav>
+{% endif %}

--- a/app/templates/main/poc-search.html
+++ b/app/templates/main/poc-search.html
@@ -1,70 +1,65 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-
-
-{% block pageTitle %}Dashboard – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-{% block beforeContent %}
-{{ super() }}
-
-{% endblock %}
-
+{% block pageTitle %}Dashboard – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block beforeContent %}{{ super() }}{% endblock %}
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-      {{ super() }}
-      <div class="govuk-width-container">
-        <main class="govuk-main-wrapper">
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-two-thirds">
-              <h2 class="govuk-heading-l">Search design PoC</h2>
-              <h3 class="govuk-heading-s govuk-!-font-weight-bold">Search for digital records</h3>
-              <form action="{{ url_for('main.poc_search') }}" method="POST">
-                {{ form.csrf_token }}
-                <div class="govuk-form-group">
-                  <label for="searchInput"></label>
-                  <input class="govuk-input govuk-!-width-three-quarters" id="searchInput" name="query" type="text">
-                </div>
-                <button class="govuk-button" data-module="govuk-button" type="submit">Search</button>
-              </form>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ super() }}
+            <div class="govuk-width-container">
+                <main class="govuk-main-wrapper">
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-two-thirds">
+                            <h2 class="govuk-heading-l">Search design PoC</h2>
+                            <h3 class="govuk-heading-s govuk-!-font-weight-bold">Search for digital records</h3>
+                            <form action="{{ url_for('main.poc_search') }}" method="POST">
+                                {{ form.csrf_token }}
+                                <div class="govuk-form-group">
+                                    <label for="searchInput"></label>
+                                    <input class="govuk-input govuk-!-width-three-quarters"
+                                           id="searchInput"
+                                           name="query"
+                                           type="text">
+                                </div>
+                                <button class="govuk-button" data-module="govuk-button" type="submit">Search</button>
+                            </form>
+                        </div>
+                    </div>
+                    <div class="govuk-grid-row">
+                        <div class="govuk-grid-column-full">
+                            {% if query|length >0 %}
+                                <h2 class="govuk-heading-m">{{ num_records_found }} record(s) found</h2>
+                                {% if num_records_found > 0 %}
+                                    <table class="govuk-table">
+                                        <thead class="govuk-table__head">
+                                            <tr class="govuk-table__row govuk-!-font-size-14">
+                                                <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Transferring body</th>
+                                                <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Series</th>
+                                                <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Consignment reference</th>
+                                                <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">File name</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody class="govuk-table__body">
+                                            {% for row in results %}
+                                                <tr class="govuk-table__row">
+                                                    <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[0] }}</td>
+                                                    <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[1] }}</td>
+                                                    <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[2] }}</td>
+                                                    <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[3] }}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                    <!-- PAGINATION -->
+                                    {% with view_name='main.poc_search' %}
+                                        {% include "pagination.html" %}
+                                    {% endwith %}
+                                {% endif %}
+                            {% endif %}
+                        </div>
+                    </div>
+                </main>
             </div>
-          </div>
-          <div class="govuk-grid-row">
-            <div class="govuk-grid-column-full">
-              {% if query|length >0 %}
-                <h2 class="govuk-heading-m">{{ num_records_found }} record(s) found</h2>
-                {% if num_records_found > 0 %}
-                  <table class="govuk-table">
-                    <thead class="govuk-table__head">
-                    <tr class="govuk-table__row govuk-!-font-size-14">
-                      <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Transferring body</th>
-                      <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Series</th>
-                      <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Consignment reference</th>
-                      <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">File name</th>
-                    </tr>
-                    </thead>
-                    <tbody class="govuk-table__body">
-                      {% for row in results %}
-                        <tr class="govuk-table__row">
-                          <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[0] }}</td>
-                          <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[1] }}</td>
-                          <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[2] }}</td>
-                          <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ row[3] }}</td>
-                        </tr>
-                      {% endfor %}
-                    </tbody>
-                  </table>
-                  <!-- PAGINATION -->
-                  {% with view_name='main.poc_search' %}
-                    {% include "pagination.html" %}
-                  {% endwith %}
-                {% endif %}
-              {% endif %}
-            </div>
-          </div>
-        </main>
-      </div>
+        </div>
     </div>
-  </div>
 {% endblock %}

--- a/app/templates/main/poc-search.html
+++ b/app/templates/main/poc-search.html
@@ -12,7 +12,7 @@
                         <div class="govuk-grid-column-two-thirds">
                             <h2 class="govuk-heading-l">Search design PoC</h2>
                             <h3 class="govuk-heading-s govuk-!-font-weight-bold">Search for digital records</h3>
-                            <form action="{{ url_for('main.poc_search') }}" method="POST">
+                            <form action="{{ url_for('main.poc_search') }}" method="post">
                                 {{ form.csrf_token }}
                                 <div class="govuk-form-group">
                                     <label for="searchInput"></label>

--- a/app/templates/main/privacy.html
+++ b/app/templates/main/privacy.html
@@ -1,22 +1,18 @@
 {% extends "base.html" %}
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
-
-{% block pageTitle %}Privacy notice – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Privacy notice – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block beforeContent %}
-  {{ super() }}
-  {{ govukBackLink({
+    {{ super() }}
+    {{ govukBackLink({
     'text': "Back",
-    'href': url_for('main.index')
-  }) }}
+    'href': url_for("main.index")
+    }) }}
 {% endblock %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        {{ super() }}
-        <h1 class="govuk-heading-xl">Privacy notice</h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ super() }}
+            <h1 class="govuk-heading-xl">Privacy notice</h1>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -1,119 +1,129 @@
 {% extends "base.html" %}
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-{% block pageTitle %}Record – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-
-
+{% block pageTitle %}Record – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block content %}
-
-<div class="govuk-width-container govuk-width-container--record">
-  <main class="govuk-main-wrapper">
-    <div class="govuk-grid-row">
-<div class="govuk-grid-row">
-<div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-  <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-  <div class="govuk-breadcrumbs govuk-breadcrumbs--record">
-      <ol class="govuk-breadcrumbs__list">
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link--record" href="#">Everything</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link--record" href="#">Electoral Commision</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link--record" href="#">EC9</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link--record" href="#">TDR-2023-HHA</a>
-        </li>
-        <li class="govuk-breadcrumbs__list-item">
-          <a class="govuk-breadcrumbs__link--record" href="#">political parties panel - notes of meeting 1 - 12 September 2003.doc</a>
-        </li>
-      </ol>
+    <div class="govuk-width-container govuk-width-container--record">
+        <main class="govuk-main-wrapper">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-row">
+                    <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
+                        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+                        <div class="govuk-breadcrumbs govuk-breadcrumbs--record">
+                            <ol class="govuk-breadcrumbs__list">
+                                <li class="govuk-breadcrumbs__list-item">
+                                    <a class="govuk-breadcrumbs__link--record" href="#">Everything</a>
+                                </li>
+                                <li class="govuk-breadcrumbs__list-item">
+                                    <a class="govuk-breadcrumbs__link--record" href="#">Electoral Commision</a>
+                                </li>
+                                <li class="govuk-breadcrumbs__list-item">
+                                    <a class="govuk-breadcrumbs__link--record" href="#">EC9</a>
+                                </li>
+                                <li class="govuk-breadcrumbs__list-item">
+                                    <a class="govuk-breadcrumbs__link--record" href="#">TDR-2023-HHA</a>
+                                </li>
+                                <li class="govuk-breadcrumbs__list-item">
+                                    <a class="govuk-breadcrumbs__link--record" href="#">political parties panel - notes of meeting 1 - 12 September 2003.doc</a>
+                                </li>
+                            </ol>
+                        </div>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds--record-search">
+                    <h1 class="govuk-heading-m govuk-heading-m__record-details">Record details</h1>
+                    <dl class="govuk-summary-list govuk-summary-list--record">
+                        <div class="govuk-summary-list__row"></div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Filename</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['file_name'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
+                            {% if record['status'] | lower == 'closed' %}
+                                <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                    <span class="govuk-tag govuk-tag--red">{{ record['status'] }}</span>
+                                </dd>
+                            {% else %}
+                                <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                    <span class="govuk-tag govuk-tag--green">{{ record['status'] }}</span>
+                                </dd>
+                            {% endif %}
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Transferring body</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['transferring_body'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Consignment ID</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['consignment_id'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Description</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['description'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Date last modified</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['date_last_modified'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Held by</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['held_by'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Legal status</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['legal_status'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Rights copyright</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['rights_copyright'] }}
+                            </dd>
+                        </div>
+                        <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Language</dt>
+                            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                                {{ record['language'] }}
+                            </dd>
+                        </div>
+                    </div>
+                </dl>
+                <div class="govuk-grid-column-one-third govuk-grid-column-one-third--record">
+                    <div class="rights-container">
+                        <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
+                        <button class="govuk-button govuk-button__download--record"
+                                data-module="govuk-button">Download record</button>
+                        <p class="govuk-body govuk-body--terms-of-use">
+                            Refer to <a href="/terms-of-use" class="govuk-link">Terms of use.</a>
+                        </p>
+                    </div>
+                    <div class="record-container">
+                        <h3 class="govuk-heading-m govuk-heading-m__record-header">Record arrangement</h3>
+                        <ol>
+                            <li class="govuk-body govuk-body__record-arrangement-list">Electoral commission meeting notes</li>
+                            <li class=" govuk-body govuk-body__record-arrangement-list">2003</li>
+                            <li class="govuk-body govuk-body__record-arrangement-list">September</li>
+                            <li class="govuk-body govuk-body__record-arrangement-list">
+                                political parties panel - notes of meeting 1 - 12 September 2003.doc
+                            </li>
+                        </ol>
+                    </div>
+                </div>
+            </div>
+        </main>
     </div>
-</div>
-</div>
-      <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds--record-search">
-        <h1 class="govuk-heading-m govuk-heading-m__record-details">Record details</h1>
-          <dl class="govuk-summary-list govuk-summary-list--record">
-            <div class="govuk-summary-list__row"></div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Filename</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['file_name']}}</dd>
-              </div>
-
-
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
-              {% if record['status'] | lower == 'closed' %}
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record"><span class="govuk-tag govuk-tag--red">{{record['status']}}</span>
-              </dd>
-             {% else %}
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record"><span class="govuk-tag govuk-tag--green">{{record['status']}}</span>
-              </dd>
-             {% endif %}
-              </div>
-
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Transferring body</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['transferring_body']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Consignment ID</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['consignment_id']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Description</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['description']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Date last modified</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['date_last_modified']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Held by</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['held_by']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Legal status</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['legal_status']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Rights copyright</dt>
-              <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['rights_copyright']}}</dd>
-              </div>
-              <div class="govuk-summary-list__row govuk-summary-list__row--record">
-              <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Language</dt>
-               <dd class="govuk-summary-list__value govuk-summary-list__value--record">{{record['language']}}</dd>
-              </div>
-              </div>
-              </dl>
-
-
-      <div class="govuk-grid-column-one-third govuk-grid-column-one-third--record">
-          <div class="rights-container">
-          <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-          <button class="govuk-button govuk-button__download--record" data-module="govuk-button">Download record</button>
-          <p class="govuk-body govuk-body--terms-of-use">Refer to <a href="/terms-of-use" class="govuk-link">Terms of use.</a></p>
-          </div>
-
-
-          <div class="record-container">
-              <h3 class="govuk-heading-m govuk-heading-m__record-header">Record arrangement</h3>
-
-<ol>
-  <li class="govuk-body govuk-body__record-arrangement-list">Electoral commission meeting notes</li>
-  <li class=" govuk-body govuk-body__record-arrangement-list">2003</li>
-  <li class="govuk-body govuk-body__record-arrangement-list">September</li>
-  <li class="govuk-body govuk-body__record-arrangement-list">political parties panel - notes of meeting 1 - 12 September 2003.doc</li>
-  </ol>
-  </div>
-  </div>
-  </div>
-  </main>
- </div>
-
- {% endblock %}
+{% endblock %}

--- a/app/templates/main/signed-out.html
+++ b/app/templates/main/signed-out.html
@@ -1,25 +1,20 @@
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
-
-{% block pageTitle %}Signed-out page – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
-{% block beforeContent %}
-  {{ super() }}
-
-{% endblock %}
-
+{% block pageTitle %}Signed-out page – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block beforeContent %}{{ super() }}{% endblock %}
 {% block content %}
-
-<div class="govuk-width-container">
-    <main class="govuk-main-wrapper">
-      <div class="govuk-grid-row">
-        <div class="govuk-grid-column-two-thirds">
-          <h1 class="govuk-heading-l">You have successfully signed out</h1>
-          <p class="govuk-body-l">Thank you for using Access Your Records.</p>
-          <a href="/sign-in" role="button" class="govuk-button govuk-button--sign-in-again" data-module="govuk-button">Sign back in
-          </a>
-        </div>
-      </div>
-    </main>
-  </div>
-  {% endblock %}
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper">
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    <h1 class="govuk-heading-l">You have successfully signed out</h1>
+                    <p class="govuk-body-l">Thank you for using Access Your Records.</p>
+                    <a href="/sign-in"
+                       role="button"
+                       class="govuk-button govuk-button--sign-in-again"
+                       data-module="govuk-button">Sign back in</a>
+                </div>
+            </div>
+        </main>
+    </div>
+{% endblock %}

--- a/app/templates/main/terms-of-use.html
+++ b/app/templates/main/terms-of-use.html
@@ -1,23 +1,18 @@
 {% extends "base.html" %}
-
-
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
-
-{% block pageTitle %}Terms of use – {{config['SERVICE_NAME']}} – GOV.UK{% endblock %}
-
+{% block pageTitle %}Terms of use – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block beforeContent %}
-  {{ super() }}
-  {{ govukBackLink({
+    {{ super() }}
+    {{ govukBackLink({
     'text': "Back",
-    'href': url_for('main.index')
-  }) }}
+    'href': url_for("main.index")
+    }) }}
 {% endblock %}
-
 {% block content %}
-<div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds">
-        {{ super() }}
-        <h1 class="govuk-heading-xl">Terms of use</h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ super() }}
+            <h1 class="govuk-heading-xl">Terms of use</h1>
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/app/tests/assertions.py
+++ b/app/tests/assertions.py
@@ -1,0 +1,12 @@
+from bs4 import BeautifulSoup
+
+
+def assert_contains_html(
+    expected_html_subset, html, sub_element_type, sub_element_filter={}
+):
+    soup = BeautifulSoup(html, "html.parser")
+    subset_soup = soup.find(sub_element_type, sub_element_filter)
+
+    expected_subset_soup = BeautifulSoup(expected_html_subset, "html.parser")
+
+    assert expected_subset_soup.prettify() == subset_soup.prettify()  # nosec

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -1,7 +1,12 @@
+from app.tests.assertions import assert_contains_html
+
+
 def test_record_page(client):
     response = client.get("/record")
 
     assert response.status_code == 200
+
+    html = response.data.decode()
 
     assert (
         b'<a class="govuk-breadcrumbs__link--record" href="#">Electoral Commision</a>'
@@ -12,74 +17,35 @@ def test_record_page(client):
         in response.data
     )
 
-    assert (
-        b'<button class="govuk-button govuk-button__download--record" data-module="govuk-button">'
-        b"Download record</button>" in response.data
+    expected_download_html = """
+    <div class="rights-container">
+        <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
+        <button class="govuk-button govuk-button__download--record" data-module="govuk-button">
+            Download record
+        </button>
+        <p class="govuk-body govuk-body--terms-of-use">
+            Refer to <a href="/terms-of-use" class="govuk-link">Terms of use.</a>
+        </p>
+    </div>
+    """
+
+    assert_contains_html(
+        expected_download_html, html, "div", {"class": "rights-container"}
     )
 
-    assert (
-        b'<p class="govuk-body govuk-body--terms-of-use">'
-        b'Refer to <a href="/terms-of-use" class="govuk-link">Terms of use.</a></p>'
-        in response.data
+    expected_arrangement_html = (
+        '<div class="record-container">'
+        '<h3 class="govuk-heading-m govuk-heading-m__record-header">Record arrangement</h3>'
+        "<ol>"
+        '<li class="govuk-body govuk-body__record-arrangement-list">Electoral commission meeting notes</li>'
+        '<li class=" govuk-body govuk-body__record-arrangement-list">2003</li>'
+        '<li class="govuk-body govuk-body__record-arrangement-list">September</li>'
+        '<li class="govuk-body govuk-body__record-arrangement-list">'
+        "political parties panel - notes of meeting 1 - 12 September 2003.doc</li>"
+        "</ol>"
+        "</div>"
     )
 
-    assert (
-        b'<li class="govuk-body govuk-body__record-arrangement-list">'
-        b"political parties panel - notes of meeting 1 - 12 September 2003.doc</li>"
-        in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table">'
-        b"Filename</dt>" in response.data
-    )
-
-    assert (
-        b'<dd class="govuk-summary-list__value govuk-summary-list__value--record">'
-        in response.data
-    )
-
-    assert (
-        b' <dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Status</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Transferring body</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Consignment ID</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Description</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Date last modified</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Held by</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Legal status</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Rights copyright</dt>" in response.data
-    )
-
-    assert (
-        b'<dt class="govuk-summary-list__key govuk-summary-list__key--record-table"'
-        b">Language</dt>" in response.data
+    assert_contains_html(
+        expected_arrangement_html, html, "div", {"class": "record-container"}
     )

--- a/app/tests/test_signed-out-page.py
+++ b/app/tests/test_signed-out-page.py
@@ -1,7 +1,13 @@
+from app.tests.assertions import assert_contains_html
+
+
 def test_signed_out_page(client):
     response = client.get("/signed-out")
 
     assert response.status_code == 200
+
+    html = response.data.decode()
+
     assert (
         b'<h1 class="govuk-heading-l">You have successfully signed out</h1>'
         in response.data
@@ -11,7 +17,13 @@ def test_signed_out_page(client):
         in response.data
     )
 
-    assert (
-        b'<a href="/sign-in" role="button" class="govuk-button govuk-button--sign-in-again" '
-        b'data-module="govuk-button">Sign back in'
-    ) in response.data
+    expected_button_html = (
+        '<a href="/sign-in" role="button" class="govuk-button govuk-button--sign-in-again" '
+        'data-module="govuk-button">Sign back in</a>'
+    )
+    assert_contains_html(
+        expected_button_html,
+        html,
+        "a",
+        {"class": "govuk-button--sign-in-again"},
+    )

--- a/app/tests/test_start_page.py
+++ b/app/tests/test_start_page.py
@@ -1,7 +1,13 @@
+from app.tests.assertions import assert_contains_html
+
+
 def test_start_page(client):
     response = client.get("/")
 
     assert response.status_code == 200
+
+    html = response.data.decode()
+
     assert (
         b'<h2 class="govuk-heading-m govuk-heading-m--start">Before you start</h2>'
         in response.data
@@ -10,8 +16,16 @@ def test_start_page(client):
         b'<h1 class="govuk-heading-l govuk-heading-l--start">Access your records</h1>'
         in response.data
     )
-    assert (
-        b'<a href="/sign-in" role="button" draggable="false" '
-        b'class="govuk-button govuk-button--start" '
-        b'data-module="govuk-button">Start now'
-    ) in response.data
+
+    expected_button_html = (
+        '<a class="govuk-button govuk-button--start" data-module="govuk-button" '
+        'draggable="false" href="/sign-in" role="button">Start now'
+        '<svg aria-hidden="true" class="govuk-button__start-icon" '
+        'focusable="false" height="19" viewbox="0 0 33 40" width="17.5" xmlns="http://www.w3.org/2000/svg">'
+        '<path d="M0 0h13l20 20-20 20H0l20-20z" fill="currentColor"></path>'
+        "</svg>"
+        "</a>"
+    )
+    assert_contains_html(
+        expected_button_html, html, "a", {"class": "govuk-button"}
+    )


### PR DESCRIPTION
## Reason for this PR
- We have previously had inconsistency in our html file formatting causing noise in PRs.

## Changes in this PR
- Added djlint-format and djlint to precommit to give consistency to our html files since our current precommit formatters dont do anything for html files. 
- Formatted, and fixed linting issues on all html files

Going forward we will have consistency in our html files! No longer any diffs produced from different local formating html files.

First commit deals with the autoreformatting.

The second fixes a handful of linting issues: https://github.com/nationalarchives/da-ayr-beta-webapp/pull/110/commits/e3a69d0faf12833e53d97c472d9c978eb423ab5b

Take a look at the second commit to see these changes separate from the noise of all the reformatting.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-585

## Screenshots of UI changes due to specifying height and width


### TNA Logo image

#### Before
<img width="1214" alt="Screenshot 2023-12-28 at 14 39 50" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/ac69f755-45d1-4d37-8e6d-f6cc33694c64">


#### After
<img width="814" alt="Screenshot 2023-12-28 at 14 41 10" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/ee7ab726-ceff-435e-90db-00b485af87b0">

### Filter image

#### Before
<img width="1238" alt="Screenshot 2023-12-28 at 14 36 32" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/98447b41-d6a0-4afc-88e5-cfc5d44a5d00">

#### After
<img width="1252" alt="Screenshot 2023-12-28 at 14 37 21" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/9376f44b-8087-4748-96c9-653b53aa4b18">
