### PR TITLE
Create AYRUser.from_access_token static method to concentrate calls to keycloak

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -3,7 +3,6 @@ from functools import wraps
 from flask import current_app, flash, g, redirect, session, url_for
 
 from app.main.authorize.ayr_user import AYRUser
-from app.main.authorize.keycloak_manager import get_user_groups
 
 
 def access_token_sign_in_required(view_func):
@@ -45,15 +44,12 @@ def access_token_sign_in_required(view_func):
             ):
                 return view_func(*args, **kwargs)
 
-            access_token = session.get("access_token")
+            ayr_user = AYRUser.from_access_token(session.get("access_token"))
 
-            groups = get_user_groups(access_token)
-
-            if not groups:
+            if not ayr_user.groups:
                 session.clear()
                 return redirect(url_for("main.sign_in"))
 
-            ayr_user = AYRUser(groups)
             if not ayr_user.can_access_ayr:
                 flash(
                     "TNA User is logged in but does not have access to AYR. Please contact your admin."

--- a/app/main/authorize/ayr_user.py
+++ b/app/main/authorize/ayr_user.py
@@ -1,6 +1,7 @@
 from typing import List
 
 from app.main.authorize.keycloak_manager import (
+    get_user_groups,
     get_user_transferring_body_keycloak_groups,
 )
 from app.main.db.models import Body
@@ -9,6 +10,10 @@ from app.main.db.models import Body
 class AYRUser:
     def __init__(self, groups: List[str]) -> None:
         self.groups = groups
+
+    @staticmethod
+    def from_access_token(access_token):
+        return AYRUser(get_user_groups(access_token))
 
     @property
     def can_access_ayr(self):

--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -1,7 +1,6 @@
 from flask import abort, session
 
 from app.main.authorize.ayr_user import AYRUser
-from app.main.authorize.keycloak_manager import get_user_groups
 
 
 def validate_body_user_groups_or_404(
@@ -17,7 +16,7 @@ def validate_body_user_groups_or_404(
     Raises:
         werkzeug.exceptions.NotFound: If the user does not have access to the specified transferring body.
     """
-    ayr_user = AYRUser(get_user_groups(session.get("access_token")))
+    ayr_user = AYRUser.from_access_token(session.get("access_token"))
 
     if ayr_user.is_superuser:
         return


### PR DESCRIPTION
## Changes in this PR

- Create AYRUser.from_access_token static method to concentrate calls to keycloak

There will be a followup PR which removes `FORCE_AUTHENTICATION_FOR_IN_TESTING` from test config where we will add mock_standard_user or mock_superuser to all route tests that require authentication, rather than skipping auth on any of theirs. This PR makes it so we only need to mock one thing rather than 2 in that followup and is a wortwhile refactor in itself to move towards concentrating all calls to keycloak to one place to help decouple the app.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574