### PR TITLE
split browse.html into four separate views

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,0 +1,392 @@
+{% if view_type == "desktop" %}
+    <!-- SORT -->
+    <div class="govuk-form-group sort-container__form">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END SORT -->
+    <!-- TABLE -->
+    <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+        {% if num_records_found > 0 %}
+            <table class="govuk-table browse-grid__table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col"
+                            class="govuk-table__header browse-grid__key__transferring-body">Transferring body</th>
+                        <th scope="col" class="govuk-table__header">Series</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Last record transferred</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Records held</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignments within series</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for record in results %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">
+                                <a href="{{ url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">{{ record["transferring_body"] }}</a>
+                            </td>
+                            <td class="govuk-table__cell">
+                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
+                            </td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["consignment_in_series"] }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+    <!-- END TABLE -->
+    <!-- FILTERS -->
+    <div class="govuk-grid-column-one-third filters-form">
+        <div class="browse-filter-container">
+            <div class="browse-filter__header">
+                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                     height="32px"
+                     width="32px"
+                     class="browse-filter__icon"
+                     alt="filter-icon">
+            </div>
+            <p class="govuk-body browse__body">Transferring body</p>
+            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                        id="browse_filter_transferring_body"
+                        name="sort">
+                    <option value="all" selected>Choose one...</option>
+                    <option value="arts">Arts Council England</option>
+                    <option value="food_standards_agency">Food Standards Agency</option>
+                    <option value="foreign_office">Foreign Office</option>
+                </select>
+            </div>
+        </div>
+        <div class="filters-form__series__container">
+            <p class="govuk-body browse__body">Series</p>
+            <div class="govuk-form-group filters-form__group filters-form__series-group">
+                <label class="govuk-label" for="browse_filter_series"></label>
+                <input class="govuk-input filters-form__series--input"
+                       id="browse_filter_series"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__consignment-ref__container">
+            <p class="govuk-body browse__body">
+                Consignment <abbr title="reference">ref</abbr>
+            </p>
+            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                <input class="govuk-input filters-form__consignment-ref--input"
+                       id="browse_filter_consignment-ref"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__date__container">
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                    <div class="govuk-date-input" id="date-from">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-day"
+                                       name="date-from-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-month"
+                                       name="date-from-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-from-year"
+                                       name="date-from-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                    <div class="govuk-date-input" id="date-to">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-day"
+                                       name="date-to-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-month"
+                                       name="date-to-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-to-year"
+                                       name="date-to-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="filters-form__buttons">
+                <button type="button"
+                        class="govuk-button govuk-button__filters-form-apply-button"
+                        data-module="govuk-button">Apply filters</button>
+                <button type="button"
+                        class="govuk-button__filters-form-clear-button"
+                        data-module="govuk-button">Clear all filters</button>
+            </div>
+        </div>
+    </div>
+    <!-- END FILTERS -->
+{% else %}
+    <!-- MOBILE FILTERS -->
+    <div class="mobile-filters">
+        <details class="govuk-details">
+            <summary class="govuk-mobile-details__summary">
+                <span class="govuk-mobile-details__summary-text">
+                    Filter within browse
+                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                         height="32px"
+                         width="32px"
+                         class="browse-filter__icon"
+                         alt="filter-icon">
+                </span>
+            </summary>
+            <div class="govuk-details__text govuk-mobile-details_text">
+                <div class="govuk-grid-column-one-third filters-form mobile-filters-form">
+                    <div class="browse-filter-container">
+                        <p class="govuk-body browse__body">Transferring body</p>
+                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                                    id="browse_filter_transferring_body"
+                                    name="sort">
+                                <option value="all" selected>Choose one...</option>
+                                <option value="arts">Arts Council England</option>
+                                <option value="food_standards_agency">Food Standards Agency</option>
+                                <option value="foreign_office">Foreign Office</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="filters-form__series__container">
+                        <p class="govuk-body browse__body">Series</p>
+                        <div class="govuk-form-group filters-form__group filters-form__series-group">
+                            <label class="govuk-label" for="browse_filter_series"></label>
+                            <input class="govuk-input filters-form__series--input"
+                                   id="browse_filter_series"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__consignment-ref__container">
+                        <p class="govuk-body browse__body">
+                            Consignment <abbr title="reference">ref</abbr>
+                        </p>
+                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                            <input class="govuk-input filters-form__consignment-ref--input"
+                                   id="browse_filter_consignment-ref"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__date__container">
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                                <div class="govuk-date-input" id="date-from">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-day"
+                                                   name="date-from-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-month"
+                                                   name="date-from-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-from-year"
+                                                   name="date-from-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                                <div class="govuk-date-input" id="date-to">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-day"
+                                                   name="date-to-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-month"
+                                                   name="date-to-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-to-year"
+                                                   name="date-to-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="filters-form__buttons">
+                            <button type="button"
+                                    class="govuk-button govuk-button__filters-form-apply-button"
+                                    data-module="govuk-button">Apply filters</button>
+                            <button type="button"
+                                    class="govuk-button__filters-form-clear-button"
+                                    data-module="govuk-button">Clear filters</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+    </div>
+    <!-- END MOBILE FILTERS -->
+    <!-- MOBILE SORT -->
+    <div class="govuk-form-group sort-container__form mobile-sort">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END MOBILE SORT -->
+    <!-- MOBILE TABLE -->
+    <table class="govuk-table govuk-mobile-table">
+        <thead class="govuk-table__head govuk-mobile-table__head-border">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for record in results %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row">
+                            <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
+                            }}</a>
+                        </div>
+                        <div>{{ record["last_record_transferred"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row empty-cell">-</div>
+                        <div class="right-align">{{ record["records_held"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row right-align empty-cell">-</div>
+                        <div class="right-align">{{ record["consignment_in_series"] }}</div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <!-- END TABLE -->
+{% endif %}

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -1,0 +1,405 @@
+{% if view_type == "desktop" %}
+    <!-- SORT -->
+    <div class="govuk-form-group sort-container__form">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END SORT -->
+    <!-- TABLE -->
+    <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+        {% if num_records_found > 0 %}
+            <table class="govuk-table browse-grid__table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Last modified</th>
+                        <th scope="col" class="govuk-table__header">Filename</th>
+                        <th scope="col" class="govuk-table__header">Status</th>
+                        <th scope="col" class="govuk-table__header">Closure start date</th>
+                        <th scope="col" class="govuk-table__header">Closure period</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for record in results %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ record["date_last_modified"] }}</td>
+                            <td class="govuk-table__cell">
+                                <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                            </td>
+                            <td class="govuk-table__cell">
+                                <strong class="govuk-tag {{ 'govuk-tag--green' if record['closure_type'] == 'Open' else 'govuk-tag--red' }}">
+                                    {{ record['closure_type'] }}
+                                </strong>
+                            </td>
+                            <td class="govuk-table__cell">
+                                {% if record['closure_start_date'] %}
+                                    {{ record['closure_start_date'] }}
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                            <td class="govuk-table__cell">
+                                {% if record['closure_period'] %}
+                                    {{ record['closure_period'] }} years
+                                {% else %}
+                                    -
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+    <!-- END TABLE -->
+    <!-- FILTERS -->
+    <div class="govuk-grid-column-one-third filters-form">
+        <div class="browse-filter-container">
+            <div class="browse-filter__header">
+                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                     height="32px"
+                     width="32px"
+                     class="browse-filter__icon"
+                     alt="filter-icon">
+            </div>
+            <p class="govuk-body browse__body">Transferring body</p>
+            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                        id="browse_filter_transferring_body"
+                        name="sort">
+                    <option value="all" selected>Choose one...</option>
+                    <option value="arts">Arts Council England</option>
+                    <option value="food_standards_agency">Food Standards Agency</option>
+                    <option value="foreign_office">Foreign Office</option>
+                </select>
+            </div>
+        </div>
+        <div class="filters-form__series__container">
+            <p class="govuk-body browse__body">Series</p>
+            <div class="govuk-form-group filters-form__group filters-form__series-group">
+                <label class="govuk-label" for="browse_filter_series"></label>
+                <input class="govuk-input filters-form__series--input"
+                       id="browse_filter_series"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__consignment-ref__container">
+            <p class="govuk-body browse__body">
+                Consignment <abbr title="reference">ref</abbr>
+            </p>
+            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                <input class="govuk-input filters-form__consignment-ref--input"
+                       id="browse_filter_consignment-ref"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__date__container">
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                    <div class="govuk-date-input" id="date-from">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-day"
+                                       name="date-from-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-month"
+                                       name="date-from-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-from-year"
+                                       name="date-from-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                    <div class="govuk-date-input" id="date-to">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-day"
+                                       name="date-to-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-month"
+                                       name="date-to-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-to-year"
+                                       name="date-to-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="filters-form__buttons">
+                <button type="button"
+                        class="govuk-button govuk-button__filters-form-apply-button"
+                        data-module="govuk-button">Apply filters</button>
+                <button type="button"
+                        class="govuk-button__filters-form-clear-button"
+                        data-module="govuk-button">Clear all filters</button>
+            </div>
+        </div>
+    </div>
+    <!-- END FILTERS -->
+{% else %}
+    <!-- MOBILE FILTERS -->
+    <div class="mobile-filters">
+        <details class="govuk-details">
+            <summary class="govuk-mobile-details__summary">
+                <span class="govuk-mobile-details__summary-text">
+                    Filter within browse
+                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                         height="32px"
+                         width="32px"
+                         class="browse-filter__icon"
+                         alt="filter-icon">
+                </span>
+            </summary>
+            <div class="govuk-details__text govuk-mobile-details_text">
+                <div class="govuk-grid-column-one-third filters-form mobile-filters-form">
+                    <div class="browse-filter-container">
+                        <p class="govuk-body browse__body">Transferring body</p>
+                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                                    id="browse_filter_transferring_body"
+                                    name="sort">
+                                <option value="all" selected>Choose one...</option>
+                                <option value="arts">Arts Council England</option>
+                                <option value="food_standards_agency">Food Standards Agency</option>
+                                <option value="foreign_office">Foreign Office</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="filters-form__series__container">
+                        <p class="govuk-body browse__body">Series</p>
+                        <div class="govuk-form-group filters-form__group filters-form__series-group">
+                            <label class="govuk-label" for="browse_filter_series"></label>
+                            <input class="govuk-input filters-form__series--input"
+                                   id="browse_filter_series"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__consignment-ref__container">
+                        <p class="govuk-body browse__body">
+                            Consignment <abbr title="reference">ref</abbr>
+                        </p>
+                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                            <input class="govuk-input filters-form__consignment-ref--input"
+                                   id="browse_filter_consignment-ref"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__date__container">
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                                <div class="govuk-date-input" id="date-from">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-day"
+                                                   name="date-from-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-month"
+                                                   name="date-from-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-from-year"
+                                                   name="date-from-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                                <div class="govuk-date-input" id="date-to">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-day"
+                                                   name="date-to-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-month"
+                                                   name="date-to-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-to-year"
+                                                   name="date-to-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="filters-form__buttons">
+                            <button type="button"
+                                    class="govuk-button govuk-button__filters-form-apply-button"
+                                    data-module="govuk-button">Apply filters</button>
+                            <button type="button"
+                                    class="govuk-button__filters-form-clear-button"
+                                    data-module="govuk-button">Clear filters</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+    </div>
+    <!-- END MOBILE FILTERS -->
+    <!-- MOBILE SORT -->
+    <div class="govuk-form-group sort-container__form mobile-sort">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END MOBILE SORT -->
+    <!-- MOBILE TABLE -->
+    <table class="govuk-table govuk-mobile-table">
+        <thead class="govuk-table__head govuk-mobile-table__head-border">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for record in results %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row">
+                            <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
+                            }}</a>
+                        </div>
+                        <div>{{ record["last_record_transferred"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row empty-cell">-</div>
+                        <div class="right-align">{{ record["records_held"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row right-align empty-cell">-</div>
+                        <div class="right-align">{{ record["consignment_in_series"] }}</div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <!-- END TABLE -->
+{% endif %}

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -1,0 +1,390 @@
+{% if view_type == "desktop" %}
+    <!-- SORT -->
+    <div class="govuk-form-group sort-container__form">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END SORT -->
+    <!-- TABLE -->
+    <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+        {% if num_records_found > 0 %}
+            <table class="govuk-table browse-grid__table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col"
+                            class="govuk-table__header browse-grid__key__transferring-body">Transferring body</th>
+                        <th scope="col" class="govuk-table__header">Series</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignment transferred</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Records in consignment</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignment reference</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for record in results %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ record["transferring_body"] }}</td>
+                            <td class="govuk-table__cell">{{ record["series"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
+                            <td class="govuk-table__cell">
+                                <a href="{{ url_for('main.browse', consignment_id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+    <!-- END TABLE -->
+    <!-- FILTERS -->
+    <div class="govuk-grid-column-one-third filters-form">
+        <div class="browse-filter-container">
+            <div class="browse-filter__header">
+                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                     height="32px"
+                     width="32px"
+                     class="browse-filter__icon"
+                     alt="filter-icon">
+            </div>
+            <p class="govuk-body browse__body">Transferring body</p>
+            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                        id="browse_filter_transferring_body"
+                        name="sort">
+                    <option value="all" selected>Choose one...</option>
+                    <option value="arts">Arts Council England</option>
+                    <option value="food_standards_agency">Food Standards Agency</option>
+                    <option value="foreign_office">Foreign Office</option>
+                </select>
+            </div>
+        </div>
+        <div class="filters-form__series__container">
+            <p class="govuk-body browse__body">Series</p>
+            <div class="govuk-form-group filters-form__group filters-form__series-group">
+                <label class="govuk-label" for="browse_filter_series"></label>
+                <input class="govuk-input filters-form__series--input"
+                       id="browse_filter_series"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__consignment-ref__container">
+            <p class="govuk-body browse__body">
+                Consignment <abbr title="reference">ref</abbr>
+            </p>
+            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                <input class="govuk-input filters-form__consignment-ref--input"
+                       id="browse_filter_consignment-ref"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__date__container">
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                    <div class="govuk-date-input" id="date-from">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-day"
+                                       name="date-from-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-month"
+                                       name="date-from-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-from-year"
+                                       name="date-from-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                    <div class="govuk-date-input" id="date-to">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-day"
+                                       name="date-to-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-month"
+                                       name="date-to-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-to-year"
+                                       name="date-to-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="filters-form__buttons">
+                <button type="button"
+                        class="govuk-button govuk-button__filters-form-apply-button"
+                        data-module="govuk-button">Apply filters</button>
+                <button type="button"
+                        class="govuk-button__filters-form-clear-button"
+                        data-module="govuk-button">Clear all filters</button>
+            </div>
+        </div>
+    </div>
+    <!-- END FILTERS -->
+{% else %}
+    <!-- MOBILE FILTERS -->
+    <div class="mobile-filters">
+        <details class="govuk-details">
+            <summary class="govuk-mobile-details__summary">
+                <span class="govuk-mobile-details__summary-text">
+                    Filter within browse
+                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                         height="32px"
+                         width="32px"
+                         class="browse-filter__icon"
+                         alt="filter-icon">
+                </span>
+            </summary>
+            <div class="govuk-details__text govuk-mobile-details_text">
+                <div class="govuk-grid-column-one-third filters-form mobile-filters-form">
+                    <div class="browse-filter-container">
+                        <p class="govuk-body browse__body">Transferring body</p>
+                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                                    id="browse_filter_transferring_body"
+                                    name="sort">
+                                <option value="all" selected>Choose one...</option>
+                                <option value="arts">Arts Council England</option>
+                                <option value="food_standards_agency">Food Standards Agency</option>
+                                <option value="foreign_office">Foreign Office</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="filters-form__series__container">
+                        <p class="govuk-body browse__body">Series</p>
+                        <div class="govuk-form-group filters-form__group filters-form__series-group">
+                            <label class="govuk-label" for="browse_filter_series"></label>
+                            <input class="govuk-input filters-form__series--input"
+                                   id="browse_filter_series"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__consignment-ref__container">
+                        <p class="govuk-body browse__body">
+                            Consignment <abbr title="reference">ref</abbr>
+                        </p>
+                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                            <input class="govuk-input filters-form__consignment-ref--input"
+                                   id="browse_filter_consignment-ref"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__date__container">
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                                <div class="govuk-date-input" id="date-from">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-day"
+                                                   name="date-from-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-month"
+                                                   name="date-from-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-from-year"
+                                                   name="date-from-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                                <div class="govuk-date-input" id="date-to">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-day"
+                                                   name="date-to-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-month"
+                                                   name="date-to-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-to-year"
+                                                   name="date-to-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="filters-form__buttons">
+                            <button type="button"
+                                    class="govuk-button govuk-button__filters-form-apply-button"
+                                    data-module="govuk-button">Apply filters</button>
+                            <button type="button"
+                                    class="govuk-button__filters-form-clear-button"
+                                    data-module="govuk-button">Clear filters</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+    </div>
+    <!-- END MOBILE FILTERS -->
+    <!-- MOBILE SORT -->
+    <div class="govuk-form-group sort-container__form mobile-sort">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END MOBILE SORT -->
+    <!-- MOBILE TABLE -->
+    <table class="govuk-table govuk-mobile-table">
+        <thead class="govuk-table__head govuk-mobile-table__head-border">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for record in results %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row">
+                            <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
+                            }}</a>
+                        </div>
+                        <div>{{ record["last_record_transferred"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row empty-cell">-</div>
+                        <div class="right-align">{{ record["records_held"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row right-align empty-cell">-</div>
+                        <div class="right-align">{{ record["consignment_in_series"] }}</div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <!-- END TABLE -->
+{% endif %}

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -1,0 +1,390 @@
+{% if view_type == "desktop" %}
+    <!-- SORT -->
+    <div class="govuk-form-group sort-container__form">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END SORT -->
+    <!-- TABLE -->
+    <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+        {% if num_records_found > 0 %}
+            <table class="govuk-table browse-grid__table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col"
+                            class="govuk-table__header browse-grid__key__transferring-body">Transferring body</th>
+                        <th scope="col" class="govuk-table__header">Series</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Last record transferred</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Records held</th>
+                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignments within series</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    {% for record in results %}
+                        <tr class="govuk-table__row">
+                            <td class="govuk-table__cell">{{ record["transferring_body"] }}</td>
+                            <td class="govuk-table__cell">
+                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
+                            </td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
+                            <td class="govuk-table__cell browse__table__right-align">{{ record["consignment_in_series"] }}</td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
+    <!-- END TABLE -->
+    <!-- FILTERS -->
+    <div class="govuk-grid-column-one-third filters-form">
+        <div class="browse-filter-container">
+            <div class="browse-filter__header">
+                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                     height="32px"
+                     width="32px"
+                     class="browse-filter__icon"
+                     alt="filter-icon">
+            </div>
+            <p class="govuk-body browse__body">Transferring body</p>
+            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                        id="browse_filter_transferring_body"
+                        name="sort">
+                    <option value="all" selected>Choose one...</option>
+                    <option value="arts">Arts Council England</option>
+                    <option value="food_standards_agency">Food Standards Agency</option>
+                    <option value="foreign_office">Foreign Office</option>
+                </select>
+            </div>
+        </div>
+        <div class="filters-form__series__container">
+            <p class="govuk-body browse__body">Series</p>
+            <div class="govuk-form-group filters-form__group filters-form__series-group">
+                <label class="govuk-label" for="browse_filter_series"></label>
+                <input class="govuk-input filters-form__series--input"
+                       id="browse_filter_series"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__consignment-ref__container">
+            <p class="govuk-body browse__body">
+                Consignment <abbr title="reference">ref</abbr>
+            </p>
+            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                <input class="govuk-input filters-form__consignment-ref--input"
+                       id="browse_filter_consignment-ref"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__date__container">
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                    <div class="govuk-date-input" id="date-from">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-day"
+                                       name="date-from-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-month"
+                                       name="date-from-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-from-year"
+                                       name="date-from-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                    <div class="govuk-date-input" id="date-to">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-day"
+                                       name="date-to-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-month"
+                                       name="date-to-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-to-year"
+                                       name="date-to-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="filters-form__buttons">
+                <button type="button"
+                        class="govuk-button govuk-button__filters-form-apply-button"
+                        data-module="govuk-button">Apply filters</button>
+                <button type="button"
+                        class="govuk-button__filters-form-clear-button"
+                        data-module="govuk-button">Clear all filters</button>
+            </div>
+        </div>
+    </div>
+    <!-- END FILTERS -->
+{% else %}
+    <!-- MOBILE FILTERS -->
+    <div class="mobile-filters">
+        <details class="govuk-details">
+            <summary class="govuk-mobile-details__summary">
+                <span class="govuk-mobile-details__summary-text">
+                    Filter within browse
+                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                         height="32px"
+                         width="32px"
+                         class="browse-filter__icon"
+                         alt="filter-icon">
+                </span>
+            </summary>
+            <div class="govuk-details__text govuk-mobile-details_text">
+                <div class="govuk-grid-column-one-third filters-form mobile-filters-form">
+                    <div class="browse-filter-container">
+                        <p class="govuk-body browse__body">Transferring body</p>
+                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                                    id="browse_filter_transferring_body"
+                                    name="sort">
+                                <option value="all" selected>Choose one...</option>
+                                <option value="arts">Arts Council England</option>
+                                <option value="food_standards_agency">Food Standards Agency</option>
+                                <option value="foreign_office">Foreign Office</option>
+                            </select>
+                        </div>
+                    </div>
+                    <div class="filters-form__series__container">
+                        <p class="govuk-body browse__body">Series</p>
+                        <div class="govuk-form-group filters-form__group filters-form__series-group">
+                            <label class="govuk-label" for="browse_filter_series"></label>
+                            <input class="govuk-input filters-form__series--input"
+                                   id="browse_filter_series"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__consignment-ref__container">
+                        <p class="govuk-body browse__body">
+                            Consignment <abbr title="reference">ref</abbr>
+                        </p>
+                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                            <input class="govuk-input filters-form__consignment-ref--input"
+                                   id="browse_filter_consignment-ref"
+                                   name="width10"
+                                   type="text">
+                        </div>
+                    </div>
+                    <div class="filters-form__date__container">
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                                <div class="govuk-date-input" id="date-from">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-day"
+                                                   name="date-from-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-from-month"
+                                                   name="date-from-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-from-year"
+                                                   name="date-from-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-from-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                                <div class="govuk-date-input" id="date-to">
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-day"
+                                                   name="date-to-day"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-day">(DD)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                                   id="date-to-month"
+                                                   name="date-to-month"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-month">(MM)</label>
+                                        </div>
+                                    </div>
+                                    <div class="govuk-date-input__item">
+                                        <div class="govuk-form-group">
+                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                                   id="date-to-year"
+                                                   name="date-to-year"
+                                                   type="text"
+                                                   inputmode="numeric">
+                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                                   for="date-to-year">(YYYY)</label>
+                                        </div>
+                                    </div>
+                                </div>
+                            </fieldset>
+                        </div>
+                        <div class="filters-form__buttons">
+                            <button type="button"
+                                    class="govuk-button govuk-button__filters-form-apply-button"
+                                    data-module="govuk-button">Apply filters</button>
+                            <button type="button"
+                                    class="govuk-button__filters-form-clear-button"
+                                    data-module="govuk-button">Clear filters</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </details>
+    </div>
+    <!-- END MOBILE FILTERS -->
+    <!-- MOBILE SORT -->
+    <div class="govuk-form-group sort-container__form mobile-sort">
+        <div class="browse__sort-container">
+            <label class="govuk-label" for="sort">Sort by</label>
+            <select class="govuk-select govuk-select__sort-container-select"
+                    id="sort"
+                    name="sort">
+                <option value="body-a">Transferring body (A to Z)</option>
+                <option value="body-b" selected>Transferring body (Z to A)</option>
+                <option value="series-a">Series (A to Z)</option>
+                <option value="series-b">Series (Z to A)</option>
+                <option value="date-first">Date record transferred (most recent first)</option>
+                <option value="date-last">Date record transferred (oldest first)</option>
+            </select>
+            <button class="govuk-button govuk-button__sort-container-update-button"
+                    id="sort-update-button"
+                    data-module="govuk-button">Apply</button>
+        </div>
+    </div>
+    <!-- END MOBILE SORT -->
+    <!-- MOBILE TABLE -->
+    <table class="govuk-table govuk-mobile-table">
+        <thead class="govuk-table__head govuk-mobile-table__head-border">
+            <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
+                <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+            {% for record in results %}
+                <tr class="govuk-table__row">
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row">
+                            <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
+                            }}</a>
+                        </div>
+                        <div>{{ record["last_record_transferred"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row empty-cell">-</div>
+                        <div class="right-align">{{ record["records_held"] }}</div>
+                    </td>
+                    <td class="govuk-table__cell">
+                        <div class="browse__table__series-row right-align empty-cell">-</div>
+                        <div class="right-align">{{ record["consignment_in_series"] }}</div>
+                    </td>
+                </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    <!-- END TABLE -->
+{% endif %}

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -34,322 +34,42 @@
                     <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
                     <p class="govuk-body browse__body">You are viewing</p>
                     <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
-                </div>
-                <div class="govuk-form-group sort-container__form">
-                    <div class="browse__sort-container">
-                        <label class="govuk-label" for="sort">Sort by</label>
-                        <select class="govuk-select govuk-select__sort-container-select"
-                                id="sort"
-                                name="sort">
-                            <option value="body-a">Transferring body (A to Z)</option>
-                            <option value="body-b" selected>Transferring body (Z to A)</option>
-                            <option value="series-a">Series (A to Z)</option>
-                            <option value="series-b">Series (Z to A)</option>
-                            <option value="date-first">Date record transferred (most recent first)</option>
-                            <option value="date-last">Date record transferred (oldest first)</option>
-                        </select>
-                        <button class="govuk-button govuk-button__sort-container-update-button"
-                                id="sort-update-button"
-                                data-module="govuk-button">Apply</button>
-                    </div>
+                    <br />
+                    <br />
                 </div>
             </div>
+            <!-- TABLE -->
             <div>
-                <!-- FILTERS -->
-                <div class="govuk-grid-column-one-third filters-form">
-                    <div class="browse-filter-container">
-                        <div class="browse-filter__header">
-                            <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
-                            <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
-                                 height="32px"
-                                 width="32px"
-                                 class="browse-filter__icon"
-                                 alt="filter-icon">
-                        </div>
-                        <p class="govuk-body browse__body">Transferring body</p>
-                        <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-                            <label class="govuk-label" for="browse_filter_transferring_body"></label>
-                            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-                                    id="browse_filter_transferring_body"
-                                    name="sort">
-                                <option value="all" selected>Choose one...</option>
-                                <option value="arts">Arts Council England</option>
-                                <option value="food_standards_agency">Food Standards Agency</option>
-                                <option value="foreign_office">Foreign Office</option>
-                            </select>
-                        </div>
-                    </div>
-                    <div class="filters-form__series__container">
-                        <p class="govuk-body browse__body">Series</p>
-                        <div class="govuk-form-group filters-form__group filters-form__series-group">
-                            <label class="govuk-label" for="browse_filter_series"></label>
-                            <input class="govuk-input filters-form__series--input"
-                                   id="browse_filter_series"
-                                   name="width10"
-                                   type="text">
-                        </div>
-                    </div>
-                    <div class="filters-form__consignment-ref__container">
-                        <p class="govuk-body browse__body">
-                            Consignment <abbr title="reference">ref</abbr>
-                        </p>
-                        <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
-                            <label class="govuk-label" for="browse_filter_consignment-ref"></label>
-                            <input class="govuk-input filters-form__consignment-ref--input"
-                                   id="browse_filter_consignment-ref"
-                                   name="width10"
-                                   type="text">
-                        </div>
-                    </div>
-                    <div class="filters-form__date__container">
-                        <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
-                            <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
-                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
-                                <div class="govuk-date-input" id="date-from">
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                   id="date-from-day"
-                                                   name="date-from-day"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-from-day">(DD)</label>
-                                        </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                   id="date-from-month"
-                                                   name="date-from-month"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-from-month">(MM)</label>
-                                        </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                                   id="date-from-year"
-                                                   name="date-from-year"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-from-year">(YYYY)</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
-                            <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
-                            <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
-                                <div class="govuk-date-input" id="date-to">
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                   id="date-to-day"
-                                                   name="date-to-day"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-to-day">(DD)</label>
-                                        </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                   id="date-to-month"
-                                                   name="date-to-month"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-to-month">(MM)</label>
-                                        </div>
-                                    </div>
-                                    <div class="govuk-date-input__item">
-                                        <div class="govuk-form-group">
-                                            <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                                   id="date-to-year"
-                                                   name="date-to-year"
-                                                   type="text"
-                                                   inputmode="numeric">
-                                            <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                   for="date-to-year">(YYYY)</label>
-                                        </div>
-                                    </div>
-                                </div>
-                            </fieldset>
-                        </div>
-                        <div class="filters-form__buttons">
-                            <button type="button"
-                                    class="govuk-button govuk-button__filters-form-apply-button"
-                                    data-module="govuk-button">Apply filters</button>
-                            <button type="button"
-                                    class="govuk-button__filters-form-clear-button"
-                                    data-module="govuk-button">Clear all filters</button>
-                        </div>
-                    </div>
-                </div>
-                <!-- END FILTERS -->
-            {% endif %}
-            <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
-                <!-- TABLE -->
                 {% if browse_type == "browse" %}
-                    {% if results %}
-                        {% if num_records_found > 0 %}
-                            <table class="govuk-table browse-grid__table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col"
-                                            class="govuk-table__header browse-grid__key__transferring-body">
-                                            Transferring body
-                                        </th>
-                                        <th scope="col" class="govuk-table__header">Series</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Last record transferred</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Records held</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignments within series</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    {% for record in results %}
-                                        <tr class="govuk-table__row">
-                                            <td class="govuk-table__cell">
-                                                <a href="{{ url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">{{ record["transferring_body"] }}</a>
-                                            </td>
-                                            <td class="govuk-table__cell">
-                                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
-                                            </td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["consignment_in_series"] }}</td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endif %}
+                    {% with view_type='desktop' %}
+                        {% include "browse-all.html" %}
+                    {% endwith %}
                 {% endif %}
                 {% if browse_type == "transferring_body" %}
-                    {% if results %}
-                        {% if num_records_found > 0 %}
-                            <table class="govuk-table browse-grid__table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col"
-                                            class="govuk-table__header browse-grid__key__transferring-body">
-                                            Transferring body
-                                        </th>
-                                        <th scope="col" class="govuk-table__header">Series</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Last record transferred</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Records held</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignments within series</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    {% for record in results %}
-                                        <tr class="govuk-table__row">
-                                            <td class="govuk-table__cell">{{ record["transferring_body"] }}</td>
-                                            <td class="govuk-table__cell">
-                                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
-                                            </td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["consignment_in_series"] }}</td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endif %}
+                    {% with view_type='desktop' %}
+                        {% include "browse-transferring-body.html" %}
+                    {% endwith %}
                 {% endif %}
                 {% if browse_type == "series" %}
-                    {% if results %}
-                        {% if num_records_found > 0 %}
-                            <table class="govuk-table browse-grid__table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col"
-                                            class="govuk-table__header browse-grid__key__transferring-body">
-                                            Transferring body
-                                        </th>
-                                        <th scope="col" class="govuk-table__header">Series</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignment transferred</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Records in consignment</th>
-                                        <th scope="col" class="govuk-table__header browse__table__right-align">Consignment reference</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    {% for record in results %}
-                                        <tr class="govuk-table__row">
-                                            <td class="govuk-table__cell">{{ record["transferring_body"] }}</td>
-                                            <td class="govuk-table__cell">{{ record["series"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["last_record_transferred"] }}</td>
-                                            <td class="govuk-table__cell browse__table__right-align">{{ record["records_held"] }}</td>
-                                            <td class="govuk-table__cell">
-                                                <a href="{{ url_for('main.browse', consignment_id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endif %}
+                    {% with view_type='desktop' %}
+                        {% include "browse-series.html" %}
+                    {% endwith %}
                 {% endif %}
                 {% if browse_type == "consignment" %}
-                    {% if results %}
-                        {% if num_records_found > 0 %}
-                            <table class="govuk-table browse-grid__table">
-                                <thead class="govuk-table__head">
-                                    <tr class="govuk-table__row">
-                                        <th scope="col" class="govuk-table__header">Last modified</th>
-                                        <th scope="col" class="govuk-table__header">Filename</th>
-                                        <th scope="col" class="govuk-table__header">Status</th>
-                                        <th scope="col" class="govuk-table__header">Closure start date</th>
-                                        <th scope="col" class="govuk-table__header">Closure period</th>
-                                    </tr>
-                                </thead>
-                                <tbody class="govuk-table__body">
-                                    {% for record in results %}
-                                        <tr class="govuk-table__row">
-                                            <td class="govuk-table__cell">{{ record["date_last_modified"] }}</td>
-                                            <td class="govuk-table__cell">
-                                                <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
-                                            </td>
-                                            <td class="govuk-table__cell">
-                                                <strong class="govuk-tag {{ 'govuk-tag--green' if record['closure_type'] == 'Open' else 'govuk-tag--red' }}">
-                                                    {{ record['closure_type'] }}
-                                                </strong>
-                                            </td>
-                                            <td class="govuk-table__cell">
-                                                {% if record['closure_start_date'] %}
-                                                    {{ record['closure_start_date'] }}
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                            <td class="govuk-table__cell">
-                                                {% if record['closure_period'] %}
-                                                    {{ record['closure_period'] }} years
-                                                {% else %}
-                                                    -
-                                                {% endif %}
-                                            </td>
-                                        </tr>
-                                    {% endfor %}
-                                </tbody>
-                            </table>
-                        {% endif %}
-                    {% endif %}
+                    {% with view_type='desktop' %}
+                        {% include "browse-consignment.html" %}
+                    {% endwith %}
                 {% endif %}
-                <!-- END TABLE -->
-                <!-- PAGINATION -->
+            </div>
+            <!-- END TABLE -->
+            <!-- PAGINATION -->
+            <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
                 {% with view_name='main.browse' %}
                     {% include "pagination.html" %}
                 {% endwith %}
             </div>
-        </div>
+            <!-- END PAGINATION -->
+        {% endif %}
     </div>
     <!-- MOBILE -->
     <div class="govuk-grid-row browse__page mobile">
@@ -383,321 +103,73 @@
                 <p class="govuk-body browse__body">You are viewing</p>
                 <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
             </div>
-            <div class="govuk-form-group sort-container__form">
-                <div class="browse__sort-container">
-                    <label class="govuk-label" for="sort">Sort by</label>
-                    <select class="govuk-select govuk-select__sort-container-select"
-                            id="sort"
-                            name="sort">
-                        <option value="body-a">Transferring body (A to Z)</option>
-                        <option value="body-b" selected>Transferring body (Z to A)</option>
-                        <option value="series-a">Series (A to Z)</option>
-                        <option value="series-b">Series (Z to A)</option>
-                        <option value="date-first">Date record transferred (most recent first)</option>
-                        <option value="date-last">Date record transferred (oldest first)</option>
-                    </select>
-                    <button class="govuk-button govuk-button__sort-container-update-button"
-                            id="sort-update-button"
-                            data-module="govuk-button">Apply</button>
-                </div>
-            </div>
             <div class="govuk-width-container">
-            {% endif %}
-            <!-- MOBILE SEARCH -->
-            <div class="mobile__search__container govuk-grid-column-full">
-                <div class="mobile__search__container__content">
-                    <p class="govuk-body search__heading">Search for digital records</p>
-                    <form method="post" action="{{ url_for('main.search') }}">
-                        {{ form.csrf_token }}
-                        <div class="govuk-form-group govuk-form-group__search-form">
-                            <label for="searchInput"></label>
-                            <input class="govuk-input govuk-!-width-three-quarters"
-                                   id="searchInput"
-                                   name="query"
-                                   type="text">
-                            <p class="govuk-body-s mobile__search__text">
-                                Search using a record metadata term, for example – transferring body, series,
-                                consignment
-                                ref etc.
-                            </p>
-                            <button class="govuk-button govuk-button__search-button"
-                                    data-module="govuk-button"
-                                    type="submit">Search</button>
-                        </div>
-                    </form>
-                </div>
-            </div>
-            <!--  -->
-            <div class="mobile__search__container-block"></div>
-            <!-- MOBILE DETAILS -->
-            <div class="mobile-details">
-                <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
-                <h2 class="govuk-body browse__body">You are viewing</h2>
-                <p class="govuk-body browse__body browse__available__text">Everything available to you</p>
-            </div>
-            <!-- MOBILE FILTERS -->
-            <div class="mobile-filters">
-                <details class="govuk-details">
-                    <summary class="govuk-mobile-details__summary">
-                        <span class="govuk-mobile-details__summary-text">
-                            Filter within browse
-                            <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
-                                 height="32px"
-                                 width="32px"
-                                 class="browse-filter__icon"
-                                 alt="filter-icon">
-                        </span>
-                    </summary>
-                    <div class="govuk-details__text govuk-mobile-details_text">
-                        <div class="govuk-grid-column-one-third filters-form mobile-filters-form">
-                            <div class="browse-filter-container">
-                                <p class="govuk-body browse__body">Transferring body</p>
-                                <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-                                    <label class="govuk-label" for="browse_filter_transferring_body"></label>
-                                    <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-                                            id="browse_filter_transferring_body"
-                                            name="sort">
-                                        <option value="all" selected>Choose one...</option>
-                                        <option value="arts">Arts Council England</option>
-                                        <option value="food_standards_agency">Food Standards Agency</option>
-                                        <option value="foreign_office">Foreign Office</option>
-                                    </select>
-                                </div>
-                            </div>
-                            <div class="filters-form__series__container">
-                                <p class="govuk-body browse__body">Series</p>
-                                <div class="govuk-form-group filters-form__group filters-form__series-group">
-                                    <label class="govuk-label" for="browse_filter_series"></label>
-                                    <input class="govuk-input filters-form__series--input"
-                                           id="browse_filter_series"
-                                           name="width10"
-                                           type="text">
-                                </div>
-                            </div>
-                            <div class="filters-form__consignment-ref__container">
-                                <p class="govuk-body browse__body">
-                                    Consignment <abbr title="reference">ref</abbr>
+                <!-- MOBILE SEARCH -->
+                <div class="mobile__search__container govuk-grid-column-full">
+                    <div class="mobile__search__container__content">
+                        <p class="govuk-body search__heading">Search for digital records</p>
+                        <form method="post" action="{{ url_for('main.search') }}">
+                            {{ form.csrf_token }}
+                            <div class="govuk-form-group govuk-form-group__search-form">
+                                <label for="searchInput"></label>
+                                <input class="govuk-input govuk-!-width-three-quarters"
+                                       id="searchInput"
+                                       name="query"
+                                       type="text">
+                                <p class="govuk-body-s mobile__search__text">
+                                    Search using a record metadata term, for example – transferring body, series,
+                                    consignment
+                                    ref etc.
                                 </p>
-                                <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
-                                    <label class="govuk-label" for="browse_filter_consignment-ref"></label>
-                                    <input class="govuk-input filters-form__consignment-ref--input"
-                                           id="browse_filter_consignment-ref"
-                                           name="width10"
-                                           type="text">
-                                </div>
+                                <button class="govuk-button govuk-button__search-button"
+                                        data-module="govuk-button"
+                                        type="submit">Search</button>
                             </div>
-                            <div class="filters-form__date__container">
-                                <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
-                                    <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
-                                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
-                                        <div class="govuk-date-input" id="date-from">
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                           id="date-from-day"
-                                                           name="date-from-day"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-from-day">(DD)</label>
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                           id="date-from-month"
-                                                           name="date-from-month"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-from-month">(MM)</label>
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                                           id="date-from-year"
-                                                           name="date-from-year"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-from-year">(YYYY)</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                                <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
-                                    <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
-                                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
-                                        <div class="govuk-date-input" id="date-to">
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                           id="date-to-day"
-                                                           name="date-to-day"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-to-day">(DD)</label>
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                                           id="date-to-month"
-                                                           name="date-to-month"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-to-month">(MM)</label>
-                                                </div>
-                                            </div>
-                                            <div class="govuk-date-input__item">
-                                                <div class="govuk-form-group">
-                                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                                           id="date-to-year"
-                                                           name="date-to-year"
-                                                           type="text"
-                                                           inputmode="numeric">
-                                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                                           for="date-to-year">(YYYY)</label>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </fieldset>
-                                </div>
-                                <div class="filters-form__buttons">
-                                    <button type="button"
-                                            class="govuk-button govuk-button__filters-form-apply-button"
-                                            data-module="govuk-button">Apply filters</button>
-                                    <button type="button"
-                                            class="govuk-button__filters-form-clear-button"
-                                            data-module="govuk-button">Clear filters</button>
-                                </div>
-                            </div>
-                        </div>
+                        </form>
                     </div>
-                </details>
-            </div>
-            <!-- END MOBILE FILTERS -->
-            <!-- MOBILE SORT -->
-            <div class="govuk-form-group sort-container__form mobile-sort">
-                <div class="browse__sort-container">
-                    <label class="govuk-label" for="sort">Sort by</label>
-                    <select class="govuk-select govuk-select__sort-container-select"
-                            id="sort"
-                            name="sort">
-                        <option value="body-a">Transferring body (A to Z)</option>
-                        <option value="body-b" selected>Transferring body (Z to A)</option>
-                        <option value="series-a">Series (A to Z)</option>
-                        <option value="series-b">Series (Z to A)</option>
-                        <option value="date-first">Date record transferred (most recent first)</option>
-                        <option value="date-last">Date record transferred (oldest first)</option>
-                    </select>
-                    <button class="govuk-button govuk-button__sort-container-update-button"
-                            id="sort-update-button"
-                            data-module="govuk-button">Apply</button>
                 </div>
-            </div>
-            <!-- END MOBILE SORT -->
-            <!-- MOBILE LIST -->
-            <table class="govuk-table govuk-mobile-table">
-                <thead class="govuk-table__head govuk-mobile-table__head-border">
-                    <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
-                        <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
-                        <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
-                    </tr>
-                </thead>
-                <tbody class="govuk-table__body">
+                <!--  -->
+                <div class="mobile__search__container-block"></div>
+                <!-- MOBILE DETAILS -->
+                <div class="mobile-details">
+                    <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
+                    <h2 class="govuk-body browse__body">You are viewing</h2>
+                    <p class="govuk-body browse__body browse__available__text">Everything available to you</p>
+                    <br />
+                    <br />
+                </div>
+                <!-- TABLE -->
+                <div>
                     {% if browse_type == "browse" %}
-                        {% for record in results %}
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row">
-                                        <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
-                                        }}</a>
-                                    </div>
-                                    <div>{{ record["last_record_transferred"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row empty-cell">-</div>
-                                    <div class="right-align">{{ record["records_held"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row right-align empty-cell">-</div>
-                                    <div class="right-align">{{ record["consignment_in_series"] }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
+                        {% with view_type='mobile' %}
+                            {% include "browse-all.html" %}
+                        {% endwith %}
                     {% endif %}
                     {% if browse_type == "transferring_body" %}
-                        {% for record in results %}
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row">
-                                        <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
-                                        }}</a>
-                                    </div>
-                                    <div>{{ record["last_record_transferred"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row empty-cell">-</div>
-                                    <div class="right-align">{{ record["records_held"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row right-align empty-cell">-</div>
-                                    <div class="right-align">{{ record["consignment_in_series"] }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
+                        {% with view_type='mobile' %}
+                            {% include "browse-transferring-body.html" %}
+                        {% endwith %}
                     {% endif %}
                     {% if browse_type == "series" %}
-                        {% for record in results %}
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row">
-                                        <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
-                                        }}</a>
-                                    </div>
-                                    <div>{{ record["last_record_transferred"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row empty-cell">-</div>
-                                    <div class="right-align">{{ record["records_held"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row right-align empty-cell">-</div>
-                                    <div class="right-align">{{ record["consignment_in_series"] }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
+                        {% with view_type='mobile' %}
+                            {% include "browse-series.html" %}
+                        {% endwith %}
                     {% endif %}
                     {% if browse_type == "consignment" %}
-                        {% for record in results %}
-                            <tr class="govuk-table__row">
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row">
-                                        <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"]
-                                        }}</a>
-                                    </div>
-                                    <div>{{ record["last_record_transferred"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row empty-cell">-</div>
-                                    <div class="right-align">{{ record["records_held"] }}</div>
-                                </td>
-                                <td class="govuk-table__cell">
-                                    <div class="browse__table__series-row right-align empty-cell">-</div>
-                                    <div class="right-align">{{ record["consignment_in_series"] }}</div>
-                                </td>
-                            </tr>
-                        {% endfor %}
+                        {% with view_type='mobile' %}
+                            {% include "browse-consignment.html" %}
+                        {% endwith %}
                     {% endif %}
-                </tbody>
-            </table>
-            <!-- END MOBILE -->
-        </div>
+                </div>
+                <!-- END TABLE -->
+                <!-- PAGINATION -->
+                <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
+                    {% with view_name='main.browse' %}
+                        {% include "pagination.html" %}
+                    {% endwith %}
+                </div>
+                <!-- END PAGINATION -->
+            </div>
+        {% endif %}
     </div>
 {% endblock %}


### PR DESCRIPTION

<!-- Amend as appropriate -->

## Changes in this PR

1. split browse.html into four new views browse-all.html, browse-transferring-body.html, browse-series.html and browse-consignment.html, 
2. all new views will have desktop and mobile views with sorting and filter options specific to that view
3. browse.html will be used as a base view for generic search and header and footer options

## JIRA ticket

AYR-672 

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
