### PR TITLE
Use DB_PASSWORD from secrets manager in deployment, not IAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Properties configurable at runtime:
 - `DB_PORT`: The port of the database to connect to.
 - `DB_HOST`: The host of the database to connect to.
 - `DB_USER`: The username of the database to connect to.
-- `DB_PASSWORD`: The password of the database to connect to. Note: When using `CONFIG_SOURCE=AWS_SECRETS_MANAGER` then this does not need to be set in Secrets Manager and instead this is generated using an AWS API in the config.
+- `DB_PASSWORD`: The password of the database to connect to.
 - `DB_NAME`: The name of the database to connect to.
 - `KEYCLOAK_BASE_URI`: The base URI of the Keycloak authentication service.
 - `KEYCLOAK_CLIENT_ID`: The client ID used for Keycloak authentication.

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -1,5 +1,4 @@
 import json
-from unittest.mock import patch
 
 import boto3
 from moto import mock_aws
@@ -76,6 +75,7 @@ def test_aws_secrets_manager_config_initialized():
             "DB_PORT": "5432",
             "DB_HOST": "test_db_host",
             "DB_USER": "test_db_user",
+            "DB_PASSWORD": "test_db_password",  # pragma: allowlist secret
             "DB_NAME": "test_db_name",
             "DEFAULT_PAGE_SIZE": "test_default_page_size",
         }
@@ -90,18 +90,12 @@ def test_aws_secrets_manager_config_initialized():
 
     config = AWSSecretsManagerConfig()
 
-    with patch(
-        "configs.aws_secrets_manager_config.boto3.client"
-    ) as mock_boto3_client:
-        mock_boto3_client.return_value.generate_db_auth_token.return_value = (
-            "mocked_unescaped_%F4_/rds@_:token"
-        )
-        assert (
-            config.SQLALCHEMY_DATABASE_URI
-            == "postgresql+psycopg2://test_db_user:"
-            "mocked_unescaped_%25F4_%2Frds%40_%3Atoken@test_db_host:5432/"
-            "test_db_name?sslmode=require"
-        )
+    assert (
+        config.SQLALCHEMY_DATABASE_URI
+        == "postgresql+psycopg2://test_db_user:test_db_password"
+        "@test_db_host:5432/"
+        "test_db_name?sslmode=require"
+    )
 
     assert config.KEYCLOAK_BASE_URI == "test_keycloak_base_uri"
     assert config.KEYCLOAK_CLIENT_ID == "test_keycloak_client_id"

--- a/configs/aws_secrets_manager_config.py
+++ b/configs/aws_secrets_manager_config.py
@@ -34,16 +34,5 @@ class AWSSecretsManagerConfig(BaseConfig):
 
         return secrets_dict
 
-    @property
-    def DB_PASSWORD(self):
-        client = boto3.client("rds")
-        token = client.generate_db_auth_token(
-            DBHostname=self.DB_HOST,
-            Port=self.DB_PORT,
-            DBUsername=self.DB_USER,
-            Region=self.AWS_REGION,
-        )
-        return token
-
     def _get_config_value(self, variable_name):
         return self.secrets_dict[variable_name]


### PR DESCRIPTION
## Changes in this PR

- Use DB_PASSWORD from secrets manager in deployment, not IAM

NOTE: I have updated all of our environments with their appropriate passwords, so ready to merge whenever approved.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-723