### PR TITLE
Trigger Non Prod Application Deployment in da-ayr-terraform private repo

### DIFF
--- a/.github/workflows/trigger_non_prod_cd.yml
+++ b/.github/workflows/trigger_non_prod_cd.yml
@@ -1,0 +1,21 @@
+name: Trigger Non Prod Deployment CD
+
+on:
+    push:
+      branches:
+        - main
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Trigger Non Prod Application Deployment in da-ayr-terraform private repo
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.PAT }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/nationalarchives/da-ayr-terraform/actions/workflows/deploy_application_code.yml/dispatches \
+          -d '{"ref":"main","inputs":{"environment":"test-one"}}'


### PR DESCRIPTION
## Changes in this PR

- Added `Trigger Non Prod Deployment CD` GH Action so that we deploy to non prod on every merge to main in this repo whilst keeping that deployment hidden from viewers of this repo.

This utilises a TNA PAT saved in secrets for this repo and https://docs.github.com/en/rest/actions/workflows?apiVersion=2022-11-28#create-a-workflow-dispatch-event and the non prod environment name `test-one`.


Have verified this works by manually calling the curl command locally and then pushing this branch with the on push section of the workflow extended to this branch name also and it worked. Have removed that and pushed since.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-679