### PR TITLE
breadcrumb styling updated for various filter views

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -58,40 +58,46 @@
 
     margin-top: 0;
 
+    &__list-item {
+        &:last-child a {
+            color: black;
+            text-decoration: none;
+            line-height: 1.5rem;
+            font-size: 1.5rem;
+            font-weight: bold;
+        }
+
+    }
 
     &__link--record {
         color:#1d70b8;
         font-size: 1.1rem;
         font-weight: 400;
         margin-top:0;
+
+        &:visited {
+            color: #1d70b8;
+        }
+
+    &--series {
+        white-space: nowrap;
     }
 
-    &__list-item {
-        &:last-child {
-            text-decoration: none;
-            font-weight:bold;
-            color: black;
-            font-size: 1.625rem;
-            padding-left: 0;
-            margin-left: 0;
+    &--transferring-body {
+        flex-wrap: wrap;
+    }
 
-            &::before {
-                content: none;
-                }
-
-        a {
-            text-decoration: none;
-            font-weight:bold;
-            color: black;
-            font-size: 1.8rem;
-        }
-        }
+    &--consignment {
+        white-space: nowrap;
     }
 
     &--record {
        display: flex;
     }
+    }
 }
+
+
 
 .govuk-heading-m {
     &__rights-header {

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -233,7 +233,7 @@
 
 .govuk-body-m {
     &__record-view {
-        margin-bottom: 0;
+        margin-bottom: 0.3rem;
     }
 }
 

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -75,20 +75,29 @@
         font-weight: 400;
         margin-top:0;
 
+    &--series {
+        white-space: nowrap;
+
         &:visited {
             color: #1d70b8;
         }
 
-    &--series {
-        white-space: nowrap;
     }
 
     &--transferring-body {
         flex-wrap: wrap;
+
+        &:visited {
+            color: #1d70b8;
+        }
     }
 
     &--consignment {
         white-space: nowrap;
+
+        &:visited {
+            color: #1d70b8;
+        }
     }
 
     &--record {

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -62,7 +62,7 @@
         &:last-child a {
             color: black;
             text-decoration: none;
-            line-height: 1.5rem;
+            line-height: 1.3rem;
             font-size: 1.5rem;
             font-weight: bold;
         }

--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -10,19 +10,19 @@
                     {% if key == "everything" %}
                         <a class="govuk-breadcrumbs__link--record" href="{{ browse_url }}">{{ value }}</a>
                     {% elif key == "body" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--transferring-body"
                            href="{{ transferring_body_url ~ value[0] }}">{{ value[1] }}</a>
                     {% elif key == "series" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--series"
                            href="{{ series_url ~ value[0] }}">{{ value[1] }}</a>
                     {% elif key == "consignment" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--consignment"
                            href="{{ consignment_url ~ value[0] }}">{{ value[1] }}</a>
                     {% endif %}
                 </li>
             {% else %}
                 <li class="govuk-breadcrumbs__list-item">
-                    <p class="govuk-breadcrumbs__link--record">{{ value }}</p>
+                    <a class="govuk-breadcrumbs__link--record" href="#">{{ value }}</a>
                 </li>
             {% endif %}
         {% endfor %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -16,8 +16,6 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
                         <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-                        <br />
-                        <br />
                         {% with dict = breadcrumbs %}
                             {% include "breadcrumb.html" %}
                         {% endwith %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Update/fix made to the record page breadcrumbs  via the _record.scss file. 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-609
## Screenshots of UI changes

### Before
<img width="1649" alt="Screenshot 2024-01-31 at 09 21 36" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/de624020-40dc-42fb-a993-90bb51e569d9">

### After
<img width="1441" alt="Screenshot 2024-01-31 at 09 51 11" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/31503cc3-3841-4ff7-a4a6-863f9ea872f6">




- [ ] Requires env variable(s) to be updated
