### PR TITLE
Filter search route for standard users by their transferring body

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -25,7 +25,7 @@ from app.main.authorize.ayr_user import AYRUser
 from app.main.authorize.permissions_helpers import (
     validate_body_user_groups_or_404,
 )
-from app.main.db.models import File
+from app.main.db.models import Body, File
 from app.main.db.queries import (
     browse_data,
     build_fuzzy_search_query,
@@ -185,6 +185,11 @@ def search():
 
     if query:
         fuzzy_search_query = build_fuzzy_search_query(query)
+        ayr_user = AYRUser.from_access_token(session.get("access_token"))
+        if ayr_user.is_standard_user:
+            fuzzy_search_query = fuzzy_search_query.where(
+                Body.Name == ayr_user.transferring_body.Name
+            )
         search_results = fuzzy_search_query.paginate(
             page=page, per_page=per_page
         )


### PR DESCRIPTION
## Changes in this PR

- Filter search route for standard users by their transferring body

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-574

## Screenshots of UI changes

### Before
<img width="826" alt="Screenshot 2024-01-16 at 15 42 45" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/024067b9-2db6-4471-8a34-c8a065ac702e">


### After

<img width="936" alt="Screenshot 2024-01-16 at 15 42 25" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/16b8e41a-e1ec-4593-8b9f-04357ce4d45b">


