### PR TITLE
Removed FORCE_AUTHENTICATION_FOR_IN_TESTING

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -1,6 +1,6 @@
 from functools import wraps
 
-from flask import current_app, flash, g, redirect, session, url_for
+from flask import flash, g, redirect, session, url_for
 
 from app.main.authorize.ayr_user import AYRUser
 
@@ -25,9 +25,6 @@ def access_token_sign_in_required(view_func):
     Configuration options for Keycloak, such as the client ID, realm name, base URI, and client secret,
     are expected to be set in the Flask application configuration.
 
-    When the application is running in testing mode and the 'FORCE_AUTHENTICATION_FOR_IN_TESTING' config
-    option is not set, the decorator allows unauthenticated access to facilitate testing.
-
     Example:
         @app.route('/protected')
         @access_token_sign_in_required
@@ -39,11 +36,6 @@ def access_token_sign_in_required(view_func):
     def decorated_view(*args, **kwargs):
         g.access_token_sign_in_required = True  # Set attribute on g
         try:
-            if current_app.config["TESTING"] and not current_app.config.get(
-                "FORCE_AUTHENTICATION_FOR_IN_TESTING"
-            ):
-                return view_func(*args, **kwargs)
-
             ayr_user = AYRUser.from_access_token(session.get("access_token"))
 
             if not ayr_user.groups:

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -16,7 +16,7 @@ def mock_standard_user():
     patcher = patch("app.main.authorize.ayr_user.AYRUser.from_access_token")
 
     def _mock_standard_user(
-        client: FlaskClient, bodies: List[str] = ["test_bodies_1"]
+        client: FlaskClient, bodies: List[str] = ["test_body"]
     ):
         mock_ayr_user_from_access_token = patcher.start()
         with client.session_transaction() as session:

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -13,7 +13,6 @@ def test_access_token_sign_in_required_decorator_no_token(app):
     When accessing a route protected by the 'access_token_sign_in_required' decorator,
     Then it should redirect to the sign in view.
     """
-    app.config["FORCE_AUTHENTICATION_FOR_IN_TESTING"] = True
     view_name = "/protected_view"
     with app.test_client() as client:
 
@@ -46,7 +45,6 @@ def test_access_token_sign_in_required_decorator_inactive_token(
     mock_ayr_user.can_access_ayr = False
     mock_ayr_user_from_access_token.return_value = mock_ayr_user
 
-    app.config["FORCE_AUTHENTICATION_FOR_IN_TESTING"] = True
     view_name = "/protected_view"
     with app.test_client() as client:
 
@@ -123,8 +121,6 @@ def test_access_token_sign_in_required_decorator_valid_token(
     When accessing a route protected by the 'access_token_sign_in_required' decorator,
     Then it should grant access
     """
-    app.config["FORCE_AUTHENTICATION_FOR_IN_TESTING"] = True
-
     view_name = "/protected_view"
     with app.test_client() as client:
 
@@ -239,7 +235,9 @@ def test_get_expected_routes_separated_by_protection():
     assert set(unprotected_routes) == {"static", "unprotected_view"}
 
 
-def test_sign_out_button_on_protected_view_that_uses_base_template(app):
+def test_sign_out_button_on_protected_view_that_uses_base_template(
+    app, mock_standard_user
+):
     """
     Given a view that is protected by the 'access_token_sign_in_required' decorator,
         and renders the `base.html` template
@@ -256,6 +254,7 @@ def test_sign_out_button_on_protected_view_that_uses_base_template(app):
         )
 
     with app.test_client() as client:
+        mock_standard_user(client)
         response = client.get(view_name)
 
     assert response.status_code == 200

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -7,12 +7,13 @@ from app.tests.mock_database import (
 )
 
 
-def test_browse_get(client: FlaskClient):
+def test_browse_get(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request
     Then they should see the browse page content.
     """
+    mock_standard_user(client)
 
     response = client.get("/browse")
 
@@ -22,12 +23,13 @@ def test_browse_get(client: FlaskClient):
     assert b"Everything available to you" in response.data
 
 
-def test_browse_submit_search_query(client: FlaskClient):
+def test_browse_submit_search_query(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a POST request
     Then they should see results in content.
     """
+    mock_standard_user(client)
     create_multiple_test_records()
 
     query = "test"
@@ -38,12 +40,13 @@ def test_browse_submit_search_query(client: FlaskClient):
     assert b"Records found 11" in response.data
 
 
-def test_browse_get_with_data(client: FlaskClient):
+def test_browse_get_with_data(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request with page as a query string parameter
     Then they should see first five records on browse page content.
     """
+    mock_standard_user(client)
     create_multiple_test_records()
 
     response = client.get("/browse")
@@ -86,13 +89,16 @@ def test_browse_get_with_data(client: FlaskClient):
     assert [row_data] == expected_results_table[1]
 
 
-def test_browse_display_first_page(client: FlaskClient, app):
+def test_browse_display_first_page(
+    client: FlaskClient, app, mock_standard_user
+):
     """
     Given a user accessing the browse page
     When they make a GET request with page as a query string parameter
     Then they should see first page with five records on browse page content
     (excluding previous and incl. next page option).
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
 
@@ -141,12 +147,15 @@ def test_browse_display_first_page(client: FlaskClient, app):
     assert next_option.text.replace("\n", "").strip("") == "Nextpage"
 
 
-def test_browse_display_middle_page(client: FlaskClient, app):
+def test_browse_display_middle_page(
+    client: FlaskClient, app, mock_standard_user
+):
     """
     Given a user accessing the browse page
     When they make a GET request with page as a query string parameter
     Then they should see first page with five records on browse page content (incl. previous and next page options).
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
 
@@ -199,13 +208,14 @@ def test_browse_display_middle_page(client: FlaskClient, app):
     )
 
 
-def test_browse_display_last_page(client: FlaskClient, app):
+def test_browse_display_last_page(client: FlaskClient, app, mock_standard_user):
     """
     Given a user accessing the browse page
     When they make a GET request with page as a query string parameter
     Then they should see last page with n records on browse page content
     (incl. previous and excluding next page option).
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
 
@@ -251,12 +261,15 @@ def test_browse_display_last_page(client: FlaskClient, app):
     assert not next_option
 
 
-def test_browse_display_multiple_pages(client: FlaskClient, app):
+def test_browse_display_multiple_pages(
+    client: FlaskClient, app, mock_standard_user
+):
     """
     Given a user accessing the browse page
     When they make a GET request with page as a query string parameter
     Then they should see first page with five records on browse page content (incl. previous and next page options).
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
 

--- a/app/tests/test_logout.py
+++ b/app/tests/test_logout.py
@@ -4,7 +4,7 @@ from flask import url_for
 
 
 @patch("app.main.routes.keycloak.KeycloakOpenID")
-def test_sign_out(mock_keycloak_openid, client):
+def test_sign_out(mock_keycloak_openid, client, mock_standard_user):
     """
     Given a session with `refresh_token` set, and a mocked KeycloakOpenID instance,
     When a request with this session is made to the 'main.sign_out' route,
@@ -13,6 +13,7 @@ def test_sign_out(mock_keycloak_openid, client):
         and the session should be cleared
     """
     with client.session_transaction() as session:
+        mock_standard_user(client)
         session["refresh_token"] = "mock_refresh_token"
 
     response = client.get(url_for("main.sign_out"))

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -48,7 +48,7 @@ def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
     Then the function should raise a 404 exception
     """
     BodyFactory(Name="bar")
-    mock_standard_user(client, ["foo"])
+    mock_standard_user(client, ["foo"], get_or_create_body=False)
 
     with pytest.raises(werkzeug.exceptions.NotFound):
         validate_body_user_groups_or_404("foo")

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -4,13 +4,13 @@ from flask.testing import FlaskClient
 from app.tests.mock_database import create_multiple_test_records
 
 
-def test_search_get(client: FlaskClient):
+def test_search_get(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the search page
     When they make a GET request
     Then they should see the search form and page content.
     """
-
+    mock_standard_user(client)
     response = client.get("/poc-search")
 
     assert response.status_code == 200
@@ -19,12 +19,13 @@ def test_search_get(client: FlaskClient):
     assert b"Search" in response.data
 
 
-def test_search_no_query(client: FlaskClient):
+def test_search_no_query(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the search page
     When they make a POST request without a query
     Then they should not see any records found.
     """
+    mock_standard_user(client)
     form_data = {"foo": "bar"}
     response = client.post("/poc-search", data=form_data)
 
@@ -32,12 +33,13 @@ def test_search_no_query(client: FlaskClient):
     assert b"records found" not in response.data
 
 
-def test_search_with_no_results(client: FlaskClient):
+def test_search_with_no_results(client: FlaskClient, mock_standard_user):
     """
     Given a user with a search query
     When they make a request on the search page, and no results are found
     Then they should see no records found.
     """
+    mock_standard_user(client)
     create_multiple_test_records()
 
     form_data = {"query": "junk"}
@@ -47,12 +49,15 @@ def test_search_with_no_results(client: FlaskClient):
     assert b"0 record(s) found"
 
 
-def test_search_results_displayed_single_page(client: FlaskClient, app):
+def test_search_results_displayed_single_page(
+    client: FlaskClient, app, mock_standard_user
+):
     """
     Given a user with a search query which should return n results
     When they make a request on the search page
     Then a table is populated with the n results with metadata fields.
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
     form_data = {"query": "test body"}
@@ -93,12 +98,15 @@ def test_search_results_displayed_single_page(client: FlaskClient, app):
     )
 
 
-def test_search_results_displayed_multiple_pages(client: FlaskClient, app):
+def test_search_results_displayed_multiple_pages(
+    client: FlaskClient, app, mock_standard_user
+):
     """
     Given a user with a search query which should return n results
     When they make a request on the search page
     Then a table is populated with the n results with metadata fields.
     """
+    mock_standard_user(client)
     create_multiple_test_records()
     app.config["DEFAULT_PAGE_SIZE"] = 5
     form_data = {"query": "testing body"}


### PR DESCRIPTION
## Changes in this PR

- Removed FORCE_AUTHENTICATION_FOR_IN_TESTING use mock_standard_user where necessary, adjusting _mock_standard_user to have default bodies list so dont need to specify when we dont care about db details.

Reason for this is now we have  mock_standard_user and mock_superuser fixtures which should be used in all route tests, i.e those that utilise the flask `client` 

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574