### PR TITLE
Fix record route by using get_or_404, not one_or_404

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -177,7 +177,7 @@ def record(record_id: uuid.UUID):
     Returns:
         A rendered HTML page with record details.
     """
-    file = File.query.one_or_404(record_id)
+    file = File.query.get_or_404(record_id)
 
     validate_body_user_groups_or_404(
         file.file_consignments.consignment_bodies.Name


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Fix record route by using get_or_404, not one_or_404

https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/api/#flask_sqlalchemy.query.Query.get_or_404

is what should be used, not https://flask-sqlalchemy.palletsprojects.com/en/3.0.x/api/#flask_sqlalchemy.query.Query.get_or_404 since one_or_404 will error if more than one File in the db.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574
