### PR TITLE
Ask for group scope and expect only group scope in access token respo…

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -63,8 +63,7 @@ def sign_in():
     keycloak_openid = get_keycloak_instance_from_flask_config()
     auth_url = keycloak_openid.auth_url(
         redirect_uri=f"{request.url_root}callback",
-        scope="email",
-        state="your_state_info",
+        scope="group_mapper_client_scope",
     )
 
     return redirect(auth_url)

--- a/app/tests/test_sign_in.py
+++ b/app/tests/test_sign_in.py
@@ -1,0 +1,16 @@
+from unittest.mock import patch
+
+
+@patch("app.main.routes.get_keycloak_instance_from_flask_config")
+def test_sign_in(mock_keycloak, client):
+    mock_keycloak.return_value.auth_url.return_value = "keycloak_auth_url"
+
+    response = client.get("/sign-in")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "keycloak_auth_url"
+
+    mock_keycloak.return_value.auth_url.assert_called_once_with(
+        redirect_uri="http://localhost/callback",
+        scope="group_mapper_client_scope",
+    )


### PR DESCRIPTION
## Changes in this PR

As part of the user session work, I decided to limit the scopes we send across from keycloak for our client. This PR just:

- adjusts the authorization call so that it passes that scope
- adds a unit test for sign-in route that didnt exiust before
- expand the successfull sign in e2e test to verify that we have an access token with the expected scopes in the flask session cookie

## JIRA ticket

AYR-420