### PR TITLE
Create AYRUser class and refactor business logic that depends on ayr group logic

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -2,6 +2,7 @@ from functools import wraps
 
 from flask import current_app, flash, g, redirect, session, url_for
 
+from app.main.authorize.ayr_user import AYRUser
 from app.main.authorize.keycloak_manager import get_user_groups
 
 
@@ -52,7 +53,8 @@ def access_token_sign_in_required(view_func):
                 session.clear()
                 return redirect(url_for("main.sign_in"))
 
-            if not _check_if_user_has_access_to_ayr(groups):
+            ayr_user = AYRUser(groups)
+            if not ayr_user.can_access_ayr:
                 flash(
                     "TNA User is logged in but does not have access to AYR. Please contact your admin."
                 )  # FIXME: this flash doesn't currently show when first redirected, only on a new page load
@@ -67,12 +69,3 @@ def access_token_sign_in_required(view_func):
     decorated_view.access_token_sign_in_required = True
 
     return decorated_view
-
-
-def _check_if_user_has_access_to_ayr(groups):
-    group_exists = False
-    for group in groups:
-        if group.startswith("/ayr_user_type/"):
-            group_exists = True
-            break
-    return group_exists

--- a/app/main/authorize/ayr_user.py
+++ b/app/main/authorize/ayr_user.py
@@ -1,0 +1,68 @@
+from typing import List
+
+from sqlalchemy import exc
+
+from app.main.authorize.keycloak_manager import (
+    get_user_transferring_body_keycloak_groups,
+)
+from app.main.db.models import Body, db
+
+
+class AYRUser:
+    def __init__(self, groups: List[str]) -> None:
+        self.groups = groups
+
+    @property
+    def can_access_ayr(self):
+        return self.is_superuser or self.is_standard_user
+
+    @property
+    def is_superuser(self) -> bool:
+        return "/ayr_user_type/view_all" in self.groups
+
+    @property
+    def is_standard_user(self) -> bool:
+        return "/ayr_user_type/view_dept" in self.groups
+
+    @property
+    def transferring_bodies(self) -> str | None:
+        if self.is_superuser or not self.is_standard_user:
+            return None
+
+        return get_user_accessible_transferring_bodies(self.groups)
+
+
+def get_user_accessible_transferring_bodies(groups: List[str]) -> List[str]:
+    user_transferring_bodies = get_user_transferring_body_keycloak_groups(
+        groups
+    )
+
+    if not user_transferring_bodies:
+        return []
+
+    try:
+        query = db.session.query(Body.Name)
+        bodies = db.session.execute(query)
+    except exc.SQLAlchemyError as e:
+        print("Failed to return results from database with error : " + str(e))
+        return []
+
+    user_accessible_transferring_bodies = []
+
+    for body in bodies:
+        body_name = body.Name
+        if _body_in_users_groups(body_name, user_transferring_bodies):
+            user_accessible_transferring_bodies.append(body_name)
+
+    return user_accessible_transferring_bodies
+
+
+def _body_in_users_groups(body, user_transferring_body_keycloak_groups):
+    for user_group in user_transferring_body_keycloak_groups:
+        if (
+            user_group.strip().replace(" ", "").lower()
+            == body.strip().replace(" ", "").lower()
+        ):
+            return True
+
+    return False

--- a/app/main/authorize/ayr_user.py
+++ b/app/main/authorize/ayr_user.py
@@ -1,11 +1,9 @@
 from typing import List
 
-from sqlalchemy import exc
-
 from app.main.authorize.keycloak_manager import (
     get_user_transferring_body_keycloak_groups,
 )
-from app.main.db.models import Body, db
+from app.main.db.models import Body
 
 
 class AYRUser:
@@ -40,16 +38,9 @@ def get_user_accessible_transferring_bodies(groups: List[str]) -> List[str]:
     if not user_transferring_bodies:
         return []
 
-    try:
-        query = db.session.query(Body.Name)
-        bodies = db.session.execute(query)
-    except exc.SQLAlchemyError as e:
-        print("Failed to return results from database with error : " + str(e))
-        return []
-
     user_accessible_transferring_bodies = []
 
-    for body in bodies:
+    for body in Body.query.all():
         body_name = body.Name
         if _body_in_users_groups(body_name, user_transferring_bodies):
             user_accessible_transferring_bodies.append(body_name)

--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -1,13 +1,7 @@
-from typing import List
-
 from flask import abort, session
-from sqlalchemy import exc
 
-from app.main.authorize.keycloak_manager import (
-    get_user_groups,
-    get_user_transferring_body_keycloak_groups,
-)
-from app.main.db.models import Body, db
+from app.main.authorize.ayr_user import AYRUser
+from app.main.authorize.keycloak_manager import get_user_groups
 
 
 def validate_body_user_groups_or_404(
@@ -23,49 +17,10 @@ def validate_body_user_groups_or_404(
     Raises:
         werkzeug.exceptions.NotFound: If the user does not have access to the specified transferring body.
     """
-    groups = get_user_groups(session.get("access_token"))
-    user_accessible_transferring_bodies = (
-        get_user_accessible_transferring_bodies(groups)
-    )
+    ayr_user = AYRUser(get_user_groups(session.get("access_token")))
 
-    if "/ayr_user_type/view_all" not in groups and (
-        not user_accessible_transferring_bodies
-        or (transferring_body_name not in user_accessible_transferring_bodies)
-    ):
+    if ayr_user.is_superuser:
+        return
+
+    if transferring_body_name not in ayr_user.transferring_bodies:
         abort(404)
-
-
-def get_user_accessible_transferring_bodies(groups: List[str]) -> List[str]:
-    user_transferring_bodies = get_user_transferring_body_keycloak_groups(
-        groups
-    )
-
-    if not user_transferring_bodies:
-        return []
-
-    try:
-        query = db.session.query(Body.Name)
-        bodies = db.session.execute(query)
-    except exc.SQLAlchemyError as e:
-        print("Failed to return results from database with error : " + str(e))
-        return []
-
-    user_accessible_transferring_bodies = []
-
-    for body in bodies:
-        body_name = body.Name
-        if _body_in_users_groups(body_name, user_transferring_bodies):
-            user_accessible_transferring_bodies.append(body_name)
-
-    return user_accessible_transferring_bodies
-
-
-def _body_in_users_groups(body, user_transferring_body_keycloak_groups):
-    for user_group in user_transferring_body_keycloak_groups:
-        if (
-            user_group.strip().replace(" ", "").lower()
-            == body.strip().replace(" ", "").lower()
-        ):
-            return True
-
-    return False

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,3 +1,4 @@
+from typing import List
 from unittest.mock import patch
 
 import pytest
@@ -9,14 +10,12 @@ from app.main.db.models import db
 from configs.testing_config import TestingConfig
 
 
-def mock_standard_user(client: FlaskClient, body: str):
+def mock_standard_user(client: FlaskClient, bodies: List[str]):
     with client.session_transaction() as session:
         session["access_token"] = "valid_token"
 
-    groups = [
-        "/ayr_user_type/view_department",
-        f"/transferring_body_user/{body}",
-    ]
+    groups = [f"/transferring_body_user/{body}" for body in bodies]
+    groups.append("/ayr_user_type/view_dept")
 
     patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
     mock_get_user_groups = patcher.start()

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -119,7 +119,7 @@ def test_access_token_sign_in_required_decorator_valid_token(
     Then it should grant access
     """
     mock_get_user_groups.return_value = [
-        "/ayr_user_type/view_department",
+        "/ayr_user_type/view_dept",
         "/transferring_body_user/foo",
         "/transferring_body_user/bar",
     ]

--- a/app/tests/test_ayr_user.py
+++ b/app/tests/test_ayr_user.py
@@ -1,0 +1,134 @@
+from unittest.mock import patch
+
+from flask.testing import FlaskClient
+from sqlalchemy import exc
+
+from app.main.authorize.ayr_user import (
+    AYRUser,
+    get_user_accessible_transferring_bodies,
+)
+from app.tests.conftest import mock_standard_user
+from app.tests.factories import BodyFactory
+
+
+class TestAYRUser:
+    def test_properties_when_ayr_user_type_view_dept_group(self):
+        groups = ["/ayr_user_type/view_dept"]
+        user = AYRUser(groups)
+        assert user.can_access_ayr
+        assert user.is_standard_user
+        assert not user.is_superuser
+
+    def test_properties_when_ayr_user_type_view_all_group(self):
+        groups = ["/ayr_user_type/view_all"]
+        user = AYRUser(groups)
+        assert user.can_access_ayr
+        assert user.is_superuser
+        assert not user.is_standard_user
+
+    def test_properties_when_no_valid_ayr_user_group(self):
+        groups = ["/ayr_user_type/foo"]
+        user = AYRUser(groups)
+        assert not user.can_access_ayr
+        assert not user.is_superuser
+        assert not user.is_standard_user
+
+    def test_when_transferring_body_user_prefix_in_groups(self, client):
+        BodyFactory(Name="foo")
+        BodyFactory(Name="bar")
+        mock_standard_user(client, ["foo", "bar"])
+        groups = [
+            "/ayr_user_type/view_dept",
+            "/transferring_body_user/foo",
+            "/transferring_body_user/bar",
+        ]
+        user = AYRUser(groups)
+        assert user.transferring_bodies == ["foo", "bar"]
+
+    def test_when_superuser_transferring_bodies_is_none(self):
+        groups = ["/ayr_user_type/view_all", "/transferring_body_user/foo"]
+        user = AYRUser(groups)
+        assert user.transferring_bodies is None
+
+
+class TestGetUserAccessibleTransferringBodies:
+    def test_no_groups_returns_empty_list(
+        self,
+    ):
+        """
+        Given an empty list,
+        When calling get_user_accessible_transferring_bodies with it
+        Then it should return an empty list
+        """
+        results = get_user_accessible_transferring_bodies([])
+        assert results == []
+
+    def test_no_transferring_bodies_returns_empty_list(
+        self,
+    ):
+        """
+        Given a list of groups not containing any /transferring_body_user/ groups
+        When I call get_user_accessible_transferring_bodies with it
+        Then it should return an empty list
+        """
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/something_else/test body1",
+                "/something_else/test body2",
+                "/ayr_user_type/bar",
+            ]
+        )
+        assert results == []
+
+    def test_transferring_bodies_in_groups_returns_corresponding_body_names(
+        self, client: FlaskClient
+    ):
+        """
+        Given a list of groups including 2 prefixed with
+            /transferring_body_user/
+            and another group
+            and 2 corresponding bodies in the database
+            and an extra body in the database
+        When get_user_accessible_transferring_bodies is called with it
+        Then it should return a list with the 2 corresponding body names
+        """
+        BodyFactory(Name="test body1")
+        BodyFactory(Name="test body2")
+        BodyFactory(Name="test body3")
+
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/transferring_body_user/test body1",
+                "/transferring_body_user/test body2",
+                "/foo/bar",
+            ]
+        )
+        assert results == ["test body1", "test body2"]
+
+    @patch("app.main.authorize.ayr_user.db")
+    def test_db_raised_exception_returns_empty_list_and_log_message(
+        self, database, capsys, client
+    ):
+        """
+        Given a db execution error
+        When get_user_accessible_transferring_bodies is called
+        Then it should return an empty list and an error message is logged
+        """
+
+        def mock_execute(_):
+            raise exc.SQLAlchemyError("foo bar")
+
+        database.session.execute.side_effect = mock_execute
+
+        results = get_user_accessible_transferring_bodies(
+            [
+                "/transferring_body_user/test body1",
+                "/transferring_body_user/test body2",
+                "/ayr_user_type/bar",
+            ]
+        )
+        assert results == []
+        assert (
+            "Failed to return results from database with error : foo bar"
+            in capsys.readouterr().out
+        )

--- a/app/tests/test_ayr_user.py
+++ b/app/tests/test_ayr_user.py
@@ -1,7 +1,4 @@
-from unittest.mock import patch
-
 from flask.testing import FlaskClient
-from sqlalchemy import exc
 
 from app.main.authorize.ayr_user import (
     AYRUser,
@@ -104,31 +101,3 @@ class TestGetUserAccessibleTransferringBodies:
             ]
         )
         assert results == ["test body1", "test body2"]
-
-    @patch("app.main.authorize.ayr_user.db")
-    def test_db_raised_exception_returns_empty_list_and_log_message(
-        self, database, capsys, client
-    ):
-        """
-        Given a db execution error
-        When get_user_accessible_transferring_bodies is called
-        Then it should return an empty list and an error message is logged
-        """
-
-        def mock_execute(_):
-            raise exc.SQLAlchemyError("foo bar")
-
-        database.session.execute.side_effect = mock_execute
-
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/transferring_body_user/test body1",
-                "/transferring_body_user/test body2",
-                "/ayr_user_type/bar",
-            ]
-        )
-        assert results == []
-        assert (
-            "Failed to return results from database with error : foo bar"
-            in capsys.readouterr().out
-        )

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -317,7 +317,7 @@ def test_browse_transferring_body(client: FlaskClient):
     file = files[0]
     transferring_body_id = file.file_consignments.consignment_bodies.BodyId
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     response = client.get(
         f"/browse?transferring_body_id={transferring_body_id}"
@@ -365,7 +365,7 @@ def test_browse_series(client: FlaskClient):
     file = files[0]
     series_id = file.file_consignments.SeriesId
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     response = client.get(f"/browse?series_id={series_id}")
 
@@ -413,7 +413,7 @@ def test_browse_consignment(client: FlaskClient):
     file = files[0]
     consignment_id = file.file_consignments.ConsignmentId
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     response = client.get(f"/browse?consignment_id={consignment_id}")
 
@@ -460,7 +460,7 @@ def test_browse_consignment_with_missing_file_metadata(client: FlaskClient):
     file = files[10]
     consignment_id = file.file_consignments.ConsignmentId
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     response = client.get(f"/browse?consignment_id={consignment_id}")
 
@@ -511,7 +511,7 @@ def test_browse_consignment_filter_display_multiple_pages(
 
     create_multiple_files_for_consignment(consignment_id)
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     response = client.get(f"/browse?page=2&consignment_id={consignment_id}")
     assert response.status_code == 200

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -1,16 +1,9 @@
-import uuid
-from unittest.mock import patch
-
 import pytest
 import werkzeug
-from flask.testing import FlaskClient
-from sqlalchemy import exc
 
 from app.main.authorize.permissions_helpers import (
-    get_user_accessible_transferring_bodies,
     validate_body_user_groups_or_404,
 )
-from app.main.db.models import Body, db
 from app.tests.conftest import mock_standard_user, mock_superuser
 from app.tests.factories import BodyFactory
 
@@ -25,7 +18,7 @@ def test_does_not_raise_404_for_body_name_user_has_access_to_and_is_in_database(
     Then the function should not raise a 404 exception
     """
     BodyFactory(Name="foo")
-    mock_standard_user(client, "foo")
+    mock_standard_user(client, ["foo"])
 
     validate_body_user_groups_or_404("foo")
 
@@ -40,7 +33,7 @@ def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
     Then the function should raise a 404 exception
     """
     BodyFactory(Name="foo")
-    mock_standard_user(client, "bar")
+    mock_standard_user(client, ["bar"])
 
     with pytest.raises(werkzeug.exceptions.NotFound):
         validate_body_user_groups_or_404("foo")
@@ -56,7 +49,7 @@ def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
     Then the function should raise a 404 exception
     """
     BodyFactory(Name="bar")
-    mock_standard_user(client, "foo")
+    mock_standard_user(client, ["foo"])
 
     with pytest.raises(werkzeug.exceptions.NotFound):
         validate_body_user_groups_or_404("foo")
@@ -73,100 +66,3 @@ def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_fo
     mock_superuser(client)
 
     validate_body_user_groups_or_404("foo")
-
-
-class TestGetUserAccessibleTransferringBodies:
-    def test_no_groups_returns_empty_list(
-        self,
-    ):
-        """
-        Given an empty list,
-        When calling get_user_accessible_transferring_bodies with it
-        Then it should return an empty list
-        """
-        results = get_user_accessible_transferring_bodies([])
-        assert results == []
-
-    def test_no_transferring_bodies_returns_empty_list(
-        self,
-    ):
-        """
-        Given a list of groups not containing any /transferring_body_user/ groups
-        When I call get_user_accessible_transferring_bodies with it
-        Then it should return an empty list
-        """
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/something_else/test body1",
-                "/something_else/test body2",
-                "/ayr_user_type/bar",
-            ]
-        )
-        assert results == []
-
-    def test_transferring_bodies_in_groups_returns_corresponding_body_names(
-        self, client: FlaskClient
-    ):
-        """
-        Given a list of groups including 2 prefixed with
-            /transferring_body_user/
-            and another group
-            and 2 corresponding bodies in the database
-            and an extra body in the database
-        When get_user_accessible_transferring_bodies is called with it
-        Then it should return a list with the 2 corresponding body names
-        """
-        body_1 = Body(
-            BodyId=uuid.uuid4(), Name="test body1", Description="test body1"
-        )
-        db.session.add(body_1)
-        db.session.commit()
-
-        body_2 = Body(
-            BodyId=uuid.uuid4(), Name="test body2", Description="test body2"
-        )
-        db.session.add(body_2)
-        db.session.commit()
-
-        body_3 = Body(
-            BodyId=uuid.uuid4(), Name="test body3", Description="test body3"
-        )
-        db.session.add(body_3)
-        db.session.commit()
-
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/transferring_body_user/test body1",
-                "/transferring_body_user/test body2",
-                "/foo/bar",
-            ]
-        )
-        assert results == ["test body1", "test body2"]
-
-    @patch("app.main.authorize.permissions_helpers.db")
-    def test_db_raised_exception_returns_empty_list_and_log_message(
-        self, database, capsys, client
-    ):
-        """
-        Given a db execution error
-        When get_user_accessible_transferring_bodies is called
-        Then it should return an empty list and an error message is logged
-        """
-
-        def mock_execute(_):
-            raise exc.SQLAlchemyError("foo bar")
-
-        database.session.execute.side_effect = mock_execute
-
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/transferring_body_user/test body1",
-                "/transferring_body_user/test body2",
-                "/ayr_user_type/bar",
-            ]
-        )
-        assert results == []
-        assert (
-            "Failed to return results from database with error : foo bar"
-            in capsys.readouterr().out
-        )

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -32,7 +32,7 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
         FileType="file",
     )
 
-    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
+    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
 
     metadata = {
         "date_last_modified": "2023-02-25T10:12:47",
@@ -219,7 +219,7 @@ def test_raises_404_for_user_without_access_to_files_transferring_body(client):
         for property_name, value in metadata.items()
     ]
 
-    mock_standard_user(client, "different_body")
+    mock_standard_user(client, ["different_body"])
 
     response = client.get(f"/record/{file.FileId}")
 


### PR DESCRIPTION
## JIRA ticket

Another prep PR for https://national-archives.atlassian.net/browse/AYR-574.

## Reason for this PR

This groups together all our keycloak user group logic into a new AYRUser class. This will help us maintain any changes to user group structure and assumptions we make between our keycloak implementation and the webapp.

In preparation of PRs for top level browse and search filtering by standard user's transferring body groups

## Changes in this PR
- Created AYRUser class
- Refactored business logic that depends on keycloak group logic
