### PR TITLE
get_file_metadata doesnt error when a file has no associated file met…

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -411,7 +411,9 @@ def _get_file_metadata_query(file_id: uuid.UUID):
     ]
 
     query = (
-        query.join(File, FileMetadata.FileId == File.FileId)
+        query.join(
+            FileMetadata, File.FileId == FileMetadata.FileId, isouter=True
+        )
         .join(Consignment, File.ConsignmentId == Consignment.ConsignmentId)
         .join(
             Series,

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -1,11 +1,7 @@
 import boto3
 from moto import mock_s3
 
-from app.tests.factories import (
-    ConsignmentFactory,
-    FileFactory,
-    FileMetadataFactory,
-)
+from app.tests.factories import ConsignmentFactory, FileFactory
 
 BUCKET = "test-download"
 CONSIGNMENT_REF = "TDR-123-TEST"
@@ -24,25 +20,6 @@ def mock_record():
         FilePath=FILE_PATH,
         FileType="file",
     )
-
-    metadata = {
-        "date_last_modified": "2023-02-25T10:12:47",
-        "closure_type": "Closed",
-        "description": "Test description",
-        "held_by": "Test holder",
-        "legal_status": "Test legal status",
-        "rights_copyright": "Test copyright",
-        "language": "English",
-    }
-
-    [
-        FileMetadataFactory(
-            file=file,
-            PropertyName=property_name,
-            Value=value,
-        )
-        for property_name, value in metadata.items()
-    ]
 
     return file
 

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -2734,3 +2734,37 @@ class TestGetFileMetadata:
             "series": file.consignment.series.Name,
             "series_id": file.consignment.series.SeriesId,
         }
+
+    def test_valid_uuid_returns_none_for_any_metadata(
+        self, client: FlaskClient
+    ):
+        """
+        Given a file with no associatedf file metadata,
+        When get_file_metadata is called with its UUID,
+        Then a dict of metadata for the file is returned
+            and all the file metadata fields are None
+        """
+        file = FileFactory(
+            FileName="test_file.txt",
+            FilePath="data/content/test_file.txt",
+            FileType="file",
+        )
+
+        assert get_file_metadata(file_id=file.FileId) == {
+            "file_id": file.FileId,
+            "file_name": "test_file.txt",
+            "file_path": "data/content/test_file.txt",
+            "status": None,
+            "description": None,
+            "date_last_modified": None,
+            "held_by": None,
+            "legal_status": None,
+            "rights_copyright": None,
+            "language": None,
+            "consignment": file.consignment.ConsignmentReference,
+            "consignment_id": file.ConsignmentId,
+            "transferring_body": file.consignment.series.body.Name,
+            "transferring_body_id": file.consignment.series.body.BodyId,
+            "series": file.consignment.series.Name,
+            "series_id": file.consignment.series.SeriesId,
+        }


### PR DESCRIPTION
## Changes in this PR

Fixed bug where record page returned 404 for records without any associated file metadata objects.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-637

## Screenshots of UI changes

### Before
![Screenshot 2024-01-17 at 15 38 11](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/c24df755-d679-4860-9ecc-7a9aec225183)


### After
![Screenshot 2024-01-17 at 15 37 49](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/42998618/f2fbfcf7-d3f9-4bd6-9d01-c2e856790ed9)
