### PR TITLE
Extract get_user_groups out of access_token_sign_in_required and refa…

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -2,7 +2,7 @@ from functools import wraps
 
 from flask import current_app, flash, g, redirect, session, url_for
 
-from app.main.authorize import keycloak_manager
+from app.main.authorize.keycloak_manager import get_user_groups
 
 
 def access_token_sign_in_required(view_func):
@@ -45,16 +45,14 @@ def access_token_sign_in_required(view_func):
                 return view_func(*args, **kwargs)
 
             access_token = session.get("access_token")
-            if not access_token:
-                return redirect(url_for("main.sign_in"))
 
-            decoded_token = keycloak_manager.decode_token(access_token)
+            groups = get_user_groups(access_token)
 
-            if not decoded_token["active"]:
+            if not groups:
                 session.clear()
                 return redirect(url_for("main.sign_in"))
 
-            if not _check_if_user_has_access_to_ayr(decoded_token):
+            if not _check_if_user_has_access_to_ayr(groups):
                 flash(
                     "TNA User is logged in but does not have access to AYR. Please contact your admin."
                 )  # FIXME: this flash doesn't currently show when first redirected, only on a new page load
@@ -71,8 +69,7 @@ def access_token_sign_in_required(view_func):
     return decorated_view
 
 
-def _check_if_user_has_access_to_ayr(decoded_token):
-    groups = decoded_token["groups"]
+def _check_if_user_has_access_to_ayr(groups):
     group_exists = False
     for group in groups:
         if group.startswith("/ayr_user_type/"):

--- a/app/main/authorize/keycloak_manager.py
+++ b/app/main/authorize/keycloak_manager.py
@@ -1,23 +1,11 @@
 import os
+from typing import Dict, List
 
 import keycloak
 from flask import current_app
 
 
-def decode_token(access_token):
-    keycloak_openid = keycloak.KeycloakOpenID(
-        server_url=current_app.config["KEYCLOAK_BASE_URI"],
-        client_id=current_app.config["KEYCLOAK_CLIENT_ID"],
-        realm_name=current_app.config["KEYCLOAK_REALM_NAME"],
-        client_secret_key=current_app.config["KEYCLOAK_CLIENT_SECRET"],
-    )
-
-    decoded_token = keycloak_openid.introspect(access_token)
-
-    return decoded_token
-
-
-def get_user_transferring_body_keycloak_groups(groups):
+def get_user_transferring_body_keycloak_groups(groups: List[str]) -> List[str]:
     """
     Returns a list of transferring body group names based on a list of keycloak
     user group names
@@ -35,3 +23,28 @@ def get_user_transferring_body_keycloak_groups(groups):
         if len(transferring_body) > 0:
             users_transferring_bodies.append(transferring_body)
     return users_transferring_bodies
+
+
+def get_user_groups(access_token: str) -> List[str]:
+    if not access_token:
+        return []
+
+    decoded_token = _decode_token(access_token)
+
+    if not decoded_token["active"]:
+        return []
+
+    return decoded_token["groups"]
+
+
+def _decode_token(access_token: str) -> Dict[str, str]:
+    keycloak_openid = keycloak.KeycloakOpenID(
+        server_url=current_app.config["KEYCLOAK_BASE_URI"],
+        client_id=current_app.config["KEYCLOAK_CLIENT_ID"],
+        realm_name=current_app.config["KEYCLOAK_REALM_NAME"],
+        client_secret_key=current_app.config["KEYCLOAK_CLIENT_SECRET"],
+    )
+
+    decoded_token = keycloak_openid.introspect(access_token)
+
+    return decoded_token

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -62,9 +62,9 @@ def test_access_token_sign_in_required_decorator_inactive_token(
             assert cleared_session == {}
 
 
-@patch("app.main.authorize.keycloak_manager.keycloak.KeycloakOpenID.introspect")
+@patch("app.main.authorize.access_token_sign_in_required.get_user_groups")
 def test_access_token_sign_in_required_decorator_active_without_ayr_access(
-    mock_decode_keycloak_access_token,
+    mock_get_user_groups,
     app,
 ):
     """
@@ -73,13 +73,10 @@ def test_access_token_sign_in_required_decorator_active_without_ayr_access(
     When accessing a route protected by the 'access_token_sign_in_required' decorator,
     Then it should redirect to the index page with a flashed message.
     """
-    mock_decode_keycloak_access_token.return_value = {
-        "active": True,
-        "groups": [
-            "/transferring_body_user/foo",
-            "/transferring_body_user/bar",
-        ],
-    }
+    mock_get_user_groups.return_value = [
+        "/transferring_body_user/foo",
+        "/transferring_body_user/bar",
+    ]
 
     app.config["FORCE_AUTHENTICATION_FOR_IN_TESTING"] = True
 
@@ -110,9 +107,9 @@ def test_access_token_sign_in_required_decorator_active_without_ayr_access(
         assert response.headers["Location"] == url_for("main.index")
 
 
-@patch("app.main.authorize.keycloak_manager.keycloak.KeycloakOpenID.introspect")
+@patch("app.main.authorize.access_token_sign_in_required.get_user_groups")
 def test_access_token_sign_in_required_decorator_valid_token(
-    mock_decode_keycloak_access_token,
+    mock_get_user_groups,
     app,
 ):
     """
@@ -121,14 +118,11 @@ def test_access_token_sign_in_required_decorator_valid_token(
     When accessing a route protected by the 'access_token_sign_in_required' decorator,
     Then it should grant access
     """
-    mock_decode_keycloak_access_token.return_value = {
-        "active": True,
-        "groups": [
-            "/ayr_user_type/view_department",
-            "/transferring_body_user/foo",
-            "transferring_body_user/bar",
-        ],
-    }
+    mock_get_user_groups.return_value = [
+        "/ayr_user_type/view_department",
+        "/transferring_body_user/foo",
+        "/transferring_body_user/bar",
+    ]
 
     app.config["FORCE_AUTHENTICATION_FOR_IN_TESTING"] = True
 

--- a/app/tests/test_keycloak_manager.py
+++ b/app/tests/test_keycloak_manager.py
@@ -1,41 +1,9 @@
 from unittest.mock import patch
 
 from app.main.authorize.keycloak_manager import (
-    decode_token,
+    get_user_groups,
     get_user_transferring_body_keycloak_groups,
 )
-
-
-@patch("app.main.authorize.keycloak_manager.keycloak.KeycloakOpenID")
-def test_decode_token(mock_keycloak_open_id, app):
-    """
-    Given a valid access token,
-    When decoding the token using the decode_token function,
-    Then it should return the decoded token,
-    And it should make the correct calls to KeycloakOpenID for token introspection.
-    """
-    mock_keycloak_open_id.return_value.introspect.return_value = {
-        "active": True,
-        "groups": ["application_1/foo", "application_2/bar"],
-    }
-
-    app.config["KEYCLOAK_BASE_URI"] = "a"
-    app.config["KEYCLOAK_CLIENT_ID"] = "b"
-    app.config["KEYCLOAK_REALM_NAME"] = "c"
-    app.config["KEYCLOAK_CLIENT_SECRET"] = "d"
-
-    with app.app_context():
-        decoded_token = decode_token("valid_token")
-
-    assert decoded_token == {
-        "active": True,
-        "groups": ["application_1/foo", "application_2/bar"],
-    }
-
-    mock_keycloak_open_id.assert_called_once_with(
-        server_url="a", client_id="b", realm_name="c", client_secret_key="d"
-    )
-    mock_keycloak_open_id.return_value.introspect.assert_called_once()
 
 
 class TestGetUserTransferringBodyGroups:
@@ -66,7 +34,7 @@ class TestGetUserTransferringBodyGroups:
                 [
                     "/transferring_body_user/foo",
                     "/transferring_body_user/bar",
-                    "/ayr_user/abc",
+                    "/ayr_user_type/abc",
                 ]
             ) == [
                 "foo",
@@ -87,9 +55,81 @@ class TestGetUserTransferringBodyGroups:
             assert get_user_transferring_body_keycloak_groups(
                 [
                     "/transferring_body_user/foo",
-                    "/ayr_user/abc",
+                    "/ayr_user_type/abc",
                     "/transferring_body_user/",
                 ]
             ) == [
                 "foo",
             ]
+
+
+class TestGetUserGroups:
+    def test_no_token_returns_empty_list(
+        self,
+    ):
+        """
+        Given no access token,
+        When calling the get_user_groups
+        Then it should return an empty list
+        """
+        results = get_user_groups("")
+        assert results == []
+
+    @patch("app.main.authorize.keycloak_manager.keycloak.KeycloakOpenID")
+    def test_inactive_user_returns_empty_list(self, mock_keycloak_open_id, app):
+        """
+        Given a mocked KeycloakOpenID with introspection result indicating an inactive user
+        And configured Keycloak parameters in the Flask app
+        When the get_user_groups function is called with a valid token
+        Then the result should be an empty list
+        And KeycloakOpenID should be instantiated with the correct configuration
+        And introspect should be called once on the KeycloakOpenID instance
+        """
+        mock_keycloak_open_id.return_value.introspect.return_value = {
+            "active": False,
+        }
+
+        app.config["KEYCLOAK_BASE_URI"] = "a"
+        app.config["KEYCLOAK_CLIENT_ID"] = "b"
+        app.config["KEYCLOAK_REALM_NAME"] = "c"
+        app.config["KEYCLOAK_CLIENT_SECRET"] = "d"
+
+        with app.app_context():
+            groups = get_user_groups("valid_token")
+
+        assert groups == []
+
+        mock_keycloak_open_id.assert_called_once_with(
+            server_url="a", client_id="b", realm_name="c", client_secret_key="d"
+        )
+        mock_keycloak_open_id.return_value.introspect.assert_called_once()
+
+    @patch("app.main.authorize.keycloak_manager.keycloak.KeycloakOpenID")
+    def test_active_user_returns_groups(self, mock_keycloak_open_id, app):
+        """
+        Given a mocked KeycloakOpenID with introspection result indicating an active user and associated groups
+        And configured Keycloak parameters in the Flask app
+        When the get_user_groups function is called with a valid token
+        Then the result should be the list of associated groups
+        And KeycloakOpenID should be instantiated with the correct configuration
+        And introspect should be called once on the KeycloakOpenID instance
+        """
+        mock_keycloak_open_id.return_value.introspect.return_value = {
+            "active": True,
+            "groups": ["foo", "bar"],
+        }
+
+        app.config["KEYCLOAK_BASE_URI"] = "a"
+        app.config["KEYCLOAK_CLIENT_ID"] = "b"
+        app.config["KEYCLOAK_REALM_NAME"] = "c"
+        app.config["KEYCLOAK_CLIENT_SECRET"] = "d"
+
+        with app.app_context():
+            groups = get_user_groups("valid_token")
+
+        assert groups == ["foo", "bar"]
+
+        mock_keycloak_open_id.assert_called_once_with(
+            server_url="a", client_id="b", realm_name="c", client_secret_key="d"
+        )
+        mock_keycloak_open_id.return_value.introspect.assert_called_once()


### PR DESCRIPTION
## Changes in this PR

- Extract get_user_groups out of access_token_sign_in_required and refactor get_user_accessible_transferring_bodies so that it doesnt need the same logic anymore


## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574
