### PR TITLE
Redirect to sign in if no access or refresh token in session, dont error

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -41,8 +41,8 @@ def access_token_sign_in_required(view_func):
         g.access_token_sign_in_required = True  # Set attribute on g
 
         try:
-            access_token = session["access_token"]
-            refresh_token = session["refresh_token"]
+            access_token = session.get("access_token")
+            refresh_token = session.get("refresh_token")
             try:
                 (
                     access_token,

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -12,15 +12,11 @@ from app.main.authorize.access_token_sign_in_required import (
 class TestAccessTokenSignInRequiredDecorator:
     @staticmethod
     @pytest.mark.parametrize(
-        "access_token, refresh_token",
-        [
-            (None, None),
-            ("foo", None),
-            (None, "foo"),
-        ],
+        "session_dict",
+        [{}, {"access_token": "foo"}, {"refresh_token": "foo"}],
     )
     def test_no_access_or_refresh_token_is_redirected_to_sign_in(
-        app, access_token, refresh_token
+        app, session_dict
     ):
         """
         Given either no access or refresh token in the session,
@@ -36,8 +32,7 @@ class TestAccessTokenSignInRequiredDecorator:
                 return "Access granted"
 
             with client.session_transaction() as session:
-                session["access_token"] = access_token
-                session["refresh_token"] = refresh_token
+                session.update(session_dict)
 
             response = client.get(view_name)
 
@@ -69,6 +64,8 @@ class TestAccessTokenSignInRequiredDecorator:
             with client.session_transaction() as session:
                 session["access_token"] = "inactive_access_token"
                 session["refresh_token"] = "inactive_refresh_token"
+
+            session
 
             def mock_refresh_token(token):
                 raise keycloak.exceptions.KeycloakPostError


### PR DESCRIPTION
Thanks to @colinbowen  for spotting this bug that I introduced when I was working on the refresh flow work. 

## Changes in this PR

Redirect to sign in if no access or refresh token in session, dont error

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-420