### PR TITLE
browse transferring body view sorting

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -23,7 +23,9 @@ def browse_data(
     if browse_type == "transferring_body":
         body = Body.query.get_or_404(transferring_body_id)
         validate_body_user_groups_or_404(body.Name)
-        browse_query = _build_transferring_body_view_query(transferring_body_id)
+        browse_query = _build_transferring_body_view_query(
+            transferring_body_id, filters, sorting_orders
+        )
     elif browse_type == "series":
         series = Series.query.get_or_404(series_id)
         validate_body_user_groups_or_404(series.body.Name)
@@ -151,17 +153,18 @@ def _build_browse_everything_query(filters, sorting_orders):
     return query
 
 
-def _build_transferring_body_view_query(transferring_body_id):
-    query = (
+def _build_transferring_body_view_query(
+    transferring_body_id, filters, sorting_orders
+):
+    sub_query = (
         db.session.query(
             Body.BodyId.label("transferring_body_id"),
             Body.Name.label("transferring_body"),
             Series.SeriesId.label("series_id"),
             Series.Name.label("series"),
-            func.to_char(
-                func.cast(func.max(Consignment.TransferCompleteDatetime), DATE),
-                current_app.config["DEFAULT_DATE_FORMAT"],
-            ).label("last_record_transferred"),
+            func.max(Consignment.TransferCompleteDatetime).label(
+                "last_record_transferred"
+            ),
             func.count(func.distinct(Consignment.ConsignmentReference)).label(
                 "consignment_in_series"
             ),
@@ -175,8 +178,27 @@ def _build_transferring_body_view_query(transferring_body_id):
             & (Body.BodyId == transferring_body_id)
         )
         .group_by(Body.BodyId, Series.SeriesId)
-        .order_by(Body.Name, Series.Name)
+    ).subquery()
+
+    query = db.session.query(
+        sub_query.c.transferring_body_id,
+        sub_query.c.transferring_body,
+        sub_query.c.series_id,
+        sub_query.c.series,
+        func.to_char(
+            sub_query.c.last_record_transferred,
+            current_app.config["DEFAULT_DATE_FORMAT"],
+        ).label("last_record_transferred"),
+        sub_query.c.consignment_in_series,
+        sub_query.c.records_held,
     )
+
+    if sorting_orders:
+        query = _build_sorting_orders(query, sub_query, sorting_orders)
+    else:
+        query = query.order_by(
+            sub_query.c.transferring_body, sub_query.c.series
+        )
 
     return query
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -130,6 +130,13 @@ def browse():
     if transferring_body_id:
         browse_type = "transferring_body"
         browse_parameters["transferring_body_id"] = transferring_body_id
+        # sorting_orders["series"] = "asc"  # A to Z
+        # sorting_orders["series"] = "desc"  # Z to A
+        # sorting_orders["last_record_transferred"] = "asc"  # oldest first
+        # sorting_orders["last_record_transferred"] = "desc"  # most recent first
+        # sorting_orders["records_held"] = "asc"  # least first
+        # sorting_orders["records_held"] = "desc"  # most first
+
     elif series_id:
         browse_type = "series"
         browse_parameters["series_id"] = series_id

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -501,7 +501,7 @@ def browse_transferring_body_files():
     )
 
     file_2 = FileFactory(
-        consignment=consignment_1,
+        consignment=consignment_2,
         FileType="File",
         FileName="second_file.xls",
         FilePath="/data/second_file.xls",
@@ -515,7 +515,7 @@ def browse_transferring_body_files():
     )
 
     file_4 = FileFactory(
-        consignment=consignment_2,
+        consignment=consignment_3,
         FileType="File",
         FileName="fourth-file.pdf",
         FilePath="/data/fourth-file.pdf",
@@ -528,10 +528,18 @@ def browse_transferring_body_files():
         FilePath="/data/fifth-file.xls",
     )
 
+    file_6 = FileFactory(
+        consignment=consignment_3,
+        FileType="File",
+        FileName="sixth-file.xls",
+        FilePath="/data/sixth-file.xls",
+    )
+
     return [
         file_1,
         file_2,
         file_3,
         file_4,
         file_5,
+        file_6,
     ]

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -431,3 +431,107 @@ def browse_files():
         file_26,
         file_27,
     ]
+
+
+@pytest.fixture(scope="function")
+def browse_transferring_body_files():
+    """
+
+    purpose of this function to return file objects to perform testing on
+      combination of single and multiple filters
+      and single sorting
+
+    returns 5 file objects associated with consignments
+
+    there is 1 body defined as Transferring bodies,
+
+    there are 3 series defined as Series in one body
+
+    there are 3 consignment objects (1 to 3) associated with transferring body and series
+      consignment_1 associated to body_1 and series_1
+      consignment_2 associated to body_1 and series_2
+      consignment_3 associated to body_1 and series_3
+
+      each consignment has a unique TransferCompleteDatetime to support date filters
+
+    there are 5 file objects (1 to 5) associated with consignments
+
+      file_1 and file_2 associated to consignment_1
+      file_3 and file_4 associated to consignment_2
+      file_5 associated to consignment_3
+    """
+
+    body_1 = BodyFactory(Name="first_body", Description="first_body")
+
+    series_1 = SeriesFactory(
+        Name="first_series", Description="first_series", body=body_1
+    )
+
+    series_2 = SeriesFactory(
+        Name="second_series", Description="second_series", body=body_1
+    )
+
+    series_3 = SeriesFactory(
+        Name="third_series", Description="third_series", body=body_1
+    )
+
+    consignment_1 = ConsignmentFactory(
+        series=series_1,
+        ConsignmentReference="TDR-2023-FI1",
+        TransferCompleteDatetime="2023-10-14",
+    )
+
+    consignment_2 = ConsignmentFactory(
+        series=series_2,
+        ConsignmentReference="TDR-2023-SE2",
+        TransferCompleteDatetime="2023-03-30",
+    )
+
+    consignment_3 = ConsignmentFactory(
+        series=series_3,
+        ConsignmentReference="TDR-2023-TH3",
+        TransferCompleteDatetime="2023-07-07",
+    )
+
+    file_1 = FileFactory(
+        consignment=consignment_1,
+        FileType="File",
+        FileName="first_file.docx",
+        FilePath="/data/first_file.docx",
+    )
+
+    file_2 = FileFactory(
+        consignment=consignment_1,
+        FileType="File",
+        FileName="second_file.xls",
+        FilePath="/data/second_file.xls",
+    )
+
+    file_3 = FileFactory(
+        consignment=consignment_2,
+        FileType="File",
+        FileName="third_file.docx",
+        FilePath="/data/third_file.docx",
+    )
+
+    file_4 = FileFactory(
+        consignment=consignment_2,
+        FileType="File",
+        FileName="fourth-file.pdf",
+        FilePath="/data/fourth-file.pdf",
+    )
+
+    file_5 = FileFactory(
+        consignment=consignment_3,
+        FileType="File",
+        FileName="fifth-file.xls",
+        FilePath="/data/fifth-file.xls",
+    )
+
+    return [
+        file_1,
+        file_2,
+        file_3,
+        file_4,
+        file_5,
+    ]

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -1081,6 +1081,462 @@ class TestBrowseTransferringBody:
             )
         ]
 
+    def test_browse_transferring_body_with_series_sorting_a_to_z(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by 'series' ascending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by series name alphabetically in ascending order (A to Z)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"series": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_transferring_body_with_series_sorting_z_to_a(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by 'series' descending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by series name alphabetically in descending order (Z to A)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"series": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_transferring_body_with_date_last_transferred_sorting_oldest_first(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by 'date last transferred' ascending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by consignment transfer complete date in ascending order (oldest first)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"last_record_transferred": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_transferring_body_with_date_last_transferred_sorting_most_recent_first(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by 'date last transferred' descending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by consignment transfer complete date in descending order (most recent first)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"last_record_transferred": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_transferring_body_with_records_held_sorting_least_first(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by records held in consignment ascending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by records held in consignment count in ascending order (least first)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"records_held": "asc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
+    def test_browse_transferring_body_with_records_held_sorting_most_first(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_transferring_body_files,
+    ):
+        """
+        Given 5 file objects with all file type as 'file'
+        And the session contains user info for a standard user with access to the consignment's
+            associated transferring body
+        When I call the 'browse_data' function with browse_view as 'transferring body' and
+            sort by records held in consignment descending
+        Then it returns a Paginate object returning 3 items
+            for the specific transferring body
+            ordered by records held in consignment count in descending order (most first)
+        """
+
+        mock_standard_user(
+            client,
+            browse_transferring_body_files[0].consignment.series.body.Name,
+        )
+        transferring_body = browse_transferring_body_files[
+            0
+        ].consignment.series.body.BodyId
+
+        sorting_orders = {"records_held": "desc"}
+        pagination_object = browse_data(
+            page=1,
+            per_page=per_page,
+            browse_type="transferring_body",
+            transferring_body_id=transferring_body,
+            sorting_orders=sorting_orders,
+        )
+
+        assert pagination_object.total == 3
+
+        expected_results = [
+            (
+                browse_transferring_body_files[
+                    2
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[2].consignment.series.body.Name,
+                browse_transferring_body_files[2].consignment.series.SeriesId,
+                browse_transferring_body_files[2].consignment.series.Name,
+                "30/03/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    0
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
+                1,
+                2,
+            ),
+            (
+                browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                1,
+            ),
+        ]
+
+        results = pagination_object.items
+
+        assert results == expected_results
+
 
 class TestBrowseSeries:
     def test_browse_series_with_series_filter(

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -1088,7 +1088,7 @@ class TestBrowseTransferringBody:
         browse_transferring_body_files,
     ):
         """
-        Given 5 file objects with all file type as 'file'
+        Given 6 file objects with all file type as 'file'
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with browse_view as 'transferring body' and
@@ -1127,7 +1127,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[0].consignment.series.Name,
                 "14/10/2023",
                 1,
-                2,
+                1,
             ),
             (
                 browse_transferring_body_files[
@@ -1149,7 +1149,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[4].consignment.series.Name,
                 "07/07/2023",
                 1,
-                1,
+                3,
             ),
         ]
 
@@ -1164,7 +1164,7 @@ class TestBrowseTransferringBody:
         browse_transferring_body_files,
     ):
         """
-        Given 5 file objects with all file type as 'file'
+        Given 6 file objects with all file type as 'file'
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with browse_view as 'transferring body' and
@@ -1203,7 +1203,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[4].consignment.series.Name,
                 "07/07/2023",
                 1,
-                1,
+                3,
             ),
             (
                 browse_transferring_body_files[
@@ -1225,7 +1225,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[0].consignment.series.Name,
                 "14/10/2023",
                 1,
-                2,
+                1,
             ),
         ]
 
@@ -1240,7 +1240,7 @@ class TestBrowseTransferringBody:
         browse_transferring_body_files,
     ):
         """
-        Given 5 file objects with all file type as 'file'
+        Given 6 file objects with all file type as 'file'
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with browse_view as 'transferring body' and
@@ -1290,7 +1290,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[4].consignment.series.Name,
                 "07/07/2023",
                 1,
-                1,
+                3,
             ),
             (
                 browse_transferring_body_files[
@@ -1301,7 +1301,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[0].consignment.series.Name,
                 "14/10/2023",
                 1,
-                2,
+                1,
             ),
         ]
 
@@ -1316,7 +1316,7 @@ class TestBrowseTransferringBody:
         browse_transferring_body_files,
     ):
         """
-        Given 5 file objects with all file type as 'file'
+        Given 6 file objects with all file type as 'file'
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with browse_view as 'transferring body' and
@@ -1355,7 +1355,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[0].consignment.series.Name,
                 "14/10/2023",
                 1,
-                2,
+                1,
             ),
             (
                 browse_transferring_body_files[
@@ -1366,7 +1366,7 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[4].consignment.series.Name,
                 "07/07/2023",
                 1,
-                1,
+                3,
             ),
             (
                 browse_transferring_body_files[
@@ -1392,7 +1392,7 @@ class TestBrowseTransferringBody:
         browse_transferring_body_files,
     ):
         """
-        Given 5 file objects with all file type as 'file'
+        Given 6 file objects with all file type as 'file'
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with browse_view as 'transferring body' and
@@ -1424,12 +1424,12 @@ class TestBrowseTransferringBody:
         expected_results = [
             (
                 browse_transferring_body_files[
-                    4
+                    0
                 ].consignment.series.body.BodyId,
-                browse_transferring_body_files[4].consignment.series.body.Name,
-                browse_transferring_body_files[4].consignment.series.SeriesId,
-                browse_transferring_body_files[4].consignment.series.Name,
-                "07/07/2023",
+                browse_transferring_body_files[0].consignment.series.body.Name,
+                browse_transferring_body_files[0].consignment.series.SeriesId,
+                browse_transferring_body_files[0].consignment.series.Name,
+                "14/10/2023",
                 1,
                 1,
             ),
@@ -1446,14 +1446,14 @@ class TestBrowseTransferringBody:
             ),
             (
                 browse_transferring_body_files[
-                    0
+                    4
                 ].consignment.series.body.BodyId,
-                browse_transferring_body_files[0].consignment.series.body.Name,
-                browse_transferring_body_files[0].consignment.series.SeriesId,
-                browse_transferring_body_files[0].consignment.series.Name,
-                "14/10/2023",
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
                 1,
-                2,
+                3,
             ),
         ]
 
@@ -1500,6 +1500,17 @@ class TestBrowseTransferringBody:
         expected_results = [
             (
                 browse_transferring_body_files[
+                    4
+                ].consignment.series.body.BodyId,
+                browse_transferring_body_files[4].consignment.series.body.Name,
+                browse_transferring_body_files[4].consignment.series.SeriesId,
+                browse_transferring_body_files[4].consignment.series.Name,
+                "07/07/2023",
+                1,
+                3,
+            ),
+            (
+                browse_transferring_body_files[
                     2
                 ].consignment.series.body.BodyId,
                 browse_transferring_body_files[2].consignment.series.body.Name,
@@ -1517,17 +1528,6 @@ class TestBrowseTransferringBody:
                 browse_transferring_body_files[0].consignment.series.SeriesId,
                 browse_transferring_body_files[0].consignment.series.Name,
                 "14/10/2023",
-                1,
-                2,
-            ),
-            (
-                browse_transferring_body_files[
-                    4
-                ].consignment.series.body.BodyId,
-                browse_transferring_body_files[4].consignment.series.body.Name,
-                browse_transferring_body_files[4].consignment.series.SeriesId,
-                browse_transferring_body_files[4].consignment.series.Name,
-                "07/07/2023",
                 1,
                 1,
             ),


### PR DESCRIPTION


<!-- Amend as appropriate -->

## Changes in this PR
1. updated logic for browse series view sorting in queries.py,
2. updated example usage in routes.py,
3. added new test cases for sorting for browse series view in test_queries.py , 
4. added a new pytest fixture in conftest.py

## JIRA ticket

AYR- 599

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
