### PR TITLE
Users can only have one body associated

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ We have 2 fixtures used for mocking a user and their permissions in our non end 
 
 which can be called like
 
-`mock_standard_user(client, ["foo", "bar"])`
+`mock_standard_user(client, "foo")`
 
 `mock_superuser(client)`
 

--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -21,5 +21,5 @@ def validate_body_user_groups_or_404(
     if ayr_user.is_superuser:
         return
 
-    if transferring_body_name not in ayr_user.transferring_bodies:
+    if transferring_body_name != ayr_user.transferring_body.Name:
         abort(404)

--- a/app/tests/test_ayr_user.py
+++ b/app/tests/test_ayr_user.py
@@ -1,104 +1,97 @@
-from flask.testing import FlaskClient
-
-from app.main.authorize.ayr_user import (
-    AYRUser,
-    get_user_accessible_transferring_bodies,
-)
+from app.main.authorize.ayr_user import AYRUser
 from app.tests.factories import BodyFactory
 
 
 class TestAYRUser:
-    def test_properties_when_ayr_user_type_view_dept_group(self):
+    def test_type_of_user_when_ayr_user_type_view_dept_group(self):
         groups = ["/ayr_user_type/view_dept"]
         user = AYRUser(groups)
-        assert user.can_access_ayr
         assert user.is_standard_user
         assert not user.is_superuser
 
-    def test_properties_when_ayr_user_type_view_all_group(self):
+    def test_type_of_user_when_ayr_user_type_view_all_group(self):
         groups = ["/ayr_user_type/view_all"]
         user = AYRUser(groups)
-        assert user.can_access_ayr
         assert user.is_superuser
         assert not user.is_standard_user
 
-    def test_properties_when_no_valid_ayr_user_group(self):
+    def test_type_of_user_when_no_valid_ayr_user_group(self):
         groups = ["/ayr_user_type/foo"]
         user = AYRUser(groups)
-        assert not user.can_access_ayr
         assert not user.is_superuser
         assert not user.is_standard_user
 
-    def test_when_transferring_body_user_prefix_in_groups(
-        self, client, mock_standard_user
-    ):
+    def test_can_access_ayr_when_superuser_and_no_bodies(self):
+        groups = ["/ayr_user_type/view_all"]
+        user = AYRUser(groups)
+        assert user.is_superuser
+        assert user.transferring_body is None
+        assert user.can_access_ayr
+
+    def test_can_access_ayr_when_standard_user_and_one_valid_body(self, app):
+        body = BodyFactory(Name="foo")
+        groups = ["/ayr_user_type/view_dept", "/transferring_body_user/foo"]
+        user = AYRUser(groups)
+        assert user.is_standard_user
+        assert user.transferring_body == body
+        assert user.can_access_ayr
+
+    def test_cannot_access_ayr_when_superuser_and_some_bodies(self, app):
+        groups = ["/ayr_user_type/view_all", "/transferring_body_user/foo"]
+        user = AYRUser(groups)
+        assert user.is_superuser
+        assert user.transferring_body is None
+        assert user.can_access_ayr
+
+    def test_transferring_body_is_none_when_empty_groups(self, app):
         BodyFactory(Name="foo")
         BodyFactory(Name="bar")
-        mock_standard_user(client, ["foo", "bar"])
+        groups = []
+        user = AYRUser(groups)
+        assert user.transferring_body is None
+
+    def test_transferring_body_is_first_valid_transferring_body_in_groups(
+        self, app
+    ):
+        body = BodyFactory(Name="foo")
+        BodyFactory(Name="bar")
         groups = [
             "/ayr_user_type/view_dept",
             "/transferring_body_user/foo",
             "/transferring_body_user/bar",
         ]
         user = AYRUser(groups)
-        assert user.transferring_bodies == ["foo", "bar"]
+        assert user.transferring_body == body
 
-    def test_when_superuser_transferring_bodies_is_none(self):
+    def test_transferring_body_is_none_when_no_valid_transferring_body_in_groups(
+        self, app
+    ):
+        groups = [
+            "/ayr_user_type/view_dept",
+            "/transferring_body_user/foo",
+            "/transferring_body_user/bar",
+        ]
+        user = AYRUser(groups)
+        assert user.transferring_body is None
+
+    def test_when_superuser_transferring_bodies_is_none(self, client):
         groups = ["/ayr_user_type/view_all", "/transferring_body_user/foo"]
         user = AYRUser(groups)
-        assert user.transferring_bodies is None
-
-
-class TestGetUserAccessibleTransferringBodies:
-    def test_no_groups_returns_empty_list(
-        self,
-    ):
-        """
-        Given an empty list,
-        When calling get_user_accessible_transferring_bodies with it
-        Then it should return an empty list
-        """
-        results = get_user_accessible_transferring_bodies([])
-        assert results == []
+        assert user.transferring_body is None
 
     def test_no_transferring_bodies_returns_empty_list(
         self,
     ):
         """
         Given a list of groups not containing any /transferring_body_user/ groups
-        When I call get_user_accessible_transferring_bodies with it
+        When I call get_user_accessible_transferring_body with it
         Then it should return an empty list
         """
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/something_else/test body1",
-                "/something_else/test body2",
-                "/ayr_user_type/bar",
-            ]
-        )
-        assert results == []
+        groups = [
+            "/something_else/test body1",
+            "/something_else/test body2",
+            "/ayr_user_type/bar",
+        ]
 
-    def test_transferring_bodies_in_groups_returns_corresponding_body_names(
-        self, client: FlaskClient
-    ):
-        """
-        Given a list of groups including 2 prefixed with
-            /transferring_body_user/
-            and another group
-            and 2 corresponding bodies in the database
-            and an extra body in the database
-        When get_user_accessible_transferring_bodies is called with it
-        Then it should return a list with the 2 corresponding body names
-        """
-        BodyFactory(Name="test body1")
-        BodyFactory(Name="test body2")
-        BodyFactory(Name="test body3")
-
-        results = get_user_accessible_transferring_bodies(
-            [
-                "/transferring_body_user/test body1",
-                "/transferring_body_user/test body2",
-                "/foo/bar",
-            ]
-        )
-        assert results == ["test body1", "test body2"]
+        user = AYRUser(groups)
+        assert user.transferring_body is None

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -329,7 +329,7 @@ def test_browse_transferring_body(client: FlaskClient, mock_standard_user):
     file = files[0]
     transferring_body_id = file.file_consignments.consignment_bodies.BodyId
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(
         f"/browse?transferring_body_id={transferring_body_id}"
@@ -377,7 +377,7 @@ def test_browse_series(client: FlaskClient, mock_standard_user):
     file = files[0]
     series_id = file.file_consignments.SeriesId
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?series_id={series_id}")
 
@@ -425,7 +425,7 @@ def test_browse_consignment(client: FlaskClient, mock_standard_user):
     file = files[0]
     consignment_id = file.file_consignments.ConsignmentId
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?consignment_id={consignment_id}")
 
@@ -474,7 +474,7 @@ def test_browse_consignment_with_missing_file_metadata(
     file = files[10]
     consignment_id = file.file_consignments.ConsignmentId
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?consignment_id={consignment_id}")
 
@@ -525,7 +525,7 @@ def test_browse_consignment_filter_display_multiple_pages(
 
     create_multiple_files_for_consignment(consignment_id)
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     response = client.get(f"/browse?page=2&consignment_id={consignment_id}")
     assert response.status_code == 200

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -86,7 +86,7 @@ def test_downloads_record_successfully_for_user_with_access_to_files_transferrin
     create_mock_s3_bucket_with_object()
     app.config["RECORD_BUCKET_NAME"] = BUCKET
     file = mock_record()
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
     response = client.get(f"/download/{file.FileId}")
 
     assert response.status_code == 200

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -17,7 +17,7 @@ def test_does_not_raise_404_for_body_name_user_has_access_to_and_is_in_database(
     Then the function should not raise a 404 exception
     """
     BodyFactory(Name="foo")
-    mock_standard_user(client, ["foo"])
+    mock_standard_user(client, "foo")
 
     validate_body_user_groups_or_404("foo")
 
@@ -32,23 +32,7 @@ def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
     Then the function should raise a 404 exception
     """
     BodyFactory(Name="foo")
-    mock_standard_user(client, ["bar"])
-
-    with pytest.raises(werkzeug.exceptions.NotFound):
-        validate_body_user_groups_or_404("foo")
-
-
-def test_raises_404_for_body_name_user_has_access_to_but_is_not_in_database(
-    client, mock_standard_user
-):
-    """
-    Given a standard user with access to the body 'foo'
-    And no Body with name 'foo' in the database
-    When validate_body_user_groups_or_404 is called with 'foo'
-    Then the function should raise a 404 exception
-    """
-    BodyFactory(Name="bar")
-    mock_standard_user(client, ["foo"], get_or_create_body=False)
+    mock_standard_user(client, "bar")
 
     with pytest.raises(werkzeug.exceptions.NotFound):
         validate_body_user_groups_or_404("foo")

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -549,7 +549,7 @@ class TestBrowseTransferringBody:
         file = files[0]
 
         mock_standard_user(
-            client, [file.file_consignments.consignment_bodies.Name]
+            client, file.file_consignments.consignment_bodies.Name
         )
 
         transferring_body_id = file.file_consignments.consignment_bodies.BodyId
@@ -591,7 +591,7 @@ class TestBrowseSeries:
 
         file = files[0]
         mock_standard_user(
-            client, [file.file_consignments.consignment_bodies.Name]
+            client, file.file_consignments.consignment_bodies.Name
         )
         transferring_body_id = file.file_consignments.consignment_bodies.BodyId
         series_id = file.file_consignments.consignment_series.SeriesId
@@ -632,7 +632,7 @@ class TestBrowseConsignment:
         """
         consignment = ConsignmentFactory()
 
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -726,7 +726,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -818,7 +818,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -910,7 +910,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -1010,7 +1010,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,
@@ -1142,7 +1142,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,
@@ -1267,7 +1267,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,
@@ -1393,7 +1393,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,
@@ -1517,7 +1517,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -1565,9 +1565,6 @@ class TestBrowseConsignment:
 
         FileFactory(FileType="file")
 
-        mock_standard_user(
-            client, [file_1.file_consignments.consignment_bodies.Name]
-        )
         filters = {
             "date_range": {"date_from": "25/02/2023"},
             "date_filter_field": "date_last_modified",
@@ -1621,7 +1618,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -1668,10 +1665,6 @@ class TestBrowseConsignment:
         FileFactory(file_consignments=consignment, FileType="folder")
 
         FileFactory(FileType="file")
-
-        mock_standard_user(
-            client, [file_1.file_consignments.consignment_bodies.Name]
-        )
 
         filters = {
             "date_range": {"date_to": "26/02/2023"},
@@ -1719,7 +1712,7 @@ class TestBrowseConsignment:
             ordered by their names and with the expected metadata values
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -1768,7 +1761,7 @@ class TestBrowseConsignment:
         FileFactory(FileType="file")
 
         mock_standard_user(
-            client, [file_1.file_consignments.consignment_bodies.Name]
+            client, file_1.file_consignments.consignment_bodies.Name
         )
         filters = {
             "date_range": {"date_from": "01/02/2023", "date_to": "28/02/2023"},
@@ -1822,7 +1815,7 @@ class TestBrowseConsignment:
             ordered by their closure_type 'Closed' first and then 'Open' in ascending orders
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -1957,7 +1950,7 @@ class TestBrowseConsignment:
             ordered by their closure_type 'Closed' first and then 'Open' in ascending orders
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -2093,7 +2086,7 @@ class TestBrowseConsignment:
             ordered by their date last modified as oldest first(ascending)
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -2229,7 +2222,7 @@ class TestBrowseConsignment:
             ordered by their date last modified as most recent(descending)
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment, FileName="file_1", FileType="file"
@@ -2364,7 +2357,7 @@ class TestBrowseConsignment:
             ordered by their file name in ascending orders (A to Z)
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,
@@ -2505,7 +2498,7 @@ class TestBrowseConsignment:
             ordered by their file name in descending orders (Z to A)
         """
         consignment = ConsignmentFactory()
-        mock_standard_user(client, [consignment.consignment_bodies.Name])
+        mock_standard_user(client, consignment.consignment_bodies.Name)
 
         file_1 = FileFactory(
             file_consignments=consignment,

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -31,7 +31,7 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
         FileType="file",
     )
 
-    mock_standard_user(client, [file.file_consignments.consignment_bodies.Name])
+    mock_standard_user(client, file.file_consignments.consignment_bodies.Name)
 
     metadata = {
         "date_last_modified": "2023-02-25T10:12:47",
@@ -220,7 +220,7 @@ def test_raises_404_for_user_without_access_to_files_transferring_body(
         for property_name, value in metadata.items()
     ]
 
-    mock_standard_user(client, ["different_body"])
+    mock_standard_user(client, "different_body")
 
     response = client.get(f"/record/{file.FileId}")
 


### PR DESCRIPTION
## Changes in this PR

- Adjusted AYRUser from having `transferring_bodies` to `transferring_body`, taking the first body if the user has multiple bodies specified. We will have a ticket addressing validity of a user where we can enforce that a user should only ever have one, but need to think about how we want to enforce that.

- Updated mock_standard_user fixture to reflect the above also.

- Updated tests appropriately

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574