### PR TITLE
browse view all (top level) sorting functionality

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -142,7 +142,7 @@ def _build_browse_everything_query(filters, sorting_orders):
             query = query.filter(date_filter)
 
     if sorting_orders:
-        query = _build_browse_sorting_orders(query, sub_query, sorting_orders)
+        query = _build_sorting_orders(query, sub_query, sorting_orders)
     else:
         query = query.order_by(
             sub_query.c.transferring_body, sub_query.c.series
@@ -207,33 +207,6 @@ def _build_series_view_query(series_id):
         .order_by(Body.Name, Series.Name)
     )
 
-    return query
-
-
-def _build_browse_sorting_orders(query, sub_query, sorting_orders):
-    for field, order in sorting_orders.items():
-        column = getattr(sub_query.c, field, None)
-        if column is not None:
-            query = (
-                query.order_by(desc(column))
-                if order == "desc"
-                else query.order_by(column)
-            )
-    return query
-
-
-def _old_build_browse_sorting_orders(query, sorting_orders):
-    fields = []
-    for col in query.column_descriptions:
-        fields.append(col["name"])
-
-    for field, order in sorting_orders.items():
-        if field in fields:
-            query = (
-                query.order_by(desc(field))
-                if order == "desc"
-                else query.order_by(field)
-            )
     return query
 
 
@@ -315,9 +288,7 @@ def _build_consignment_view_query(
     if filters:
         query = _build_consignment_filters(query, sub_query, filters)
     if sorting_orders:
-        query = _build_consignment_sorting_orders(
-            query, sub_query, sorting_orders
-        )
+        query = _build_sorting_orders(query, sub_query, sorting_orders)
 
     return query
 
@@ -355,7 +326,7 @@ def _build_consignment_filters(query, sub_query, filters):
     return query
 
 
-def _build_consignment_sorting_orders(query, sub_query, sorting_orders):
+def _build_sorting_orders(query, sub_query, sorting_orders):
     for field, order in sorting_orders.items():
         column = getattr(sub_query.c, field, None)
         if column is not None:

--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -23,13 +23,11 @@ def browse_data(
     if browse_type == "transferring_body":
         body = Body.query.get_or_404(transferring_body_id)
         validate_body_user_groups_or_404(body.Name)
-        browse_query = _build_transferring_body_view_query(
-            transferring_body_id, filters
-        )
+        browse_query = _build_transferring_body_view_query(transferring_body_id)
     elif browse_type == "series":
         series = Series.query.get_or_404(series_id)
         validate_body_user_groups_or_404(series.body.Name)
-        browse_query = _build_series_view_query(series_id, filters)
+        browse_query = _build_series_view_query(series_id)
     elif browse_type == "consignment":
         consignment = Consignment.query.get_or_404(consignment_id)
         validate_body_user_groups_or_404(consignment.series.body.Name)
@@ -153,7 +151,7 @@ def _build_browse_everything_query(filters, sorting_orders):
     return query
 
 
-def _build_transferring_body_view_query(transferring_body_id, filters):
+def _build_transferring_body_view_query(transferring_body_id):
     query = (
         db.session.query(
             Body.BodyId.label("transferring_body_id"),
@@ -180,21 +178,10 @@ def _build_transferring_body_view_query(transferring_body_id, filters):
         .order_by(Body.Name, Series.Name)
     )
 
-    if filters:
-        if "date_range" in filters:
-            dt_range = validate_date_range(filters["date_range"])
-
-            date_filter = _build_date_range_filter(
-                Consignment.TransferCompleteDatetime,
-                dt_range["date_from"],
-                dt_range["date_to"],
-            )
-            query = query.filter(date_filter)
-
     return query
 
 
-def _build_series_view_query(series_id, filters):
+def _build_series_view_query(series_id):
     query = (
         db.session.query(
             Body.BodyId.label("transferring_body_id"),
@@ -219,17 +206,6 @@ def _build_series_view_query(series_id, filters):
         .group_by(Body.BodyId, Series.SeriesId, Consignment.ConsignmentId)
         .order_by(Body.Name, Series.Name)
     )
-
-    if filters:
-        if "date_range" in filters:
-            dt_range = validate_date_range(filters["date_range"])
-
-            date_filter = _build_date_range_filter(
-                Consignment.TransferCompleteDatetime,
-                dt_range["date_from"],
-                dt_range["date_to"],
-            )
-            query = query.filter(date_filter)
 
     return query
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -119,7 +119,6 @@ def browse():
     filters = {}
     sorting_orders = {}
 
-    # if browse_type == "browse":
     # e.g. please usd example below to pass sorting order for browse all (top level)
     # sorting_orders["transferring_body"] = "asc"  # A to Z
     # sorting_orders["transferring_body"] = "desc"  # Z to A

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -119,6 +119,15 @@ def browse():
     filters = {}
     sorting_orders = {}
 
+    # if browse_type == "browse":
+    # e.g. please usd example below to pass sorting order for browse all (top level)
+    # sorting_orders["transferring_body"] = "asc"  # A to Z
+    # sorting_orders["transferring_body"] = "desc"  # Z to A
+    # sorting_orders["series"] = "asc"  # A to Z
+    # sorting_orders["series"] = "desc"  # Z to A
+    # sorting_orders["last_record_transferred"] = "asc"  # oldest first
+    # sorting_orders["last_record_transferred"] = "desc"  # most recent first
+
     if transferring_body_id:
         browse_type = "transferring_body"
         browse_parameters["transferring_body_id"] = transferring_body_id

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -136,6 +136,7 @@ def browse():
     elif consignment_id:
         browse_type = "consignment"
         browse_parameters["consignment_id"] = consignment_id
+
         # e.g. please use example below to pass filter values
         # filters["record_status"] = "open"
         # filters["file_type"] = "docx"

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -119,6 +119,7 @@ def browse():
     filters = {}
     sorting_orders = {}
 
+    # if browse_type == "browse":
     # e.g. please usd example below to pass sorting order for browse all (top level)
     # sorting_orders["transferring_body"] = "asc"  # A to Z
     # sorting_orders["transferring_body"] = "desc"  # Z to A

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -7,7 +7,12 @@ from testing.postgresql import PostgresqlFactory
 from app import create_app
 from app.main.authorize.ayr_user import AYRUser
 from app.main.db.models import Body, db
-from app.tests.factories import BodyFactory
+from app.tests.factories import (
+    BodyFactory,
+    ConsignmentFactory,
+    FileFactory,
+    SeriesFactory,
+)
 from configs.testing_config import TestingConfig
 
 
@@ -79,3 +84,350 @@ def database(request):
     @request.addfinalizer
     def drop_database():
         postgresql.stop()
+
+
+@pytest.fixture(scope="function")
+def browse_files():
+    """
+
+    purpose of this function to return file objects to perform testing on
+      combination of single and multiple filters
+      and single sorting
+
+    returns 28 file objects associated with consignments
+
+    there are 6 bodies defined as Transferring bodies,
+
+    there are 6 series defined as Series (linked directly to one transferring body)
+
+    there are 12 consignment objects (1 to 12) associated with transferring body and series
+      consignment_1 and consignment_2 associated to body_1 and series_1
+      consignment_3 and consignment_4 associated to body_2 and series_2
+      consignment_5 and consignment_6 associated to body_3 and series_3
+      consignment_7 and consignment_8 associated to body_4 and series_4
+      consignment_9 and consignment_10 associated to body_5 and series_5
+      consignment_11 associated to body_6 and series_6
+
+      each consignment has a unique ConsignmentReference to support filter
+      each consignment has a unique TransferCompleteDatetime to support date filters
+
+    there are 28 file objects (1 to 28) associated with consignments
+      file_1 associated to consignment_1
+      file_2 and file_3 associated to consignment_2
+      file_4 , file_5 and file_6 associated to consignment_3
+      file_7 , file_8, file_9 and file_10 associated to consignment_4
+      file_11 associated to consignment_5
+      file_12 and file_3 associated to consignment_6
+      file_14 , file_15 and file_16 associated to consignment_7
+      file_17 , file_18 and file_19 associated to consignment_8
+      file_20 and file_21 associated to consignment_9
+      file_22 , file_23, file_24 and file_25 associated to consignment_10
+      file_26 and file_27 associated to consignment_11
+    """
+
+    body_1 = BodyFactory(Name="first_body", Description="first_body")
+    body_2 = BodyFactory(Name="second_body", Description="second_body")
+    body_3 = BodyFactory(Name="third_body", Description="third_body")
+    body_4 = BodyFactory(Name="fourth_body", Description="fourth_body")
+    body_5 = BodyFactory(Name="fifth_body", Description="fifth_body")
+    body_6 = BodyFactory(Name="sixth_body", Description="sixth_body")
+
+    series_1 = SeriesFactory(
+        Name="first_series", Description="first_series", body=body_1
+    )
+    series_2 = SeriesFactory(
+        Name="second_series", Description="second_series", body=body_2
+    )
+    series_3 = SeriesFactory(
+        Name="third_series", Description="third_series", body=body_3
+    )
+    series_4 = SeriesFactory(
+        Name="fourth_series", Description="fourth_series", body=body_4
+    )
+    series_5 = SeriesFactory(
+        Name="fifth_series", Description="fifth_series", body=body_5
+    )
+
+    series_6 = SeriesFactory(
+        Name="sixth_series", Description="sixth_series", body=body_6
+    )
+
+    consignment_1 = ConsignmentFactory(
+        series=series_1,
+        ConsignmentReference="TDR-2023-FI1",
+        TransferCompleteDatetime="2023-01-13",
+    )
+    consignment_2 = ConsignmentFactory(
+        series=series_1,
+        ConsignmentReference="TDR-2023-SE2",
+        TransferCompleteDatetime="2023-02-7",
+    )
+
+    consignment_3 = ConsignmentFactory(
+        series=series_2,
+        ConsignmentReference="TDR-2023-TH3",
+        TransferCompleteDatetime="2023-03-15",
+    )
+    consignment_4 = ConsignmentFactory(
+        series=series_2,
+        ConsignmentReference="TDR-2023-FO4",
+        TransferCompleteDatetime="2023-04-26",
+    )
+
+    consignment_5 = ConsignmentFactory(
+        series=series_3,
+        ConsignmentReference="TDR-2023-FI5",
+        TransferCompleteDatetime="2023-05-10",
+    )
+    consignment_6 = ConsignmentFactory(
+        series=series_3,
+        ConsignmentReference="TDR-2023-SI6",
+        TransferCompleteDatetime="2023-06-17",
+    )
+
+    consignment_7 = ConsignmentFactory(
+        series=series_4,
+        ConsignmentReference="TDR-2023-SE7",
+        TransferCompleteDatetime="2023-07-21",
+    )
+    consignment_8 = ConsignmentFactory(
+        series=series_4,
+        ConsignmentReference="TDR-2023-EI8",
+        TransferCompleteDatetime="2023-08-3",
+    )
+
+    consignment_9 = ConsignmentFactory(
+        series=series_5,
+        ConsignmentReference="TDR-2023-NI9",
+        TransferCompleteDatetime="2023-09-21",
+    )
+    consignment_10 = ConsignmentFactory(
+        series=series_5,
+        ConsignmentReference="TDR-2023-TE10",
+        TransferCompleteDatetime="2023-09-21",
+    )
+
+    consignment_11 = ConsignmentFactory(
+        series=series_6,
+        ConsignmentReference="TDR-2023-EL11",
+        TransferCompleteDatetime="2023-10-14",
+    )
+
+    file_1 = FileFactory(
+        consignment=consignment_1,
+        FileType="File",
+        FileName="first_file.txt",
+        FilePath="/data/first_file.txt",
+    )
+
+    file_2 = FileFactory(
+        consignment=consignment_2,
+        FileType="File",
+        FileName="second_file.pdf",
+        FilePath="/data/second_file.pdf",
+    )
+
+    file_3 = FileFactory(
+        consignment=consignment_2,
+        FileType="File",
+        FileName="third_file.doc",
+        FilePath="/data/third_file.doc",
+    )
+
+    file_4 = FileFactory(
+        consignment=consignment_3,
+        FileType="File",
+        FileName="fourth_file.docx",
+        FilePath="/data/fourth_file.docx",
+    )
+
+    file_5 = FileFactory(
+        consignment=consignment_3,
+        FileType="File",
+        FileName="fifth_file.docx",
+        FilePath="/data/fifth_file.docx",
+    )
+
+    file_6 = FileFactory(
+        consignment=consignment_3,
+        FileType="File",
+        FileName="sixth_file.ppt",
+        FilePath="/data/sixth_file.ppt",
+    )
+
+    file_7 = FileFactory(
+        consignment=consignment_4,
+        FileType="File",
+        FileName="seventh_file.xls",
+        FilePath="/data/seventh_file.xls",
+    )
+
+    file_8 = FileFactory(
+        consignment=consignment_4,
+        FileType="File",
+        FileName="eighth_file.pdf",
+        FilePath="/data/seventh_file.pdf",
+    )
+
+    file_9 = FileFactory(
+        consignment=consignment_4,
+        FileType="File",
+        FileName="ninth_file.txt",
+        FilePath="/data/ninth_file.txt",
+    )
+
+    file_10 = FileFactory(
+        consignment=consignment_4,
+        FileType="File",
+        FileName="tenth_file.ppt",
+        FilePath="/data/tenth_file.ppt",
+    )
+
+    file_11 = FileFactory(
+        consignment=consignment_5,
+        FileType="File",
+        FileName="eleventh_file.zip",
+        FilePath="/data/eleventh_file.zip",
+    )
+
+    file_12 = FileFactory(
+        consignment=consignment_6,
+        FileType="File",
+        FileName="twelfth_file.ppt",
+        FilePath="/data/twelfth_file.ppt",
+    )
+
+    file_13 = FileFactory(
+        consignment=consignment_6,
+        FileType="File",
+        FileName="thirteenth_file.docx",
+        FilePath="/data/thirteenth_file.docx",
+    )
+
+    file_14 = FileFactory(
+        consignment=consignment_7,
+        FileType="File",
+        FileName="fourteenth_file.ppt",
+        FilePath="/data/fourteenth_file.ppt",
+    )
+
+    file_15 = FileFactory(
+        consignment=consignment_7,
+        FileType="File",
+        FileName="fifteenth_file.png",
+        FilePath="/data/fifteenth_file.png",
+    )
+
+    file_16 = FileFactory(
+        consignment=consignment_7,
+        FileType="File",
+        FileName="sixteenth_file.gif",
+        FilePath="/data/sixteenth_file.gif",
+    )
+
+    file_17 = FileFactory(
+        consignment=consignment_8,
+        FileType="File",
+        FileName="seventeenth_file.pdf",
+        FilePath="/data/seventeenth_file.pdf",
+    )
+
+    file_18 = FileFactory(
+        consignment=consignment_8,
+        FileType="File",
+        FileName="eighteenth_file.xls",
+        FilePath="/data/eighteenth_file.xls",
+    )
+
+    file_19 = FileFactory(
+        consignment=consignment_8,
+        FileType="File",
+        FileName="nineteenth_file.ppt",
+        FilePath="/data/nineteenth_file.ppt",
+    )
+
+    file_20 = FileFactory(
+        consignment=consignment_9,
+        FileType="File",
+        FileName="twentieth_file.tiff",
+        FilePath="/data/twentieth_file.tiff",
+    )
+
+    file_21 = FileFactory(
+        consignment=consignment_9,
+        FileType="File",
+        FileName="twenty-first.ppt",
+        FilePath="/data/twenty-first.ppt",
+    )
+
+    file_22 = FileFactory(
+        consignment=consignment_10,
+        FileType="File",
+        FileName="twenty-second.doc",
+        FilePath="/data/twenty-second.doc",
+    )
+
+    file_23 = FileFactory(
+        consignment=consignment_10,
+        FileType="File",
+        FileName="twenty-third.docx",
+        FilePath="/data/twenty-third.docx",
+    )
+
+    file_24 = FileFactory(
+        consignment=consignment_10,
+        FileType="File",
+        FileName="twenty-fourth.docx",
+        FilePath="/data/twenty-fourth.docx",
+    )
+
+    file_25 = FileFactory(
+        consignment=consignment_10,
+        FileType="File",
+        FileName="twenty-fifth.xls",
+        FilePath="/data/twenty-fifth.xls",
+    )
+
+    file_26 = FileFactory(
+        consignment=consignment_11,
+        FileType="File",
+        FileName="twenty-sixth.docx",
+        FilePath="/data/twenty-sixth.docx",
+    )
+
+    file_27 = FileFactory(
+        consignment=consignment_11,
+        FileType="File",
+        FileName="twenty-seventh.xls",
+        FilePath="/data/twenty-seventh.xls",
+    )
+
+    return [
+        file_1,
+        file_2,
+        file_3,
+        file_4,
+        file_5,
+        file_6,
+        file_7,
+        file_8,
+        file_9,
+        file_10,
+        file_11,
+        file_12,
+        file_13,
+        file_14,
+        file_15,
+        file_16,
+        file_17,
+        file_18,
+        file_19,
+        file_20,
+        file_21,
+        file_22,
+        file_23,
+        file_24,
+        file_25,
+        file_26,
+        file_27,
+    ]

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -584,6 +584,462 @@ class TestBrowse:
 
         assert result.items == []
 
+    def test_browse_with_transferring_body_sorting_a_to_z(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'transferring body' ascending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by transferring body name alphabetically in ascending order (A to Z)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"transferring_body": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[19].consignment.series.body.BodyId,
+                browse_files[19].consignment.series.body.Name,
+                browse_files[19].consignment.series.SeriesId,
+                browse_files[19].consignment.series.Name,
+                "21/09/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
+                2,
+                7,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_with_transferring_body_sorting_z_to_a(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'transferring body' descending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by transferring body name alphabetically in descending order (Z to A)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"transferring_body": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[10].consignment.series.body.BodyId,
+                browse_files[10].consignment.series.body.Name,
+                browse_files[10].consignment.series.SeriesId,
+                browse_files[10].consignment.series.Name,
+                "17/06/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
+                2,
+                7,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_with_series_sorting_a_to_z(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'series' ascending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by series name alphabetically in ascending order (A to Z)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"series": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[19].consignment.series.body.BodyId,
+                browse_files[19].consignment.series.body.Name,
+                browse_files[19].consignment.series.SeriesId,
+                browse_files[19].consignment.series.Name,
+                "21/09/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
+                2,
+                7,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_with_series_sorting_z_to_a(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'series' descending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by series name alphabetically in descending order (Z to A)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"series": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[10].consignment.series.body.BodyId,
+                browse_files[10].consignment.series.body.Name,
+                browse_files[10].consignment.series.SeriesId,
+                browse_files[10].consignment.series.Name,
+                "17/06/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
+                2,
+                7,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_with_date_last_transferred_sorting_oldest_first(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'date last transferred' ascending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by consignment transfer complete date in ascending order (oldest first)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"last_record_transferred": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_files[10].consignment.series.body.BodyId,
+                browse_files[10].consignment.series.body.Name,
+                browse_files[10].consignment.series.SeriesId,
+                browse_files[10].consignment.series.Name,
+                "17/06/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[19].consignment.series.body.BodyId,
+                browse_files[19].consignment.series.body.Name,
+                browse_files[19].consignment.series.SeriesId,
+                browse_files[19].consignment.series.Name,
+                "21/09/2023",
+                2,
+                6,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_with_date_last_transferred_sorting_most_recent_first(
+        self, client: FlaskClient, mock_standard_user, browse_files
+    ):
+        """
+        Given 27 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'browse' and
+            sort by 'date last transferred' descending
+        Then it returns a Paginate object returning the first 5 items
+            ordered by consignment transfer complete date in descending order (most recent first)
+        """
+
+        mock_standard_user(client, browse_files[0].consignment.series.body.Name)
+        sorting_orders = {"last_record_transferred": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="browse",
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 6
+
+        expected_results = [
+            (
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
+                2,
+                7,
+            ),
+            (
+                browse_files[19].consignment.series.body.BodyId,
+                browse_files[19].consignment.series.body.Name,
+                browse_files[19].consignment.series.SeriesId,
+                browse_files[19].consignment.series.Name,
+                "21/09/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[10].consignment.series.body.BodyId,
+                browse_files[10].consignment.series.body.Name,
+                browse_files[10].consignment.series.SeriesId,
+                browse_files[10].consignment.series.Name,
+                "17/06/2023",
+                2,
+                3,
+            ),
+            (
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_files[0].consignment.series.body.BodyId,
+                browse_files[0].consignment.series.body.Name,
+                browse_files[0].consignment.series.SeriesId,
+                browse_files[0].consignment.series.Name,
+                "07/02/2023",
+                2,
+                3,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
 
 class TestBrowseTransferringBody:
     def test_browse_transferring_body_with_transferring_body_filter(

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -914,15 +914,6 @@ class TestBrowse:
 
         expected_results = [
             (
-                browse_files[13].consignment.series.body.BodyId,
-                browse_files[13].consignment.series.body.Name,
-                browse_files[13].consignment.series.SeriesId,
-                browse_files[13].consignment.series.Name,
-                "03/08/2023",
-                2,
-                6,
-            ),
-            (
                 browse_files[0].consignment.series.body.BodyId,
                 browse_files[0].consignment.series.body.Name,
                 browse_files[0].consignment.series.SeriesId,
@@ -932,13 +923,13 @@ class TestBrowse:
                 3,
             ),
             (
-                browse_files[25].consignment.series.body.BodyId,
-                browse_files[25].consignment.series.body.Name,
-                browse_files[25].consignment.series.SeriesId,
-                browse_files[25].consignment.series.Name,
-                "14/10/2023",
-                1,
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
                 2,
+                7,
             ),
             (
                 browse_files[10].consignment.series.body.BodyId,
@@ -948,6 +939,15 @@ class TestBrowse:
                 "17/06/2023",
                 2,
                 3,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
+                2,
+                6,
             ),
             (
                 browse_files[19].consignment.series.body.BodyId,
@@ -990,13 +990,13 @@ class TestBrowse:
 
         expected_results = [
             (
-                browse_files[3].consignment.series.body.BodyId,
-                browse_files[3].consignment.series.body.Name,
-                browse_files[3].consignment.series.SeriesId,
-                browse_files[3].consignment.series.Name,
-                "26/04/2023",
+                browse_files[25].consignment.series.body.BodyId,
+                browse_files[25].consignment.series.body.Name,
+                browse_files[25].consignment.series.SeriesId,
+                browse_files[25].consignment.series.Name,
+                "14/10/2023",
+                1,
                 2,
-                7,
             ),
             (
                 browse_files[19].consignment.series.body.BodyId,
@@ -1004,6 +1004,15 @@ class TestBrowse:
                 browse_files[19].consignment.series.SeriesId,
                 browse_files[19].consignment.series.Name,
                 "21/09/2023",
+                2,
+                6,
+            ),
+            (
+                browse_files[13].consignment.series.body.BodyId,
+                browse_files[13].consignment.series.body.Name,
+                browse_files[13].consignment.series.SeriesId,
+                browse_files[13].consignment.series.Name,
+                "03/08/2023",
                 2,
                 6,
             ),
@@ -1017,22 +1026,13 @@ class TestBrowse:
                 3,
             ),
             (
-                browse_files[25].consignment.series.body.BodyId,
-                browse_files[25].consignment.series.body.Name,
-                browse_files[25].consignment.series.SeriesId,
-                browse_files[25].consignment.series.Name,
-                "14/10/2023",
-                1,
+                browse_files[3].consignment.series.body.BodyId,
+                browse_files[3].consignment.series.body.Name,
+                browse_files[3].consignment.series.SeriesId,
+                browse_files[3].consignment.series.Name,
+                "26/04/2023",
                 2,
-            ),
-            (
-                browse_files[0].consignment.series.body.BodyId,
-                browse_files[0].consignment.series.body.Name,
-                browse_files[0].consignment.series.SeriesId,
-                browse_files[0].consignment.series.Name,
-                "07/02/2023",
-                2,
-                3,
+                7,
             ),
         ]
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

1. added a new pytest fixture to create browse file records for testing in conftest.py, 
2. modified browse_data query to accommodate sorting orders, added a new function _build_browse_sorting_orders in queries.py, 
3. modified /browse route to put example sorting order details in routes.py, 
4. created new test cases for browse sorting in test_queries.py


## JIRA ticket

AYR-598

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
