### PR TITLE
Fix mock user fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,35 @@ python -m pytest --cov=app --cov-report=term-missing --cov-branch -vvv
 
 This also will generate a test coverage report.
 
+#### Mocking user permissions in tests
+
+We have 2 fixtures used for mocking a user and their permissions in our non end to end, flask tests:
+
+- `mock_standard_user`
+- `mock_superuser`
+
+which can be called like
+
+`mock_standard_user(client, ["foo", "bar"])`
+
+`mock_superuser(client)`
+
+respectively.
+
+These mock the `get_user_groups` permissions helper which abstracts away the external api call to keycloak, which we do not want to call in our non end to end tests.
+
+- `mock_standard_user` gives the user and results in an AYRUser where:
+  - `can_access_ayr`: True
+  - `is_standard_user`: True
+  - `is_superuser`: False
+  - `transferring_bodies`: same list as pass in as second arg to mock_standard_user
+
+- `mock_standard_user` gives the user and results in an AYRUser where:
+  - `can_access_ayr`: True
+  - `is_standard_user`: False
+  - `is_superuser`: True
+  - `transferring_bodies`: None
+
 ### End To End Tests
 
 We have a separate End To End suite of [Playwright](https://playwright.dev/python/docs/intro) tests in the `e2e_tests/` directory. These are also written in python and use the `pytest-playwright` `PyPi` package to run the tests as specified in the poetry dependencies.

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -10,25 +10,39 @@ from app.main.db.models import db
 from configs.testing_config import TestingConfig
 
 
-def mock_standard_user(client: FlaskClient, bodies: List[str]):
-    with client.session_transaction() as session:
-        session["access_token"] = "valid_token"
-
-    groups = [f"/transferring_body_user/{body}" for body in bodies]
-    groups.append("/ayr_user_type/view_dept")
-
+@pytest.fixture(scope="function")
+def mock_standard_user():
     patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
     mock_get_user_groups = patcher.start()
-    mock_get_user_groups.return_value = groups
+
+    def _mock_standard_user(client: FlaskClient, bodies: List[str]):
+        with client.session_transaction() as session:
+            session["access_token"] = "valid_token"
+
+        groups = [f"/transferring_body_user/{body}" for body in bodies]
+        groups.append("/ayr_user_type/view_dept")
+
+        mock_get_user_groups.return_value = groups
+
+    yield _mock_standard_user
+
+    patcher.stop()
 
 
-def mock_superuser(client: FlaskClient):
-    with client.session_transaction() as session:
-        session["access_token"] = "valid_token"
-
+@pytest.fixture(scope="function")
+def mock_superuser():
     patcher = patch("app.main.authorize.permissions_helpers.get_user_groups")
     mock_get_user_groups = patcher.start()
-    mock_get_user_groups.return_value = ["/ayr_user_type/view_all"]
+
+    def _mock_superuser(client: FlaskClient):
+        with client.session_transaction() as session:
+            session["access_token"] = "valid_token"
+
+        mock_get_user_groups.return_value = ["/ayr_user_type/view_all"]
+
+    yield _mock_superuser
+
+    patcher.stop()
 
 
 @pytest.fixture

--- a/app/tests/test_ayr_user.py
+++ b/app/tests/test_ayr_user.py
@@ -4,7 +4,6 @@ from app.main.authorize.ayr_user import (
     AYRUser,
     get_user_accessible_transferring_bodies,
 )
-from app.tests.conftest import mock_standard_user
 from app.tests.factories import BodyFactory
 
 
@@ -30,7 +29,9 @@ class TestAYRUser:
         assert not user.is_superuser
         assert not user.is_standard_user
 
-    def test_when_transferring_body_user_prefix_in_groups(self, client):
+    def test_when_transferring_body_user_prefix_in_groups(
+        self, client, mock_standard_user
+    ):
         BodyFactory(Name="foo")
         BodyFactory(Name="bar")
         mock_standard_user(client, ["foo", "bar"])

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -1,7 +1,6 @@
 from bs4 import BeautifulSoup
 from flask.testing import FlaskClient
 
-from app.tests.conftest import mock_standard_user
 from app.tests.mock_database import (
     create_multiple_files_for_consignment,
     create_multiple_test_records,
@@ -307,7 +306,7 @@ def test_browse_display_multiple_pages(client: FlaskClient, app):
     assert next_option.text.replace("\n", "").strip("") == "Nextpage"
 
 
-def test_browse_transferring_body(client: FlaskClient):
+def test_browse_transferring_body(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request with a transferring body id
@@ -355,7 +354,7 @@ def test_browse_transferring_body(client: FlaskClient):
     assert [row_data] == expected_results_table[1]
 
 
-def test_browse_series(client: FlaskClient):
+def test_browse_series(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request with a series id
@@ -403,7 +402,7 @@ def test_browse_series(client: FlaskClient):
     assert [row_data] == expected_results_table[1]
 
 
-def test_browse_consignment(client: FlaskClient):
+def test_browse_consignment(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request with a consignment id
@@ -448,7 +447,9 @@ def test_browse_consignment(client: FlaskClient):
         ] == expected_results_table[index + 1]
 
 
-def test_browse_consignment_with_missing_file_metadata(client: FlaskClient):
+def test_browse_consignment_with_missing_file_metadata(
+    client: FlaskClient, mock_standard_user
+):
     """
     Given a user accessing the browse page
     When they make a GET request with a consignment id
@@ -496,7 +497,7 @@ def test_browse_consignment_with_missing_file_metadata(client: FlaskClient):
 
 
 def test_browse_consignment_filter_display_multiple_pages(
-    client: FlaskClient, app
+    client: FlaskClient, app, mock_standard_user
 ):
     """
     Given a user accessing the browse page

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -4,12 +4,11 @@ import werkzeug
 from app.main.authorize.permissions_helpers import (
     validate_body_user_groups_or_404,
 )
-from app.tests.conftest import mock_standard_user, mock_superuser
 from app.tests.factories import BodyFactory
 
 
 def test_does_not_raise_404_for_body_name_user_has_access_to_and_is_in_database(
-    client,
+    client, mock_standard_user
 ):
     """
     Given a Body with name 'foo' in the database
@@ -24,7 +23,7 @@ def test_does_not_raise_404_for_body_name_user_has_access_to_and_is_in_database(
 
 
 def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
-    client,
+    client, mock_standard_user
 ):
     """
     Given a Body with name 'foo' in the database
@@ -40,7 +39,7 @@ def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
 
 
 def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
-    client,
+    client, mock_standard_user
 ):
     """
     Given a standard user with access to the body 'foo'
@@ -56,7 +55,7 @@ def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
 
 
 def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_for_superuser(
-    client,
+    client, mock_superuser
 ):
     """
     Given a superuser

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -328,11 +328,13 @@ class TestBrowseData:
         assert result.has_prev is True
 
     def test_browse_data_with_transferring_body_filter(
-        self, client: FlaskClient
+        self, client: FlaskClient, mock_standard_user
     ):
         """
         Given multiple File objects in the database and a transferring_body_id
             that matches only one of them
+        And the session contains user info for a standard user with access to the
+            transferring body
         When browse_data is called with transferring_body_id
         Then it returns a list containing 1 dictionary for the matching record with
             expected fields
@@ -340,6 +342,10 @@ class TestBrowseData:
         files = create_multiple_test_records()
 
         file = files[0]
+
+        mock_standard_user(
+            client, [file.file_consignments.consignment_bodies.Name]
+        )
 
         transferring_body_id = file.file_consignments.consignment_bodies.BodyId
         series_id = file.file_consignments.consignment_series.SeriesId
@@ -359,10 +365,14 @@ class TestBrowseData:
             )
         ]
 
-    def test_browse_data_with_series_filter(self, client: FlaskClient):
+    def test_browse_data_with_series_filter(
+        self, client: FlaskClient, mock_standard_user
+    ):
         """
         Given multiple File objects in the database and a series_id
             that matches only one of them
+        And the session contains user info for a standard user with access to the series'
+            associated transferring body
         When browse_data is called with series_id
         Then it returns a list containing 1 dictionary for the matching record with
             expected fields
@@ -370,6 +380,10 @@ class TestBrowseData:
         files = create_multiple_test_records()
 
         file = files[0]
+
+        mock_standard_user(
+            client, [file.file_consignments.consignment_bodies.Name]
+        )
 
         transferring_body_id = file.file_consignments.consignment_bodies.BodyId
         series_id = file.file_consignments.consignment_series.SeriesId
@@ -390,17 +404,23 @@ class TestBrowseData:
             )
         ]
 
-    def test_browse_data_with_consignment_filter(self, app):
+    def test_browse_data_with_consignment_filter(
+        self, client, mock_standard_user
+    ):
         """
         Given three file objects with associated metadata part of 1 consignment,
             where 2 file types is 'file', another file 'folder', and another file of
             type 'file' and metadata associated with a different consignment
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
         When I call the 'browse_data' function with the consignment id
             of the first 3 file objects
         Then it returns a Pagination object with 2 total results corresponding to the
             first 2 files, ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
+
+        mock_standard_user(client, [consignment.consignment_bodies.Name])
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -475,11 +495,15 @@ class TestBrowseData:
 
         assert results == expected_results
 
-    def test_browse_data_with_consignment_and_date_from_filter(self, app):
+    def test_browse_data_with_consignment_and_date_from_filter(
+        self, client, mock_standard_user
+    ):
         """
         Given three file objects with associated metadata part of 1 consignment,
             where 2 file types is 'file', another file 'folder', and another file of
             type 'file' and metadata associated with a different consignment
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
         When I call the 'browse_data' function with the consignment id and date_from filter
             of the first 3 file objects
         Then it returns a Pagination object with 2 total results corresponding to the
@@ -487,6 +511,8 @@ class TestBrowseData:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
+
+        mock_standard_user(client, [consignment.consignment_bodies.Name])
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -568,11 +594,15 @@ class TestBrowseData:
 
         assert results == expected_results
 
-    def test_browse_data_with_consignment_and_date_to_filter(self, app):
+    def test_browse_data_with_consignment_and_date_to_filter(
+        self, client, mock_standard_user
+    ):
         """
         Given three file objects with associated metadata part of 1 consignment,
             where 2 file types is 'file', another file 'folder', and another file of
             type 'file' and metadata associated with a different consignment
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
         When I call the 'browse_data' function with the consignment id and date_to filter
             of the first 3 file objects
         Then it returns a Pagination object with 1 total results corresponding to the
@@ -580,6 +610,8 @@ class TestBrowseData:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
+
+        mock_standard_user(client, [consignment.consignment_bodies.Name])
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -654,12 +686,14 @@ class TestBrowseData:
         assert results == expected_results
 
     def test_browse_data_with_consignment_and_date_from_and_to_filter(
-        self, app
+        self, client, mock_standard_user
     ):
         """
         Given three file objects with associated metadata part of 1 consignment,
             where 2 file types is 'file', another file 'folder', and another file of
             type 'file' and metadata associated with a different consignment
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
         When I call the 'browse_data' function with the consignment id and date_from and date_to filter
             of the first 3 file objects
         Then it returns a Pagination object with 2 total results corresponding to the
@@ -668,6 +702,8 @@ class TestBrowseData:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
+
+        mock_standard_user(client, [consignment.consignment_bodies.Name])
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -1,5 +1,4 @@
 from app.tests.assertions import assert_contains_html
-from app.tests.conftest import mock_standard_user, mock_superuser
 from app.tests.factories import FileFactory, FileMetadataFactory
 
 
@@ -16,7 +15,7 @@ def test_invalid_id_raises_404(client):
 
 
 def test_returns_record_page_for_user_with_access_to_files_transferring_body(
-    client,
+    client, mock_standard_user
 ):
     """
     Given a File in the database
@@ -186,7 +185,9 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
     )
 
 
-def test_raises_404_for_user_without_access_to_files_transferring_body(client):
+def test_raises_404_for_user_without_access_to_files_transferring_body(
+    client, mock_standard_user
+):
     """
     Given a File in the database
     When a standard user without access to the file's consignment body makes a
@@ -226,7 +227,7 @@ def test_raises_404_for_user_without_access_to_files_transferring_body(client):
     assert response.status_code == 404
 
 
-def test_returns_record_page_for_superuser(client):
+def test_returns_record_page_for_superuser(client, mock_superuser):
     """
     Given a File in the database
     And a superuser


### PR DESCRIPTION
We noticed that there were some tests that were showing up as PASSING when running together in CI but which were in fact broken when run individually.

After investigating we noticed this was due to bugs in the helper functions `mock_standard_user` and `mock_superuser`.

## Changes in this PR

- Changed `mock_standard_user` and `mock_superuser` to fixtures and fixed them so when running mutliple tests that use them at once, the permissions mocking doesn't persist across tests unintentionally.
- Fixed the tests that were showing up as PASSING when running together in CI before fixing the above but which were in fact broken when run individually
- Added info about `mock_standard_user` and `mock_superuser` to README

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574