### PR TITLE
Limit users to their transferring bodies

### DIFF
--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -1,0 +1,29 @@
+from flask import abort, session
+
+from app.main.authorize.keycloak_manager import get_user_groups
+from app.main.db.queries import get_user_accessible_transferring_bodies
+
+
+def validate_body_user_groups_or_404(
+    transferring_body_name: str,
+):
+    """
+    Validates whether the user in the current flask session has access to a specific
+    transferring body based on their user groups.
+
+    Args:
+        transferring_body_name (str): The name of the transferring body to check access for.
+
+    Raises:
+        werkzeug.exceptions.NotFound: If the user does not have access to the specified transferring body.
+    """
+    groups = get_user_groups(session.get("access_token"))
+    user_accessible_transferring_bodies = (
+        get_user_accessible_transferring_bodies(groups)
+    )
+
+    if "/ayr_user_type/view_all" not in groups and (
+        not user_accessible_transferring_bodies
+        or (transferring_body_name not in user_accessible_transferring_bodies)
+    ):
+        abort(404)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -20,6 +20,10 @@ from app.main.authorize.access_token_sign_in_required import (
     access_token_sign_in_required,
 )
 from app.main.db.queries import browse_data, fuzzy_search, get_file_metadata
+from app.main.authorize.permissions_helpers import (
+    validate_body_user_groups_or_404,
+)
+from app.main.db.models import File
 from app.main.forms import CookiesForm
 
 from .forms import SearchForm
@@ -173,6 +177,12 @@ def record(record_id: uuid.UUID):
     Returns:
         A rendered HTML page with record details.
     """
+    file = File.query.one_or_404(record_id)
+
+    validate_body_user_groups_or_404(
+        file.file_consignments.consignment_bodies.Name
+    )
+
     file_metadata = get_file_metadata(record_id)
 
     return render_template("record.html", record=file_metadata)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -19,11 +19,11 @@ from app.main import bp
 from app.main.authorize.access_token_sign_in_required import (
     access_token_sign_in_required,
 )
-from app.main.db.queries import browse_data, fuzzy_search, get_file_metadata
 from app.main.authorize.permissions_helpers import (
     validate_body_user_groups_or_404,
 )
 from app.main.db.models import File
+from app.main.db.queries import browse_data, fuzzy_search, get_file_metadata
 from app.main.forms import CookiesForm
 
 from .forms import SearchForm

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,9 +1,35 @@
+from unittest.mock import patch
+
 import pytest
+from flask.testing import FlaskClient
 from testing.postgresql import PostgresqlFactory
 
 from app import create_app
 from app.main.db.models import db
 from configs.testing_config import TestingConfig
+
+
+def mock_standard_user(client: FlaskClient, body: str):
+    with client.session_transaction() as session:
+        session["access_token"] = "valid_token"
+
+    groups = [
+        "/ayr_user_type/view_department",
+        f"/transferring_body_user/{body}",
+    ]
+
+    patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
+    mock_get_user_groups = patcher.start()
+    mock_get_user_groups.return_value = groups
+
+
+def mock_superuser(client: FlaskClient):
+    with client.session_transaction() as session:
+        session["access_token"] = "valid_token"
+
+    patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
+    mock_get_user_groups = patcher.start()
+    mock_get_user_groups.return_value = "/ayr_user_type/view_all"
 
 
 @pytest.fixture

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -29,7 +29,7 @@ def mock_superuser(client: FlaskClient):
 
     patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
     mock_get_user_groups = patcher.start()
-    mock_get_user_groups.return_value = "/ayr_user_type/view_all"
+    mock_get_user_groups.return_value = ["/ayr_user_type/view_all"]
 
 
 @pytest.fixture

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -1,0 +1,68 @@
+import pytest
+import werkzeug
+
+from app.main.authorize.permissions_helpers import (
+    validate_body_user_groups_or_404,
+)
+from app.tests.conftest import mock_standard_user, mock_superuser
+from app.tests.factories import BodyFactory
+
+
+def test_does_not_raise_404_for_body_name_user_has_access_to_and_is_in_database(
+    client,
+):
+    """
+    Given a Body with name 'foo' in the database
+    And a standard user with access to the body 'foo'
+    When validate_body_user_groups_or_404 is called with 'foo'
+    Then the function should not raise a 404 exception
+    """
+    BodyFactory(Name="foo")
+    mock_standard_user(client, "foo")
+
+    validate_body_user_groups_or_404("foo")
+
+
+def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
+    client,
+):
+    """
+    Given a Body with name 'foo' in the database
+    And a standard user without access to the body 'foo'
+    When validate_body_user_groups_or_404 is called with 'foo'
+    Then the function should raise a 404 exception
+    """
+    BodyFactory(Name="foo")
+    mock_standard_user(client, "bar")
+
+    with pytest.raises(werkzeug.exceptions.NotFound):
+        validate_body_user_groups_or_404("foo")
+
+
+def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
+    client,
+):
+    """
+    Given a standard user with access to the body 'foo'
+    And no Body with name 'foo' in the database
+    When validate_body_user_groups_or_404 is called with 'foo'
+    Then the function should raise a 404 exception
+    """
+    BodyFactory(Name="bar")
+    mock_standard_user(client, "foo")
+
+    with pytest.raises(werkzeug.exceptions.NotFound):
+        validate_body_user_groups_or_404("foo")
+
+
+def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_for_superuser(
+    client,
+):
+    """
+    Given a superuser
+    When validate_body_user_groups_or_404 is called with any body name, e.g. 'foo'
+    Then the function should not raise a 404 exception
+    """
+    mock_superuser(client)
+
+    validate_body_user_groups_or_404("foo")

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -15,7 +15,6 @@ def test_invalid_id_raises_404(client):
     assert response.status_code == 404
 
 
-
 def test_returns_record_page_for_user_with_access_to_files_transferring_body(
     client,
 ):
@@ -34,7 +33,6 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
     )
 
     mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
-
 
     metadata = {
         "date_last_modified": "2023-02-25T10:12:47",
@@ -195,7 +193,31 @@ def test_raises_404_for_user_without_access_to_files_transferring_body(client):
         request to view the record page
     Then the response status code should be 404
     """
-    file = FileFactory()
+
+    file = FileFactory(
+        FileName="test_file.txt",
+        FilePath="data/content/folder_a/test_file.txt",
+        FileType="file",
+    )
+
+    metadata = {
+        "date_last_modified": "2023-02-25T10:12:47",
+        "closure_type": "Closed",
+        "description": "Test description",
+        "held_by": "Test holder",
+        "legal_status": "Test legal status",
+        "rights_copyright": "Test copyright",
+        "language": "English",
+    }
+
+    [
+        FileMetadataFactory(
+            file_metadata=file,
+            PropertyName=property_name,
+            Value=value,
+        )
+        for property_name, value in metadata.items()
+    ]
 
     mock_standard_user(client, "different_body")
 
@@ -213,7 +235,30 @@ def test_returns_record_page_for_superuser(client):
     """
     mock_superuser(client)
 
-    file = FileFactory()
+    file = FileFactory(
+        FileName="test_file.txt",
+        FilePath="data/content/folder_a/test_file.txt",
+        FileType="file",
+    )
+
+    metadata = {
+        "date_last_modified": "2023-02-25T10:12:47",
+        "closure_type": "Closed",
+        "description": "Test description",
+        "held_by": "Test holder",
+        "legal_status": "Test legal status",
+        "rights_copyright": "Test copyright",
+        "language": "English",
+    }
+
+    [
+        FileMetadataFactory(
+            file_metadata=file,
+            PropertyName=property_name,
+            Value=value,
+        )
+        for property_name, value in metadata.items()
+    ]
 
     response = client.get(f"/record/{file.FileId}")
 

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -1,4 +1,5 @@
 from app.tests.assertions import assert_contains_html
+from app.tests.conftest import mock_standard_user, mock_superuser
 from app.tests.factories import FileFactory, FileMetadataFactory
 
 
@@ -14,17 +15,26 @@ def test_invalid_id_raises_404(client):
     assert response.status_code == 404
 
 
-def test_valid_id_returns_expected_html(client):
+
+def test_returns_record_page_for_user_with_access_to_files_transferring_body(
+    client,
+):
     """
-    Given a file with id, file_id, and associated metadata,
-    When a GET request is made to `record/file_id`
-    Then the response contains html including the record's expected metadata
+    Given a File in the database
+    When a standard user with access to the file's transferring body makes a
+        request to view the record page
+    Then the response status code should be 200
+    And the HTML content should contain specific elements
+        related to the record
     """
     file = FileFactory(
         FileName="test_file.txt",
         FilePath="data/content/folder_a/test_file.txt",
         FileType="file",
     )
+
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+
 
     metadata = {
         "date_last_modified": "2023-02-25T10:12:47",
@@ -176,3 +186,35 @@ def test_valid_id_returns_expected_html(client):
     assert_contains_html(
         expected_download_html, html, "div", {"class": "rights-container"}
     )
+
+
+def test_raises_404_for_user_without_access_to_files_transferring_body(client):
+    """
+    Given a File in the database
+    When a standard user without access to the file's consignment body makes a
+        request to view the record page
+    Then the response status code should be 404
+    """
+    file = FileFactory()
+
+    mock_standard_user(client, "different_body")
+
+    response = client.get(f"/record/{file.FileId}")
+
+    assert response.status_code == 404
+
+
+def test_returns_record_page_for_superuser(client):
+    """
+    Given a File in the database
+    And a superuser
+    When the superuser makes a request to view the record page
+    Then the response status code should be 200
+    """
+    mock_superuser(client)
+
+    file = FileFactory()
+
+    response = client.get(f"/record/{file.FileId}")
+
+    assert response.status_code == 200


### PR DESCRIPTION
## Changes in this PR

- Added `validate_body_user_groups_or_404` function to be reused by any detail view
- Utilised it in /record/record_id/ view so standard users can only see records from the transferring body they are part of.

Followup PR to come for browse-transferring and browse-series views. 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-574
