### PR TITLE
browse view bread crumbs fix

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -134,7 +134,6 @@ def browse():
     if transferring_body_id:
         browse_type = "transferring_body"
         browse_parameters["transferring_body_id"] = transferring_body_id
-
         # filters["series"] = "tsta1"
         # filters["date_range"] = {"date_from": "01/08/2022", "date_to": "31/08/2022"}
         # sorting_orders["series"] = "asc"  # A to Z
@@ -147,7 +146,6 @@ def browse():
     elif series_id:
         browse_type = "series"
         browse_parameters["series_id"] = series_id
-
         # filters["date_range"] = {"date_from": "01/08/2022", "date_to": "31/08/2022"}
         # sorting_orders["last_record_transferred"] = "asc"  # oldest first
         # sorting_orders["last_record_transferred"] = "desc"  # most recent first

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -134,6 +134,7 @@ def browse():
     if transferring_body_id:
         browse_type = "transferring_body"
         browse_parameters["transferring_body_id"] = transferring_body_id
+
         # filters["series"] = "tsta1"
         # filters["date_range"] = {"date_from": "01/08/2022", "date_to": "31/08/2022"}
         # sorting_orders["series"] = "asc"  # A to Z
@@ -146,6 +147,7 @@ def browse():
     elif series_id:
         browse_type = "series"
         browse_parameters["series_id"] = series_id
+
         # filters["date_range"] = {"date_from": "01/08/2022", "date_to": "31/08/2022"}
         # sorting_orders["last_record_transferred"] = "asc"  # oldest first
         # sorting_orders["last_record_transferred"] = "desc"  # most recent first

--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -1,0 +1,30 @@
+{% set browse_url = "/browse" %}
+{% set transferring_body_url = browse_url ~ "?transferring_body_id=" %}
+{% set series_url = browse_url ~ "?series_id=" %}
+{% set consignment_url = browse_url ~ "?consignment_id=" %}
+<div class="govuk-breadcrumbs">
+    <ol class="govuk-breadcrumbs__list">
+        {% for key, value in dict.items() %}
+            {% if loop.index != dict|length %}
+                <li class="govuk-breadcrumbs__list-item">
+                    {% if key == "everything" %}
+                        <a class="govuk-breadcrumbs__link--record" href="{{ browse_url }}">{{ value }}</a>
+                    {% elif key == "body" %}
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="{{ transferring_body_url ~ value[0] }}">{{ value[1] }}</a>
+                    {% elif key == "series" %}
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="{{ series_url ~ value[0] }}">{{ value[1] }}</a>
+                    {% elif key == "consignment" %}
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="{{ consignment_url ~ value[0] }}">{{ value[1] }}</a>
+                    {% endif %}
+                </li>
+            {% else %}
+                <li class="govuk-breadcrumbs__list-item">
+                    <p class="govuk-breadcrumbs__link--record">{{ value }}</p>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </ol>
+</div>

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,12 +1,15 @@
+{% set breadcrumbs = {"everything": "Everything available to you"} %}
 {% if view_type == "desktop" %}
     <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
             <br />
             <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- SORT -->
@@ -62,140 +65,132 @@
     </div>
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
-        <div class="browse-filter-container">
-            <div class="browse-filter__header">
-                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
-                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
-                     height="32px"
-                     width="32px"
-                     class="browse-filter__icon"
-                     alt="filter-icon">
+        <form method="post" action="{{ url_for('main.browse') }}">
+            {{ form.csrf_token }}
+            <div class="browse-filter-container">
+                <div class="browse-filter__header">
+                    <p class="govuk-body-l browse__body filters-form__title">Filter</p>
+                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                         height="32px"
+                         width="32px"
+                         class="browse-filter__icon"
+                         alt="filter-icon">
+                </div>
+                <label class="govuk-body browse__body">Transferring body</label>
+                <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                    <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                    <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                            id="browse_filter_transferring_body"
+                            name="sort">
+                        <option value="all" selected>Choose one...</option>
+                        <option value="arts">Arts Council England</option>
+                        <option value="food_standards_agency">Food Standards Agency</option>
+                        <option value="foreign_office">Foreign Office</option>
+                    </select>
+                </div>
             </div>
-            <p class="govuk-body browse__body">Transferring body</p>
-            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-                <label class="govuk-label" for="browse_filter_transferring_body"></label>
-                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-                        id="browse_filter_transferring_body"
-                        name="sort">
-                    <option value="all" selected>Choose one...</option>
-                    <option value="arts">Arts Council England</option>
-                    <option value="food_standards_agency">Food Standards Agency</option>
-                    <option value="foreign_office">Foreign Office</option>
-                </select>
+            <div class="filters-form__series__container">
+                <label class="govuk-body browse__body">Series</label>
+                <div class="govuk-form-group filters-form__group filters-form__series-group">
+                    <label class="govuk-label" for="browse_filter_series"></label>
+                    <input class="govuk-input filters-form__series--input"
+                           id="browse_filter_series"
+                           name="width10"
+                           type="text">
+                </div>
             </div>
-        </div>
-        <div class="filters-form__series__container">
-            <p class="govuk-body browse__body">Series</p>
-            <div class="govuk-form-group filters-form__group filters-form__series-group">
-                <label class="govuk-label" for="browse_filter_series"></label>
-                <input class="govuk-input filters-form__series--input"
-                       id="browse_filter_series"
-                       name="width10"
-                       type="text">
-            </div>
-        </div>
-        <div class="filters-form__consignment-ref__container">
-            <p class="govuk-body browse__body">
-                Consignment <abbr title="reference">ref</abbr>
-            </p>
-            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
-                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
-                <input class="govuk-input filters-form__consignment-ref--input"
-                       id="browse_filter_consignment-ref"
-                       name="width10"
-                       type="text">
-            </div>
-        </div>
-        <div class="filters-form__date__container">
-            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
-                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
-                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
-                    <div class="govuk-date-input" id="date-from">
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                       id="date-from-day"
-                                       name="date-from-day"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-from-day">(DD)</label>
+            <div class="filters-form__date__container">
+                <label class="govuk-label">Date consignment transferred</label>
+                <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                    <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                        <div class="govuk-date-input" id="date-from">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-from-day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                           id="date-from-day"
+                                           name="date-from-day"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-from-month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                           id="date-from-month"
+                                           name="date-from-month"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-from-year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                           id="date-from-year"
+                                           name="date-from-year"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
                             </div>
                         </div>
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                       id="date-from-month"
-                                       name="date-from-month"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-from-month">(MM)</label>
+                    </fieldset>
+                </div>
+                <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                    <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                        <div class="govuk-date-input" id="date-to">
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-to-day">Day</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                           id="date-to-day"
+                                           name="date-to-day"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-to-month">Month</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                           id="date-to-month"
+                                           name="date-to-month"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
+                            </div>
+                            <div class="govuk-date-input__item">
+                                <div class="govuk-form-group">
+                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                           for="date-to-year">Year</label>
+                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                           id="date-to-year"
+                                           name="date-to-year"
+                                           type="text"
+                                           inputmode="numeric">
+                                </div>
                             </div>
                         </div>
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                       id="date-from-year"
-                                       name="date-from-year"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-from-year">(YYYY)</label>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
+                    </fieldset>
+                </div>
+                <div class="filters-form__buttons">
+                    <button type="submit"
+                            class="govuk-button govuk-button__filters-form-apply-button"
+                            data-module="govuk-button">Apply filters</button>
+                    <button type="submit"
+                            class="govuk-button__filters-form-clear-button"
+                            data-module="govuk-button">Clear filters</button>
+                </div>
             </div>
-            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
-                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
-                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
-                    <div class="govuk-date-input" id="date-to">
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                       id="date-to-day"
-                                       name="date-to-day"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-to-day">(DD)</label>
-                            </div>
-                        </div>
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                       id="date-to-month"
-                                       name="date-to-month"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-to-month">(MM)</label>
-                            </div>
-                        </div>
-                        <div class="govuk-date-input__item">
-                            <div class="govuk-form-group">
-                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                       id="date-to-year"
-                                       name="date-to-year"
-                                       type="text"
-                                       inputmode="numeric">
-                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                       for="date-to-year">(YYYY)</label>
-                            </div>
-                        </div>
-                    </div>
-                </fieldset>
-            </div>
-            <div class="filters-form__buttons">
-                <button type="button"
-                        class="govuk-button govuk-button__filters-form-apply-button"
-                        data-module="govuk-button">Apply filters</button>
-                <button type="button"
-                        class="govuk-button__filters-form-clear-button"
-                        data-module="govuk-button">Clear all filters</button>
-            </div>
-        </div>
+        </form>
     </div>
 {% else %}
     <!-- BREAD CRUMB -->
@@ -203,9 +198,11 @@
         <div class="mobile-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
             <br />
             <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- MOBILE FILTERS -->

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,4 +1,5 @@
 {% if view_type == "desktop" %}
+    <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
@@ -27,7 +28,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END SORT -->
     <!-- TABLE -->
     <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
         {% if num_records_found > 0 %}
@@ -60,7 +60,6 @@
             </table>
         {% endif %}
     </div>
-    <!-- END TABLE -->
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
         <div class="browse-filter-container">
@@ -198,8 +197,17 @@
             </div>
         </div>
     </div>
-    <!-- END FILTERS -->
 {% else %}
+    <!-- BREAD CRUMB -->
+    <div class="govuk-grid-column-full">
+        <div class="mobile-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
+            <br />
+            <br />
+        </div>
+    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">
@@ -345,7 +353,6 @@
             </div>
         </details>
     </div>
-    <!-- END MOBILE FILTERS -->
     <!-- MOBILE SORT -->
     <div class="govuk-form-group sort-container__form mobile-sort">
         <div class="browse__sort-container">
@@ -365,7 +372,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END MOBILE SORT -->
     <!-- MOBILE TABLE -->
     <table class="govuk-table govuk-mobile-table">
         <thead class="govuk-table__head govuk-mobile-table__head-border">
@@ -397,5 +403,4 @@
             {% endfor %}
         </tbody>
     </table>
-    <!-- END TABLE -->
 {% endif %}

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -57,132 +57,140 @@
     </div>
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
-        <form method="post" action="{{ url_for('main.browse') }}">
-            {{ form.csrf_token }}
-            <div class="browse-filter-container">
-                <div class="browse-filter__header">
-                    <p class="govuk-body-l browse__body filters-form__title">Filter</p>
-                    <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
-                         height="32px"
-                         width="32px"
-                         class="browse-filter__icon"
-                         alt="filter-icon">
-                </div>
-                <label class="govuk-body browse__body">Transferring body</label>
-                <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-                    <label class="govuk-label" for="browse_filter_transferring_body"></label>
-                    <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-                            id="browse_filter_transferring_body"
-                            name="sort">
-                        <option value="all" selected>Choose one...</option>
-                        <option value="arts">Arts Council England</option>
-                        <option value="food_standards_agency">Food Standards Agency</option>
-                        <option value="foreign_office">Foreign Office</option>
-                    </select>
-                </div>
+        <div class="browse-filter-container">
+            <div class="browse-filter__header">
+                <p class="govuk-body-l browse__body filters-form__title">Filter within browse</p>
+                <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
+                     height="32px"
+                     width="32px"
+                     class="browse-filter__icon"
+                     alt="filter-icon">
             </div>
-            <div class="filters-form__series__container">
-                <label class="govuk-body browse__body">Series</label>
-                <div class="govuk-form-group filters-form__group filters-form__series-group">
-                    <label class="govuk-label" for="browse_filter_series"></label>
-                    <input class="govuk-input filters-form__series--input"
-                           id="browse_filter_series"
-                           name="width10"
-                           type="text">
-                </div>
+            <p class="govuk-body browse__body">Transferring body</p>
+            <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
+                <label class="govuk-label" for="browse_filter_transferring_body"></label>
+                <select class="govuk-select govuk-select__filters-form-transferring-body-select"
+                        id="browse_filter_transferring_body"
+                        name="sort">
+                    <option value="all" selected>Choose one...</option>
+                    <option value="arts">Arts Council England</option>
+                    <option value="food_standards_agency">Food Standards Agency</option>
+                    <option value="foreign_office">Foreign Office</option>
+                </select>
             </div>
-            <div class="filters-form__date__container">
-                <label class="govuk-label">Date consignment transferred</label>
-                <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
-                    <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
-                        <div class="govuk-date-input" id="date-from">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-from-day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                           id="date-from-day"
-                                           name="date-from-day"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-from-month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                           id="date-from-month"
-                                           name="date-from-month"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-from-year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                           id="date-from-year"
-                                           name="date-from-year"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
+        </div>
+        <div class="filters-form__series__container">
+            <p class="govuk-body browse__body">Series</p>
+            <div class="govuk-form-group filters-form__group filters-form__series-group">
+                <label class="govuk-label" for="browse_filter_series"></label>
+                <input class="govuk-input filters-form__series--input"
+                       id="browse_filter_series"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__consignment-ref__container">
+            <p class="govuk-body browse__body">
+                Consignment <abbr title="reference">ref</abbr>
+            </p>
+            <div class="govuk-form-group filters-form__group filters-form__consignment-ref-group">
+                <label class="govuk-label" for="browse_filter_consignment-ref"></label>
+                <input class="govuk-input filters-form__consignment-ref--input"
+                       id="browse_filter_consignment-ref"
+                       name="width10"
+                       type="text">
+            </div>
+        </div>
+        <div class="filters-form__date__container">
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-from-group">
+                <p class="govuk-body date-form browse__body filters-form__body-date">Date from</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-from">
+                    <div class="govuk-date-input" id="date-from">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-day"
+                                       name="date-from-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-day">(DD)</label>
                             </div>
                         </div>
-                    </fieldset>
-                </div>
-                <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
-                    <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
-                    <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
-                        <div class="govuk-date-input" id="date-to">
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-to-day">Day</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                           id="date-to-day"
-                                           name="date-to-day"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-to-month">Month</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-2"
-                                           id="date-to-month"
-                                           name="date-to-month"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
-                            </div>
-                            <div class="govuk-date-input__item">
-                                <div class="govuk-form-group">
-                                    <label class="govuk-label govuk-date-input__label filters-form__date__label"
-                                           for="date-to-year">Year</label>
-                                    <input class="govuk-input govuk-date-input__input govuk-input--width-4"
-                                           id="date-to-year"
-                                           name="date-to-year"
-                                           type="text"
-                                           inputmode="numeric">
-                                </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-from-month"
+                                       name="date-from-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-month">(MM)</label>
                             </div>
                         </div>
-                    </fieldset>
-                </div>
-                <div class="filters-form__buttons">
-                    <button type="submit"
-                            class="govuk-button govuk-button__filters-form-apply-button"
-                            data-module="govuk-button">Apply filters</button>
-                    <button type="submit"
-                            class="govuk-button__filters-form-clear-button"
-                            data-module="govuk-button">Clear filters</button>
-                </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-from-year"
+                                       name="date-from-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-from-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
             </div>
-        </form>
+            <div class="govuk-form-group date-form filters-form__group filters-form__date-to-group">
+                <p class="govuk-body-m date-form browse__body filters-form__body-date">To date</p>
+                <fieldset class="govuk-fieldset" role="group" aria-describedby="date-to">
+                    <div class="govuk-date-input" id="date-to">
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-day"
+                                       name="date-to-day"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-day">(DD)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-2"
+                                       id="date-to-month"
+                                       name="date-to-month"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-month">(MM)</label>
+                            </div>
+                        </div>
+                        <div class="govuk-date-input__item">
+                            <div class="govuk-form-group">
+                                <input class="govuk-input govuk-date-input__input govuk-input--width-4"
+                                       id="date-to-year"
+                                       name="date-to-year"
+                                       type="text"
+                                       inputmode="numeric">
+                                <label class="govuk-label govuk-date-input__label filters-form__date__label"
+                                       for="date-to-year">(YYYY)</label>
+                            </div>
+                        </div>
+                    </div>
+                </fieldset>
+            </div>
+            <div class="filters-form__buttons">
+                <button type="button"
+                        class="govuk-button govuk-button__filters-form-apply-button"
+                        data-module="govuk-button">Apply filters</button>
+                <button type="button"
+                        class="govuk-button__filters-form-clear-button"
+                        data-module="govuk-button">Clear all filters</button>
+            </div>
+        </div>
     </div>
 {% else %}
     <!-- MOBILE FILTERS -->

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,4 +1,13 @@
 {% if view_type == "desktop" %}
+    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+        <div class="browse-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
+            <br />
+            <br />
+        </div>
+    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,17 +1,9 @@
 {% set breadcrumbs = {"everything": "Everything available to you"} %}
+<!-- BREAD CRUMB -->
+{% with dict = breadcrumbs %}
+    {% include "breadcrumb.html" %}
+{% endwith %}
 {% if view_type == "desktop" %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-        <div class="browse-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">
@@ -193,18 +185,6 @@
         </form>
     </div>
 {% else %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full">
-        <div class="mobile-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -1,27 +1,20 @@
+{% set breadcrumbs = {
+    "everything":"Everything",
+    "body": [results.items[0]['transferring_body_id'], results.items[0]['transferring_body']],
+    "series": [results.items[0]['series_id'], results.items[0]['series']],
+    "consignment": results.items[0]['consignment_reference']
+} %}
 {% if view_type == "desktop" %}
     <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?series_id={{ results.items[0]['series_id'] }}">{{ results.items[0]['series'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['consignment_reference'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            <br />
+            <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- SORT -->
@@ -232,24 +225,11 @@
         <div class="mobile-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?series_id={{ results.items[0]['series_id'] }}">{{ results.items[0]['series'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['consignment_reference'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            <br />
+            <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- MOBILE FILTERS -->

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -4,19 +4,11 @@
     "series": [results.items[0]['series_id'], results.items[0]['series']],
     "consignment": results.items[0]['consignment_reference']
 } %}
+<!-- BREAD CRUMB -->
+{% with dict = breadcrumbs %}
+    {% include "breadcrumb.html" %}
+{% endwith %}
 {% if view_type == "desktop" %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-        <div class="browse-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">
@@ -220,18 +212,6 @@
     </div>
     <!-- END FILTERS -->
 {% else %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full">
-        <div class="mobile-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -1,4 +1,5 @@
 {% if view_type == "desktop" %}
+    <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
@@ -8,21 +9,17 @@
                     <li class="govuk-breadcrumbs__list-item">
                         <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                     </li>
-                    {% for record in results %}
-                        {% if loop.index == 1 %}
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record"
-                                   href="/browse?transferring_body_id={{ record['transferring_body_id'] }}">{{ record['transferring_body'] }}</a>
-                            </li>
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record"
-                                   href="/browse?series_id={{ record['series_id'] }}">{{ record['series'] }}</a>
-                            </li>
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['consignment_reference'] }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?series_id={{ results.items[0]['series_id'] }}">{{ results.items[0]['series'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['consignment_reference'] }}</p>
+                    </li>
                 </ol>
             </div>
         </div>
@@ -46,7 +43,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END SORT -->
     <!-- TABLE -->
     <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
         {% if num_records_found > 0 %}
@@ -92,7 +88,6 @@
             </table>
         {% endif %}
     </div>
-    <!-- END TABLE -->
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
         <div class="browse-filter-container">
@@ -232,6 +227,31 @@
     </div>
     <!-- END FILTERS -->
 {% else %}
+    <!-- BREAD CRUMB -->
+    <div class="govuk-grid-column-full">
+        <div class="mobile-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?series_id={{ results.items[0]['series_id'] }}">{{ results.items[0]['series'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['consignment_reference'] }}</p>
+                    </li>
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">
@@ -377,7 +397,6 @@
             </div>
         </details>
     </div>
-    <!-- END MOBILE FILTERS -->
     <!-- MOBILE SORT -->
     <div class="govuk-form-group sort-container__form mobile-sort">
         <div class="browse__sort-container">
@@ -397,7 +416,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END MOBILE SORT -->
     <!-- MOBILE TABLE -->
     <table class="govuk-table govuk-mobile-table">
         <thead class="govuk-table__head govuk-mobile-table__head-border">
@@ -429,5 +447,4 @@
             {% endfor %}
         </tbody>
     </table>
-    <!-- END TABLE -->
 {% endif %}

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -1,4 +1,32 @@
 {% if view_type == "desktop" %}
+    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+        <div class="browse-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    {% for record in results %}
+                        {% if loop.index == 1 %}
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record"
+                                   href="/browse?transferring_body_id={{ record['transferring_body_id'] }}">{{ record['transferring_body'] }}</a>
+                            </li>
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record"
+                                   href="/browse?series_id={{ record['series_id'] }}">{{ record['series'] }}</a>
+                            </li>
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['consignment_reference'] }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -1,4 +1,28 @@
 {% if view_type == "desktop" %}
+    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+        <div class="browse-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    {% for record in results %}
+                        {% if loop.index == 1 %}
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record"
+                                   href="/browse?transferring_body_id={{ record['transferring_body_id'] }}">{{ record['transferring_body'] }}</a>
+                            </li>
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['series'] }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -1,23 +1,19 @@
+{% set breadcrumbs = {
+    "everything":"Everything",
+    "body": [results.items[0]['transferring_body_id'], results.items[0]['transferring_body']],
+    "series": results.items[0]['series']
+} %}
 {% if view_type == "desktop" %}
     <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['series'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            <br />
+            <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- SORT -->
@@ -212,20 +208,11 @@
         <div class="mobile-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
             <p class="govuk-body browse__body">You are viewing</p>
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record"
-                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['series'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            <br />
+            <br />
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- MOBILE FILTERS -->

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -3,19 +3,11 @@
     "body": [results.items[0]['transferring_body_id'], results.items[0]['transferring_body']],
     "series": results.items[0]['series']
 } %}
+<!-- BREAD CRUMB -->
+{% with dict = breadcrumbs %}
+    {% include "breadcrumb.html" %}
+{% endwith %}
 {% if view_type == "desktop" %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-        <div class="browse-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">
@@ -203,18 +195,6 @@
         </div>
     </div>
 {% else %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full">
-        <div class="mobile-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -1,4 +1,5 @@
 {% if view_type == "desktop" %}
+    <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
@@ -8,17 +9,13 @@
                     <li class="govuk-breadcrumbs__list-item">
                         <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                     </li>
-                    {% for record in results %}
-                        {% if loop.index == 1 %}
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record"
-                                   href="/browse?transferring_body_id={{ record['transferring_body_id'] }}">{{ record['transferring_body'] }}</a>
-                            </li>
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['series'] }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['series'] }}</p>
+                    </li>
                 </ol>
             </div>
         </div>
@@ -42,7 +39,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END SORT -->
     <!-- TABLE -->
     <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
         {% if num_records_found > 0 %}
@@ -73,7 +69,6 @@
             </table>
         {% endif %}
     </div>
-    <!-- END TABLE -->
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
         <div class="browse-filter-container">
@@ -211,8 +206,28 @@
             </div>
         </div>
     </div>
-    <!-- END FILTERS -->
 {% else %}
+    <!-- BREAD CRUMB -->
+    <div class="govuk-grid-column-full">
+        <div class="mobile-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record"
+                           href="/browse?transferring_body_id={{ results.items[0]['transferring_body_id'] }}">{{ results.items[0]['transferring_body'] }}</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['series'] }}</p>
+                    </li>
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">
@@ -358,7 +373,6 @@
             </div>
         </details>
     </div>
-    <!-- END MOBILE FILTERS -->
     <!-- MOBILE SORT -->
     <div class="govuk-form-group sort-container__form mobile-sort">
         <div class="browse__sort-container">
@@ -378,7 +392,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END MOBILE SORT -->
     <!-- MOBILE TABLE -->
     <table class="govuk-table govuk-mobile-table">
         <thead class="govuk-table__head govuk-mobile-table__head-border">
@@ -410,5 +423,4 @@
             {% endfor %}
         </tbody>
     </table>
-    <!-- END TABLE -->
 {% endif %}

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -2,19 +2,11 @@
     "everything":"Everything",
     "body": results.items[0]['transferring_body']
 } %}
+<!-- BREAD CRUMB -->
+{% with dict = breadcrumbs %}
+    {% include "breadcrumb.html" %}
+{% endwith %}
 {% if view_type == "desktop" %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-        <div class="browse-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">
@@ -202,18 +194,6 @@
         </div>
     </div>
 {% else %}
-    <!-- BREAD CRUMB -->
-    <div class="govuk-grid-column-full">
-        <div class="mobile-details">
-            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-            <p class="govuk-body browse__body">You are viewing</p>
-            <br />
-            <br />
-            {% with dict = breadcrumbs %}
-                {% include "breadcrumb.html" %}
-            {% endwith %}
-        </div>
-    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -1,3 +1,7 @@
+{% set breadcrumbs = {
+    "everything":"Everything",
+    "body": results.items[0]['transferring_body']
+} %}
 {% if view_type == "desktop" %}
     <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
@@ -6,16 +10,9 @@
             <p class="govuk-body browse__body">You are viewing</p>
             <br />
             <br />
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['transferring_body'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- SORT -->
@@ -212,16 +209,9 @@
             <p class="govuk-body browse__body">You are viewing</p>
             <br />
             <br />
-            <div class="govuk-breadcrumbs">
-                <ol class="govuk-breadcrumbs__list">
-                    <li class="govuk-breadcrumbs__list-item">
-                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                    </li>
-                    <li class="govuk-breadcrumbs__list-item">
-                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['transferring_body'] }}</p>
-                    </li>
-                </ol>
-            </div>
+            {% with dict = breadcrumbs %}
+                {% include "breadcrumb.html" %}
+            {% endwith %}
         </div>
     </div>
     <!-- MOBILE FILTERS -->

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -1,4 +1,5 @@
 {% if view_type == "desktop" %}
+    <!-- BREAD CRUMB -->
     <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
         <div class="browse-details">
             <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
@@ -10,13 +11,9 @@
                     <li class="govuk-breadcrumbs__list-item">
                         <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                     </li>
-                    {% for record in results %}
-                        {% if loop.index == 1 %}
-                            <li class="govuk-breadcrumbs__list-item">
-                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['transferring_body'] }}</a>
-                            </li>
-                        {% endif %}
-                    {% endfor %}
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['transferring_body'] }}</p>
+                    </li>
                 </ol>
             </div>
         </div>
@@ -40,7 +37,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END SORT -->
     <!-- TABLE -->
     <div class="govuk-grid-column-two-thirds browse-grid--two-thirds">
         {% if num_records_found > 0 %}
@@ -71,7 +67,6 @@
             </table>
         {% endif %}
     </div>
-    <!-- END TABLE -->
     <!-- FILTERS -->
     <div class="govuk-grid-column-one-third filters-form">
         <div class="browse-filter-container">
@@ -209,8 +204,26 @@
             </div>
         </div>
     </div>
-    <!-- END FILTERS -->
 {% else %}
+    <!-- BREAD CRUMB -->
+    <div class="govuk-grid-column-full">
+        <div class="mobile-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <br />
+            <br />
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        <p class="govuk-breadcrumbs__link--record">{{ results.items[0]['transferring_body'] }}</p>
+                    </li>
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- MOBILE FILTERS -->
     <div class="mobile-filters">
         <details class="govuk-details">
@@ -356,7 +369,6 @@
             </div>
         </details>
     </div>
-    <!-- END MOBILE FILTERS -->
     <!-- MOBILE SORT -->
     <div class="govuk-form-group sort-container__form mobile-sort">
         <div class="browse__sort-container">
@@ -376,7 +388,6 @@
                     data-module="govuk-button">Apply</button>
         </div>
     </div>
-    <!-- END MOBILE SORT -->
     <!-- MOBILE TABLE -->
     <table class="govuk-table govuk-mobile-table">
         <thead class="govuk-table__head govuk-mobile-table__head-border">

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -1,4 +1,26 @@
 {% if view_type == "desktop" %}
+    <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+        <div class="browse-details">
+            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+            <p class="govuk-body browse__body">You are viewing</p>
+            <br />
+            <br />
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                    </li>
+                    {% for record in results %}
+                        {% if loop.index == 1 %}
+                            <li class="govuk-breadcrumbs__list-item">
+                                <a class="govuk-breadcrumbs__link--record" href="#">{{ record['transferring_body'] }}</a>
+                            </li>
+                        {% endif %}
+                    {% endfor %}
+                </ol>
+            </div>
+        </div>
+    </div>
     <!-- SORT -->
     <div class="govuk-form-group sort-container__form">
         <div class="browse__sort-container">

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -29,15 +29,6 @@
             </div>
         </div>
         {% if results %}
-            <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-                <div class="browse-details">
-                    <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-                    <p class="govuk-body browse__body">You are viewing</p>
-                    <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
-                    <br />
-                    <br />
-                </div>
-            </div>
             <!-- TABLE -->
             <div>
                 {% if browse_type == "browse" %}

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -31,26 +31,34 @@
         {% if results %}
             <!-- TABLE -->
             <div>
-                {% if browse_type == "browse" %}
-                    {% with view_type='desktop' %}
-                        {% include "browse-all.html" %}
-                    {% endwith %}
-                {% endif %}
-                {% if browse_type == "transferring_body" %}
-                    {% with view_type='desktop' %}
-                        {% include "browse-transferring-body.html" %}
-                    {% endwith %}
-                {% endif %}
-                {% if browse_type == "series" %}
-                    {% with view_type='desktop' %}
-                        {% include "browse-series.html" %}
-                    {% endwith %}
-                {% endif %}
-                {% if browse_type == "consignment" %}
-                    {% with view_type='desktop' %}
-                        {% include "browse-consignment.html" %}
-                    {% endwith %}
-                {% endif %}
+                <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+                    <div class="browse-details">
+                        <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                        <p class="govuk-body browse__body">You are viewing</p>
+                        <br />
+                        <br />
+                        {% if browse_type == "browse" %}
+                            {% with view_type='desktop' %}
+                                {% include "browse-all.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "transferring_body" %}
+                            {% with view_type='desktop' %}
+                                {% include "browse-transferring-body.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "series" %}
+                            {% with view_type='desktop' %}
+                                {% include "browse-series.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "consignment" %}
+                            {% with view_type='desktop' %}
+                                {% include "browse-consignment.html" %}
+                            {% endwith %}
+                        {% endif %}
+                    </div>
+                </div>
             </div>
             <!-- END TABLE -->
             <!-- PAGINATION -->
@@ -118,26 +126,35 @@
                 <div class="mobile__search__container-block"></div>
                 <!-- TABLE -->
                 <div>
-                    {% if browse_type == "browse" %}
-                        {% with view_type='mobile' %}
-                            {% include "browse-all.html" %}
-                        {% endwith %}
-                    {% endif %}
-                    {% if browse_type == "transferring_body" %}
-                        {% with view_type='mobile' %}
-                            {% include "browse-transferring-body.html" %}
-                        {% endwith %}
-                    {% endif %}
-                    {% if browse_type == "series" %}
-                        {% with view_type='mobile' %}
-                            {% include "browse-series.html" %}
-                        {% endwith %}
-                    {% endif %}
-                    {% if browse_type == "consignment" %}
-                        {% with view_type='mobile' %}
-                            {% include "browse-consignment.html" %}
-                        {% endwith %}
-                    {% endif %}
+                    <!-- BREAD CRUMB -->
+                    <div class="govuk-grid-column-full">
+                        <div class="mobile-details">
+                            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                            <p class="govuk-body browse__body">You are viewing</p>
+                            <br />
+                            <br />
+                            {% if browse_type == "browse" %}
+                                {% with view_type='mobile' %}
+                                    {% include "browse-all.html" %}
+                                {% endwith %}
+                            {% endif %}
+                            {% if browse_type == "transferring_body" %}
+                                {% with view_type='mobile' %}
+                                    {% include "browse-transferring-body.html" %}
+                                {% endwith %}
+                            {% endif %}
+                            {% if browse_type == "series" %}
+                                {% with view_type='mobile' %}
+                                    {% include "browse-series.html" %}
+                                {% endwith %}
+                            {% endif %}
+                            {% if browse_type == "consignment" %}
+                                {% with view_type='mobile' %}
+                                    {% include "browse-consignment.html" %}
+                                {% endwith %}
+                            {% endif %}
+                        </div>
+                    </div>
                 </div>
                 <!-- END TABLE -->
                 <!-- PAGINATION -->

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -89,11 +89,6 @@
             </div>
         </div>
         {% if results %}
-            <div class="browse-details">
-                <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-                <p class="govuk-body browse__body">You are viewing</p>
-                <p class="govuk-body-m browse__body browse__available__text">Everything available to you</p>
-            </div>
             <div class="govuk-width-container">
                 <!-- MOBILE SEARCH -->
                 <div class="mobile__search__container govuk-grid-column-full">
@@ -121,14 +116,6 @@
                 </div>
                 <!--  -->
                 <div class="mobile__search__container-block"></div>
-                <!-- MOBILE DETAILS -->
-                <div class="mobile-details">
-                    <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
-                    <h2 class="govuk-body browse__body">You are viewing</h2>
-                    <p class="govuk-body browse__body browse__available__text">Everything available to you</p>
-                    <br />
-                    <br />
-                </div>
                 <!-- TABLE -->
                 <div>
                     {% if browse_type == "browse" %}

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -30,34 +30,32 @@
         </div>
         {% if results %}
             <!-- TABLE -->
-            <div>
-                <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
-                    <div class="browse-details">
-                        <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-                        <p class="govuk-body browse__body">You are viewing</p>
-                        <br />
-                        <br />
-                        {% if browse_type == "browse" %}
-                            {% with view_type='desktop' %}
-                                {% include "browse-all.html" %}
-                            {% endwith %}
-                        {% endif %}
-                        {% if browse_type == "transferring_body" %}
-                            {% with view_type='desktop' %}
-                                {% include "browse-transferring-body.html" %}
-                            {% endwith %}
-                        {% endif %}
-                        {% if browse_type == "series" %}
-                            {% with view_type='desktop' %}
-                                {% include "browse-series.html" %}
-                            {% endwith %}
-                        {% endif %}
-                        {% if browse_type == "consignment" %}
-                            {% with view_type='desktop' %}
-                                {% include "browse-consignment.html" %}
-                            {% endwith %}
-                        {% endif %}
-                    </div>
+            <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+                <div class="browse-details">
+                    <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                    <p class="govuk-body browse__body">You are viewing</p>
+                    <br />
+                    <br />
+                    {% if browse_type == "browse" %}
+                        {% with view_type='desktop' %}
+                            {% include "browse-all.html" %}
+                        {% endwith %}
+                    {% endif %}
+                    {% if browse_type == "transferring_body" %}
+                        {% with view_type='desktop' %}
+                            {% include "browse-transferring-body.html" %}
+                        {% endwith %}
+                    {% endif %}
+                    {% if browse_type == "series" %}
+                        {% with view_type='desktop' %}
+                            {% include "browse-series.html" %}
+                        {% endwith %}
+                    {% endif %}
+                    {% if browse_type == "consignment" %}
+                        {% with view_type='desktop' %}
+                            {% include "browse-consignment.html" %}
+                        {% endwith %}
+                    {% endif %}
                 </div>
             </div>
             <!-- END TABLE -->
@@ -125,35 +123,32 @@
                 <!--  -->
                 <div class="mobile__search__container-block"></div>
                 <!-- TABLE -->
-                <div>
-                    <!-- BREAD CRUMB -->
-                    <div class="govuk-grid-column-full">
-                        <div class="mobile-details">
-                            <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
-                            <p class="govuk-body browse__body">You are viewing</p>
-                            <br />
-                            <br />
-                            {% if browse_type == "browse" %}
-                                {% with view_type='mobile' %}
-                                    {% include "browse-all.html" %}
-                                {% endwith %}
-                            {% endif %}
-                            {% if browse_type == "transferring_body" %}
-                                {% with view_type='mobile' %}
-                                    {% include "browse-transferring-body.html" %}
-                                {% endwith %}
-                            {% endif %}
-                            {% if browse_type == "series" %}
-                                {% with view_type='mobile' %}
-                                    {% include "browse-series.html" %}
-                                {% endwith %}
-                            {% endif %}
-                            {% if browse_type == "consignment" %}
-                                {% with view_type='mobile' %}
-                                    {% include "browse-consignment.html" %}
-                                {% endwith %}
-                            {% endif %}
-                        </div>
+                <div class="govuk-grid-column-full">
+                    <div class="mobile-details">
+                        <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                        <p class="govuk-body browse__body">You are viewing</p>
+                        <br />
+                        <br />
+                        {% if browse_type == "browse" %}
+                            {% with view_type='mobile' %}
+                                {% include "browse-all.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "transferring_body" %}
+                            {% with view_type='mobile' %}
+                                {% include "browse-transferring-body.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "series" %}
+                            {% with view_type='mobile' %}
+                                {% include "browse-series.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        {% if browse_type == "consignment" %}
+                            {% with view_type='mobile' %}
+                                {% include "browse-consignment.html" %}
+                            {% endwith %}
+                        {% endif %}
                     </div>
                 </div>
                 <!-- END TABLE -->

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -1,3 +1,10 @@
+{% set breadcrumbs = {
+    "everything":"Everything",
+    "body": [record['transferring_body_id'], record['transferring_body']],
+    "series": [record['series_id'], record['series']],
+    "consignment": [record['consignment_id'], record['consignment']],
+    "File": record['file_name']
+} %}
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/back-link/macro.html' import govukBackLink -%}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
@@ -9,28 +16,11 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
                         <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-                        <div class="govuk-breadcrumbs govuk-breadcrumbs--record">
-                            <ol class="govuk-breadcrumbs__list">
-                                <li class="govuk-breadcrumbs__list-item">
-                                    <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
-                                </li>
-                                <li class="govuk-breadcrumbs__list-item">
-                                    <a class="govuk-breadcrumbs__link--record"
-                                       href="/browse?transferring_body_id={{ record['transferring_body_id'] }}">{{ record['transferring_body'] }}</a>
-                                </li>
-                                <li class="govuk-breadcrumbs__list-item">
-                                    <a class="govuk-breadcrumbs__link--record"
-                                       href="/browse?series_id={{ record['series_id'] }}">{{ record['series'] }}</a>
-                                </li>
-                                <li class="govuk-breadcrumbs__list-item">
-                                    <a class="govuk-breadcrumbs__link--record"
-                                       href="/browse?consignment_id={{ record['consignment_id'] }}">{{ record['consignment'] }}</a>
-                                </li>
-                                <li class="govuk-breadcrumbs__list-item">
-                                    <a class="govuk-breadcrumbs__link--record">{{ record['file_name'] }}</a>
-                                </li>
-                            </ol>
-                        </div>
+                        <br />
+                        <br />
+                        {% with dict = breadcrumbs %}
+                            {% include "breadcrumb.html" %}
+                        {% endwith %}
                     </div>
                 </div>
                 <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds--record-search">

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -11,6 +11,7 @@ from app.tests.factories import (
     BodyFactory,
     ConsignmentFactory,
     FileFactory,
+    FileMetadataFactory,
     SeriesFactory,
 )
 from configs.testing_config import TestingConfig
@@ -542,4 +543,165 @@ def browse_transferring_body_files():
         file_4,
         file_5,
         file_6,
+    ]
+
+
+@pytest.fixture(scope="function")
+def browse_consignment_files():
+    """
+
+    purpose of this function to return file objects to perform testing on
+      combination of single and multiple filters
+      and single sorting
+
+    returns 5 file objects associated with consignments
+
+    there is 1 body defined as Transferring bodies,
+
+    there is 1 series defined as Series in one body
+
+    there is a 1 consignment object associated with transferring body and series
+      consignment_1 associated to body_1 and series_1
+
+    there are 5 file objects (1 to 5) associated with consignment
+
+    file_1, file_2, file_3, file_4 and file_5 associated to consignment_1
+    """
+
+    body_1 = BodyFactory(Name="first_body", Description="first_body")
+
+    series_1 = SeriesFactory(
+        Name="first_series", Description="first_series", body=body_1
+    )
+
+    consignment_1 = ConsignmentFactory(
+        series=series_1,
+        ConsignmentReference="TDR-2023-FI1",
+        TransferCompleteDatetime="2023-10-14",
+    )
+
+    file_1 = FileFactory(
+        consignment=consignment_1,
+        FileName="first_file.docx",
+        FileType="file",
+    )
+
+    FileMetadataFactory(
+        file=file_1,
+        PropertyName="date_last_modified",
+        Value="2023-02-25T10:12:47",
+    )
+
+    FileMetadataFactory(
+        file=file_1, PropertyName="closure_type", Value="Closed"
+    )
+    FileMetadataFactory(
+        file=file_1,
+        PropertyName="closure_start_date",
+        Value="2023-02-25T11:14:34",
+    )
+    FileMetadataFactory(
+        file=file_1,
+        PropertyName="closure_period",
+        Value="10",
+    )
+
+    file_2 = FileFactory(
+        consignment=consignment_1,
+        FileName="second_file.ppt",
+        FileType="file",
+    )
+    FileMetadataFactory(
+        file=file_2,
+        PropertyName="date_last_modified",
+        Value="2023-01-15T12:28:08",
+    )
+    FileMetadataFactory(file=file_2, PropertyName="closure_type", Value="Open")
+    FileMetadataFactory(
+        file=file_2, PropertyName="closure_start_date", Value=None
+    )
+    FileMetadataFactory(file=file_2, PropertyName="closure_period", Value=None)
+
+    file_3 = FileFactory(
+        consignment=consignment_1,
+        FileName="third_file.docx",
+        FileType="file",
+    )
+
+    FileMetadataFactory(
+        file=file_3,
+        PropertyName="date_last_modified",
+        Value="2023-03-10T10:12:47",
+    )
+
+    FileMetadataFactory(
+        file=file_3, PropertyName="closure_type", Value="Closed"
+    )
+    FileMetadataFactory(
+        file=file_3,
+        PropertyName="closure_start_date",
+        Value="2023-03-10T10:12:47",
+    )
+    FileMetadataFactory(
+        file=file_3,
+        PropertyName="closure_period",
+        Value="25",
+    )
+
+    file_4 = FileFactory(
+        consignment=consignment_1,
+        FileName="fourth_file.xls",
+        FileType="file",
+    )
+
+    FileMetadataFactory(
+        file=file_4,
+        PropertyName="date_last_modified",
+        Value="2023-04-12T10:12:47",
+    )
+
+    FileMetadataFactory(
+        file=file_4, PropertyName="closure_type", Value="Closed"
+    )
+    FileMetadataFactory(
+        file=file_4,
+        PropertyName="closure_start_date",
+        Value="2023-04-12T10:12:47",
+    )
+    FileMetadataFactory(
+        file=file_4,
+        PropertyName="closure_period",
+        Value="70",
+    )
+
+    file_5 = FileFactory(
+        consignment=consignment_1,
+        FileName="fifth_file.doc",
+        FileType="file",
+    )
+
+    FileMetadataFactory(
+        file=file_5,
+        PropertyName="date_last_modified",
+        Value="2023-05-20T10:12:47",
+    )
+
+    FileMetadataFactory(file=file_5, PropertyName="closure_type", Value="Open")
+    FileMetadataFactory(
+        file=file_5,
+        PropertyName="closure_start_date",
+        Value=None,
+    )
+    FileMetadataFactory(
+        file=file_5,
+        PropertyName="closure_period",
+        Value=None,
+    )
+
+    return [
+        file_1,
+        file_2,
+        file_3,
+        file_4,
+        file_5,
     ]

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -2,6 +2,7 @@ from bs4 import BeautifulSoup
 from flask import url_for
 from flask.testing import FlaskClient
 
+from app.tests.assertions import assert_contains_html
 from app.tests.factories import BodyFactory
 from app.tests.mock_database import (
     create_multiple_files_for_consignment,
@@ -386,6 +387,53 @@ def test_browse_transferring_body(client: FlaskClient, mock_standard_user):
     assert [row_data] == expected_results_table[1]
 
 
+def test_browse_transferring_body_breadcrumb(
+    client: FlaskClient, mock_standard_user
+):
+    """
+    Given a user accessing the browse page
+    When they make a GET request with a transferring body id
+    Then they should see results based on transferring body filter on browse page content.
+    And breadcrumb should show 'Everything' > transferring body name
+    """
+    files = create_multiple_test_records()
+    file = files[0]
+    transferring_body_id = file.consignment.series.body.BodyId
+
+    mock_standard_user(client, file.consignment.series.body.Name)
+
+    response = client.get(
+        f"/browse?transferring_body_id={transferring_body_id}"
+    )
+
+    assert response.status_code == 200
+    assert b"Search for digital records" in response.data
+    assert b"You are viewing" in response.data
+    assert b"Records found 1" in response.data
+
+    html = response.data.decode()
+
+    expected_breadcrumbs_html = f"""
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+            <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+            <p class="govuk-breadcrumbs__link--record">{file.consignment.series.body.Name}</p>
+            </li>
+        </ol>
+    </div>
+    """
+
+    assert_contains_html(
+        expected_breadcrumbs_html,
+        html,
+        "div",
+        {"class": "govuk-breadcrumbs"},
+    )
+
+
 def test_browse_series(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
@@ -436,6 +484,53 @@ def test_browse_series(client: FlaskClient, mock_standard_user):
     assert [row_data] == expected_results_table[1]
 
 
+def test_browse_series_breadcrumb(client: FlaskClient, mock_standard_user):
+    """
+    Given a user accessing the browse page
+    When they make a GET request with a series id
+    Then they should see results based on series filter on browse page content.
+    And breadcrumb should show 'Everything' > transferring body name > series name
+    """
+    files = create_multiple_test_records()
+    file = files[0]
+    series_id = file.consignment.SeriesId
+
+    mock_standard_user(client, file.consignment.series.body.Name)
+
+    response = client.get(f"/browse?series_id={series_id}")
+
+    assert response.status_code == 200
+    assert b"Search for digital records" in response.data
+    assert b"You are viewing" in response.data
+    assert b"Records found 1" in response.data
+
+    html = response.data.decode()
+
+    expected_breadcrumbs_html = f"""
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link--record"
+                    href="/browse?transferring_body_id={file.consignment.series.body.BodyId}">{file.consignment.series.body.Name}</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <p class="govuk-breadcrumbs__link--record">{file.consignment.series.Name}</p>
+            </li>
+        </ol>
+    </div>
+    """
+
+    assert_contains_html(
+        expected_breadcrumbs_html,
+        html,
+        "div",
+        {"class": "govuk-breadcrumbs"},
+    )
+
+
 def test_browse_consignment(client: FlaskClient, mock_standard_user):
     """
     Given a user accessing the browse page
@@ -484,6 +579,56 @@ def test_browse_consignment(client: FlaskClient, mock_standard_user):
         assert [
             value.text.replace("\n", " ").strip(" ") for value in values
         ] == expected_results_table[index + 1]
+
+
+def test_browse_consignment_breadcrumb(client: FlaskClient, mock_standard_user):
+    """
+    Given a user accessing the browse page
+    When they make a GET request with a consignment id
+    Then they should see results based on consignment filter on browse page content.
+    And breadcrumb should show 'Everything' > transferring body name > series name > consignment reference
+    """
+    files = create_multiple_test_records()
+    file = files[0]
+    consignment_id = file.consignment.ConsignmentId
+
+    mock_standard_user(client, file.consignment.series.body.Name)
+
+    response = client.get(f"/browse?consignment_id={consignment_id}")
+
+    assert response.status_code == 200
+    assert b"Search for digital records" in response.data
+    assert b"You are viewing" in response.data
+
+    html = response.data.decode()
+    print(html)
+    expected_breadcrumbs_html = f"""
+    <div class="govuk-breadcrumbs">
+        <ol class="govuk-breadcrumbs__list">
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link--record"
+                    href="/browse?transferring_body_id={file.consignment.series.body.BodyId}">{file.consignment.series.body.Name}</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <a class="govuk-breadcrumbs__link--record"
+                    href="/browse?series_id={file.consignment.series.SeriesId}">{file.consignment.series.Name}</a>
+            </li>
+            <li class="govuk-breadcrumbs__list-item">
+                <p class="govuk-breadcrumbs__link--record">{file.consignment.ConsignmentReference}</p>
+            </li>
+        </ol>
+    </div>
+    """
+    print(expected_breadcrumbs_html)
+    assert_contains_html(
+        expected_breadcrumbs_html,
+        html,
+        "div",
+        {"class": "govuk-breadcrumbs"},
+    )
 
 
 def test_browse_consignment_with_missing_file(

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -356,6 +356,7 @@ def test_browse_transferring_body(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
+    assert b"test body1" in response.data
     assert b"Records found 1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
@@ -402,6 +403,8 @@ def test_browse_series(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
+    assert b"test body1" in response.data
+    assert b"test series1" in response.data
     assert b"Records found 1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
@@ -450,6 +453,9 @@ def test_browse_consignment(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
+    assert b"test body1" in response.data
+    assert b"test series1" in response.data
+    assert b"test consignment1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
     table = soup.find("table")
@@ -501,6 +507,9 @@ def test_browse_consignment_with_missing_file(
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
+    assert b"testing body11" in response.data
+    assert b"test series11" in response.data
+    assert b"test consignment11" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
     table = soup.find("table")
@@ -553,7 +562,9 @@ def test_browse_consignment_filter_display_multiple_pages(
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
-    assert b"Everything available to you" in response.data
+    assert b"test body1" in response.data
+    assert b"test series1" in response.data
+    assert b"test consignment1" in response.data
     assert b"Records found 7" in response.data
     assert b'aria-label="Page 1"' in response.data
     assert b'aria-label="Page 2"' in response.data

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -357,7 +357,6 @@ def test_browse_transferring_body(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
-    assert b"test body1" in response.data
     assert b"Records found 1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
@@ -451,8 +450,6 @@ def test_browse_series(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
-    assert b"test body1" in response.data
-    assert b"test series1" in response.data
     assert b"Records found 1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
@@ -548,9 +545,6 @@ def test_browse_consignment(client: FlaskClient, mock_standard_user):
     assert response.status_code == 200
     assert b"Search for digital records" in response.data
     assert b"You are viewing" in response.data
-    assert b"test body1" in response.data
-    assert b"test series1" in response.data
-    assert b"test consignment1" in response.data
 
     soup = BeautifulSoup(response.data, "html.parser")
     table = soup.find("table")
@@ -601,7 +595,7 @@ def test_browse_consignment_breadcrumb(client: FlaskClient, mock_standard_user):
     assert b"You are viewing" in response.data
 
     html = response.data.decode()
-    print(html)
+
     expected_breadcrumbs_html = f"""
     <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
@@ -622,7 +616,7 @@ def test_browse_consignment_breadcrumb(client: FlaskClient, mock_standard_user):
         </ol>
     </div>
     """
-    print(expected_breadcrumbs_html)
+
     assert_contains_html(
         expected_breadcrumbs_html,
         html,

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -61,7 +61,9 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
     expected_breadcrumbs_html = f"""
     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
     <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-    <div class="govuk-breadcrumbs govuk-breadcrumbs--record">
+    <br />
+    <br />
+    <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
             <li class="govuk-breadcrumbs__list-item">
             <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
@@ -79,7 +81,7 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
                 href="/browse?consignment_id={file.ConsignmentId}">{file.consignment.ConsignmentReference}</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link--record">test_file.txt</a>
+            <p class="govuk-breadcrumbs__link--record">test_file.txt</p>
             </li>
         </ol>
         </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

1. modified templates to add breadcrumb details for mobile and desktop view, 
2. modified consignment query in queries.py to include additional columns for breadcrumbs, 
3. amended test cases in test_browse.py to check breadcrumb asserts are working as expected, 
4. updated consignment test cases to use pytest fixture in test_queries.py

## JIRA ticket

AYR-595

## Screenshots of UI changes

### Before

transferring body view not showing breadcrumb from everything

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/2042446c-3868-4867-863b-223f567deb32)

series view not showing breadcrumbs for everything and transferring body

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/1718f02e-2904-4a5e-960b-55fb933f9eae)

consignment view not showing breadcrumbs for everything, transferring body and series
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/43fc250f-b9b8-42f9-9239-540cd935df62)


### After

transferring body view showing breadcrumb for everything view with a link

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/ba037293-229e-4118-a662-e93388cc7683)

series view showing breadcrumbs for everything and transferring body with a link

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/f126f965-d490-4f4e-bb8b-12c5b59e5ccc)

consignment views showing breadcrumbs for everything, transferring body and series with a link

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/1ca116cd-0a54-44bf-9a4d-584ab396a7be)


- [ ] Requires env variable(s) to be updated
