### PR TITLE
Validate standard user transferring body user group access for detail browse views

### DIFF
--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -1,7 +1,13 @@
-from flask import abort, session
+from typing import List
 
-from app.main.authorize.keycloak_manager import get_user_groups
-from app.main.db.queries import get_user_accessible_transferring_bodies
+from flask import abort, session
+from sqlalchemy import exc
+
+from app.main.authorize.keycloak_manager import (
+    get_user_groups,
+    get_user_transferring_body_keycloak_groups,
+)
+from app.main.db.models import Body, db
 
 
 def validate_body_user_groups_or_404(
@@ -27,3 +33,39 @@ def validate_body_user_groups_or_404(
         or (transferring_body_name not in user_accessible_transferring_bodies)
     ):
         abort(404)
+
+
+def get_user_accessible_transferring_bodies(groups: List[str]) -> List[str]:
+    user_transferring_bodies = get_user_transferring_body_keycloak_groups(
+        groups
+    )
+
+    if not user_transferring_bodies:
+        return []
+
+    try:
+        query = db.session.query(Body.Name)
+        bodies = db.session.execute(query)
+    except exc.SQLAlchemyError as e:
+        print("Failed to return results from database with error : " + str(e))
+        return []
+
+    user_accessible_transferring_bodies = []
+
+    for body in bodies:
+        body_name = body.Name
+        if _body_in_users_groups(body_name, user_transferring_bodies):
+            user_accessible_transferring_bodies.append(body_name)
+
+    return user_accessible_transferring_bodies
+
+
+def _body_in_users_groups(body, user_transferring_body_keycloak_groups):
+    for user_group in user_transferring_body_keycloak_groups:
+        if (
+            user_group.strip().replace(" ", "").lower()
+            == body.strip().replace(" ", "").lower()
+        ):
+            return True
+
+    return False

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -1,6 +1,7 @@
 from bs4 import BeautifulSoup
 from flask.testing import FlaskClient
 
+from app.tests.conftest import mock_standard_user
 from app.tests.mock_database import (
     create_multiple_files_for_consignment,
     create_multiple_test_records,
@@ -317,6 +318,8 @@ def test_browse_transferring_body(client: FlaskClient):
     file = files[0]
     transferring_body_id = file.file_consignments.consignment_bodies.BodyId
 
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+
     response = client.get(
         f"/browse?transferring_body_id={transferring_body_id}"
     )
@@ -363,6 +366,8 @@ def test_browse_series(client: FlaskClient):
     file = files[0]
     series_id = file.file_consignments.SeriesId
 
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+
     response = client.get(f"/browse?series_id={series_id}")
 
     assert response.status_code == 200
@@ -408,6 +413,8 @@ def test_browse_consignment(client: FlaskClient):
     files = create_multiple_test_records()
     file = files[0]
     consignment_id = file.file_consignments.ConsignmentId
+
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?consignment_id={consignment_id}")
 
@@ -457,6 +464,8 @@ def test_browse_consignment_filter_display_multiple_pages(
     consignment_id = file.file_consignments.ConsignmentId
 
     create_multiple_files_for_consignment(consignment_id)
+
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?page=2&consignment_id={consignment_id}")
     assert response.status_code == 200

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -1,9 +1,16 @@
+import uuid
+from unittest.mock import patch
+
 import pytest
 import werkzeug
+from flask.testing import FlaskClient
+from sqlalchemy import exc
 
 from app.main.authorize.permissions_helpers import (
+    get_user_accessible_transferring_bodies,
     validate_body_user_groups_or_404,
 )
+from app.main.db.models import Body, db
 from app.tests.conftest import mock_standard_user, mock_superuser
 from app.tests.factories import BodyFactory
 
@@ -66,3 +73,100 @@ def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_fo
     mock_superuser(client)
 
     validate_body_user_groups_or_404("foo")
+
+
+class TestGetUserAccessibleTransferringBodies:
+    def test_no_groups_returns_empty_list(
+        self,
+    ):
+        """
+        Given an empty list,
+        When calling get_user_accessible_transferring_bodies with it
+        Then it should return an empty list
+        """
+        results = get_user_accessible_transferring_bodies([])
+        assert results == []
+
+    def test_no_transferring_bodies_returns_empty_list(
+        self,
+    ):
+        """
+        Given a list of groups not containing any /transferring_body_user/ groups
+        When I call get_user_accessible_transferring_bodies with it
+        Then it should return an empty list
+        """
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/something_else/test body1",
+                "/something_else/test body2",
+                "/ayr_user_type/bar",
+            ]
+        )
+        assert results == []
+
+    def test_transferring_bodies_in_groups_returns_corresponding_body_names(
+        self, client: FlaskClient
+    ):
+        """
+        Given a list of groups including 2 prefixed with
+            /transferring_body_user/
+            and another group
+            and 2 corresponding bodies in the database
+            and an extra body in the database
+        When get_user_accessible_transferring_bodies is called with it
+        Then it should return a list with the 2 corresponding body names
+        """
+        body_1 = Body(
+            BodyId=uuid.uuid4(), Name="test body1", Description="test body1"
+        )
+        db.session.add(body_1)
+        db.session.commit()
+
+        body_2 = Body(
+            BodyId=uuid.uuid4(), Name="test body2", Description="test body2"
+        )
+        db.session.add(body_2)
+        db.session.commit()
+
+        body_3 = Body(
+            BodyId=uuid.uuid4(), Name="test body3", Description="test body3"
+        )
+        db.session.add(body_3)
+        db.session.commit()
+
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/transferring_body_user/test body1",
+                "/transferring_body_user/test body2",
+                "/foo/bar",
+            ]
+        )
+        assert results == ["test body1", "test body2"]
+
+    @patch("app.main.db.queries.db")
+    def test_db_raised_exception_returns_empty_list_and_log_message(
+        self, database, capsys, client
+    ):
+        """
+        Given a db execution error
+        When get_user_accessible_transferring_bodies is called
+        Then it should return an empty list and an error message is logged
+        """
+
+        def mock_execute(_):
+            raise exc.SQLAlchemyError("foo bar")
+
+        database.session.execute.side_effect = mock_execute
+
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/transferring_body_user/test body1",
+                "/transferring_body_user/test body2",
+                "/ayr_user_type/bar",
+            ]
+        )
+        assert results == []
+        assert (
+            "Failed to return results from database with error : foo bar"
+            in capsys.readouterr().out
+        )


### PR DESCRIPTION
## Changes in this PR

- Validate standard user transferring body user group access for detail browse views:
   (transferring body, series and consignment browse views)

Note: top level browse view will be dealt with similar to how search view will be dealt with.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574