### PR TITLE
Ayr 609/breadcrumbs fix

### DIFF
--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -1,0 +1,57 @@
+.govuk-breadcrumbs {
+
+    margin-top: 0;
+
+
+    &__list-item {
+        &:last-child a {
+            text-decoration: none;
+            font-weight:bold;
+            color: black;
+            font-size: 1.5rem;
+            line-height: 1.8rem;
+
+
+        }
+    }
+
+    &__link--record {
+
+        color:#1d70b8;
+        font-size: 1.1rem;
+        font-weight: 400;
+        margin-top:0;
+
+
+
+
+
+        &--series {
+            white-space: nowrap;
+
+            &:visited {
+                color: #1d70b8;
+            }
+        }
+
+        &--transferring-body {
+            flex-wrap: wrap;
+
+            &:visited {
+                color: #1d70b8;
+            }
+        }
+
+        &--consignment {
+            white-space: nowrap;
+
+            &:visited {
+                color: #1d70b8;
+            }
+        }
+        }
+
+    &--record {
+       display: flex;
+    }
+}

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -54,63 +54,6 @@
     }
 }
 
-.govuk-breadcrumbs {
-
-    margin-top: 0;
-
-    &__list-item {
-        &:last-child a {
-            text-decoration: none;
-            font-weight:bold;
-            color: black;
-            font-size: 1.5rem;
-            line-height: 1.3rem;
-        }
-    }
-
-    &__link--record {
-
-        color:#1d70b8;
-        font-size: 1.1rem;
-        font-weight: 400;
-        margin-top:0;
-        
-        &:last-child a {
-            flex-wrap:wrap;
-        }
-
-        
-
-        &--series {
-            white-space: nowrap;
-    
-            &:visited {
-                color: #1d70b8;
-            }
-        }
-
-        &--transferring-body {
-            flex-wrap: wrap;
-    
-            &:visited {
-                color: #1d70b8;
-            }
-        } 
-    
-        &--consignment {
-            white-space: nowrap;
-    
-            &:visited {
-                color: #1d70b8;
-            }
-        }
-        }
-
-    &--record {
-       display: flex;
-    }
-}
-
 .govuk-heading-m {
     &__rights-header {
         display: flex;
@@ -136,10 +79,10 @@
 
     &__record-view  {
         margin-top: 2rem;
-        margin-bottom: 0;
+        margin-bottom: 0.6rem;
 
     p {
-        margin-bottom: 0;
+        margin-bottom: 0.6rem;
     }
     }
 }

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -58,35 +58,53 @@
 
     margin-top: 0;
 
+    &__list-item {
+        &:last-child a {
+            text-decoration: none;
+            font-weight:bold;
+            color: black;
+            font-size: 1.5rem;
+            line-height: 1.3rem;
+        }
+    }
 
     &__link--record {
+
         color:#1d70b8;
         font-size: 1.1rem;
         font-weight: 400;
         margin-top:0;
-    }
+        
+        &:last-child a {
+            flex-wrap:wrap;
+        }
 
-    &__list-item {
-        &:last-child {
-            text-decoration: none;
-            font-weight:bold;
-            color: black;
-            font-size: 1.625rem;
-            padding-left: 0;
-            margin-left: 0;
+        
 
-            &::before {
-                content: none;
-                }
+        &--series {
+            white-space: nowrap;
+    
+            &:visited {
+                color: #1d70b8;
+            }
+        }
 
-        a {
-            text-decoration: none;
-            font-weight:bold;
-            color: black;
-            font-size: 1.8rem;
+        &--transferring-body {
+            flex-wrap: wrap;
+    
+            &:visited {
+                color: #1d70b8;
+            }
+        } 
+    
+        &--consignment {
+            white-space: nowrap;
+    
+            &:visited {
+                color: #1d70b8;
+            }
         }
         }
-    }
 
     &--record {
        display: flex;

--- a/app/static/src/scss/main.scss
+++ b/app/static/src/scss/main.scss
@@ -12,3 +12,4 @@
 @import "includes/search";
 @import "includes/signed-out";
 @import "includes/terms-of-use";
+@import "includes/breadcrumbs";

--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -22,7 +22,7 @@
                 </li>
             {% else %}
                 <li class="govuk-breadcrumbs__list-item">
-                    <a class="govuk-breadcrumbs__link--record">{{ value }}</a>
+                    <a class="govuk-breadcrumbs__link--record" href="#">{{ value }}</a>
                 </li>
             {% endif %}
         {% endfor %}

--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -10,19 +10,19 @@
                     {% if key == "everything" %}
                         <a class="govuk-breadcrumbs__link--record" href="{{ browse_url }}">{{ value }}</a>
                     {% elif key == "body" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--transferring-body"
                            href="{{ transferring_body_url ~ value[0] }}">{{ value[1] }}</a>
                     {% elif key == "series" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--series"
                            href="{{ series_url ~ value[0] }}">{{ value[1] }}</a>
                     {% elif key == "consignment" %}
-                        <a class="govuk-breadcrumbs__link--record"
+                        <a class="govuk-breadcrumbs__link--record--consignment"
                            href="{{ consignment_url ~ value[0] }}">{{ value[1] }}</a>
                     {% endif %}
                 </li>
             {% else %}
                 <li class="govuk-breadcrumbs__list-item">
-                    <p class="govuk-breadcrumbs__link--record">{{ value }}</p>
+                    <a class="govuk-breadcrumbs__link--record">{{ value }}</a>
                 </li>
             {% endif %}
         {% endfor %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -16,8 +16,6 @@
                 <div class="govuk-grid-row">
                     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
                         <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-                        <br />
-                        <br />
                         {% with dict = breadcrumbs %}
                             {% include "breadcrumb.html" %}
                         {% endwith %}

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -135,7 +135,6 @@ def test_standard_user_redirected_to_browse_transferring_body_when_accessing_bro
     )
 
 
-
 class TestBrowse:
     def test_browse_get_view(self, client: FlaskClient, mock_superuser):
         """
@@ -1214,8 +1213,6 @@ class TestBrowseTransferringBody:
         </div>
         """
 
-
-
         assert_contains_html(
             expected_breadcrumbs_html,
             html,
@@ -2240,8 +2237,6 @@ class TestConsignment:
 
         verify_consignment_view_header_row(response.data)
         verify_data_rows(response.data, expected_rows)
-
-  
 
     def test_browse_consignment_breadcrumb(
         self, client: FlaskClient, mock_standard_user, browse_consignment_files

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -135,6 +135,7 @@ def test_standard_user_redirected_to_browse_transferring_body_when_accessing_bro
     )
 
 
+
 class TestBrowse:
     def test_browse_get_view(self, client: FlaskClient, mock_superuser):
         """
@@ -1206,12 +1207,14 @@ class TestBrowseTransferringBody:
                 <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                <p class="govuk-breadcrumbs__link--record">
-                {browse_transferring_body_files[0].consignment.series.body.Name}</p>
+                <a class="govuk-breadcrumbs__link--record" href="#">
+                {browse_transferring_body_files[0].consignment.series.body.Name}</a>
                 </li>
             </ol>
         </div>
         """
+
+
 
         assert_contains_html(
             expected_breadcrumbs_html,
@@ -1848,11 +1851,11 @@ class TestSeries:
                     <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                    <a class="govuk-breadcrumbs__link--record"
+                    <a class="govuk-breadcrumbs__link--record--transferring-body"
                         href="/browse?transferring_body_id={browse_files[0].consignment.series.body.BodyId}">{browse_files[0].consignment.series.body.Name}</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                    <p class="govuk-breadcrumbs__link--record">{browse_files[0].consignment.series.Name}</p>
+                    <a class="govuk-breadcrumbs__link--record" href="#">{browse_files[0].consignment.series.Name}</a>
                 </li>
             </ol>
         </div>
@@ -2238,6 +2241,8 @@ class TestConsignment:
         verify_consignment_view_header_row(response.data)
         verify_data_rows(response.data, expected_rows)
 
+  
+
     def test_browse_consignment_breadcrumb(
         self, client: FlaskClient, mock_standard_user, browse_consignment_files
     ):
@@ -2269,15 +2274,15 @@ class TestConsignment:
                     <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                    <a class="govuk-breadcrumbs__link--record"
+                    <a class="govuk-breadcrumbs__link--record--transferring-body"
                         href="/browse?transferring_body_id={browse_consignment_files[0].consignment.series.body.BodyId}">{browse_consignment_files[0].consignment.series.body.Name}</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                    <a class="govuk-breadcrumbs__link--record"
+                    <a class="govuk-breadcrumbs__link--record--series"
                         href="/browse?series_id={browse_consignment_files[0].consignment.series.SeriesId}">{browse_consignment_files[0].consignment.series.Name}</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
-                    <p class="govuk-breadcrumbs__link--record">{consignment_reference}</p>
+                    <a class="govuk-breadcrumbs__link--record" href="#">{consignment_reference}</p>
                 </li>
             </ol>
         </div>

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -61,8 +61,7 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
     expected_breadcrumbs_html = f"""
     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
     <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
-    <br />
-    <br />
+
     <div class="govuk-breadcrumbs">
         <ol class="govuk-breadcrumbs__list">
             <li class="govuk-breadcrumbs__list-item">

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -69,19 +69,19 @@ def test_returns_record_page_for_user_with_access_to_files_transferring_body(
             <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link--record"
+            <a class="govuk-breadcrumbs__link--record--transferring-body"
                 href="/browse?transferring_body_id={file.consignment.series.body.BodyId}">{file.consignment.series.body.Name}</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link--record"
+            <a class="govuk-breadcrumbs__link--record--series"
                 href="/browse?series_id={file.consignment.series.SeriesId}">{file.consignment.series.Name}</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-            <a class="govuk-breadcrumbs__link--record"
+            <a class="govuk-breadcrumbs__link--record--consignment"
                 href="/browse?consignment_id={file.ConsignmentId}">{file.consignment.ConsignmentReference}</a>
             </li>
             <li class="govuk-breadcrumbs__list-item">
-            <p class="govuk-breadcrumbs__link--record">test_file.txt</p>
+            <a class="govuk-breadcrumbs__link--record" href="#">test_file.txt</a>
             </li>
         </ol>
         </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Breadcrumb styling updated to fix issue with last child of breadcrumb list element 
- Related breadcrumb tests updated 
- Moved breadcrumb styling from record.scss file into its own scss file - breadcrumbs.scss 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-609
## Screenshots of UI changes

### Before
<img width="1649" alt="Screenshot 2024-01-31 at 09 21 36" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/6cfc597c-1add-4ade-a7c9-9907daf93387">

### After
<img width="1441" alt="Screenshot 2024-01-31 at 09 51 11" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/aa74421f-8e9a-4414-ac2a-222358a1f299">

- [ ] Requires env variable(s) to be updated

