### PR TITLE
update labels, save groups in session, change default consignment sort - do not use

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -83,6 +83,11 @@ def callback():
     session["refresh_token"] = access_token_response["refresh_token"]
     decoded_access_token = keycloak_openid.introspect(session["access_token"])
     session["user_groups"] = decoded_access_token["groups"]
+    ayr_user = AYRUser(session.get("user_groups"))
+    if ayr_user.is_superuser:
+        session["user_type"] = "superuser"
+    else:
+        session["user_type"] = "standard_user"
 
     return redirect(url_for("main.browse"))
 

--- a/app/main/util/filter_sort_builder.py
+++ b/app/main/util/filter_sort_builder.py
@@ -25,7 +25,7 @@ def build_sorting_orders(args):
     if args:
         # set default sort for consignment view
         if args.get("consignment_id") and not args.get("sort"):
-            sorting_orders["closure_type"] = "asc"
+            sorting_orders["date_last_modified"] = "desc"
             return sorting_orders
         if args.get("sort"):
             sort_details = args.get("sort").split("-")

--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -24,6 +24,11 @@
   &-form-group {
     &__search-form {
       margin-bottom: 0;
+      margin-right: -8rem;
+
+      @include on-mobile {
+        margin-right: 0;
+      }
     }
   }
 
@@ -170,6 +175,7 @@
 
     &__content {
       margin: 0 auto;
+      width: 80%;
     }
   }
 

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -5,13 +5,14 @@
     "consignment": breadcrumb_values[4]["consignment_reference"]
 } %}
 {% set sorting_list = {
-    "Record status (closed first)": "closure_type-asc",
-    "Record status (open first)": "closure_type-desc",
-    "Record opening date (soonest first)": "opening_date-asc",
-    "Date last modified (most recent first)": "date_last_modified-desc",
-    "Date last modified (oldest first)": "date_last_modified-asc",
-    "Record filename (A to Z)": "file_name-asc",
-    "Record filename (Z to A)": "file_name-desc"
+    "Record date (most recent first)": "date_last_modified-desc",
+    "Record date (oldest first)": "date_last_modified-asc",
+    "Filename (A to Z)": "file_name-asc",
+    "Filename (Z to A)": "file_name-desc",
+    "Record opening (sooner)": "opening_date-asc",
+    "Record opening (later)": "opening_date-desc",
+    "Record status (closed)": "closure_type-asc",
+    "Record status (open)": "closure_type-desc"
 } %}
 <!-- BREAD CRUMB -->
 {% with dict = breadcrumbs %}
@@ -33,7 +34,7 @@
             <table class="govuk-table browse-grid__table" id="tbl_result">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Last modified</th>
+                        <th scope="col" class="govuk-table__header">Record date</th>
                         <th scope="col" class="govuk-table__header">Filename</th>
                         <th scope="col" class="govuk-table__header">Status</th>
                         <th scope="col" class="govuk-table__header">Record opening date</th>
@@ -118,7 +119,7 @@
                                             type="radio" value="date_last_modified" {% if
                                             user_filters["date_filter_field"]=='date_last_modified' %}checked{% endif %}>
                                             <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
-                                                   for="date_last_modified">File last modified</label>
+                                                   for="date_last_modified">Record date</label>
                                         </div>
                                         <div class="govuk-radios__item">
                                             <input class="govuk-radios__input" id="opening_date" name="date_filter_field" type="radio"
@@ -203,7 +204,7 @@
                                                                         user_filters["date_filter_field"]=='date_last_modified' %}checked{% endif %}>
                                                                         <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
                                                                                for="date_last_modified">
-                                                                            File last modified
+                                                                            Record date
                                                                         </label>
                                                                     </div>
                                                                     <div class="govuk-radios__item">
@@ -212,7 +213,7 @@
                                                                             %}checked{% endif %}>
                                                                             <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
                                                                                    for="opening_date">
-                                                                                Closure expiry
+                                                                                Record opening date
                                                                             </label>
                                                                         </div>
                                                                     </div>
@@ -243,9 +244,9 @@
                                         <table class="govuk-table govuk-mobile-table" id="tbl_result">
                                             <thead class="govuk-table__head govuk-mobile-table__head-border">
                                                 <tr class="govuk-table__row">
-                                                    <th scope="col" class="govuk-table__header">Last modified</th>
+                                                    <th scope="col" class="govuk-table__header">Record date</th>
                                                     <th scope="col" class="govuk-table__header govuk-table__header__right">Status</th>
-                                                    <th scope="col" class="govuk-table__header govuk-table__header__right">Closure expiry</th>
+                                                    <th scope="col" class="govuk-table__header govuk-table__header__right">Record opening date</th>
                                                 </tr>
                                             </thead>
                                             <tbody class="govuk-table__body">

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -115,7 +115,7 @@
         <table class="govuk-table govuk-mobile-table" id="tbl_result">
             <thead class="govuk-table__head govuk-mobile-table__head-border">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                    <th scope="col" class="govuk-table__header">Series / Consignment transferred</th>
                     <th scope="col" class="govuk-table__header govuk-table__header__right">Records in consignment</th>
                     <th scope="col" class="govuk-table__header govuk-table__header__right">Consignment reference</th>
                 </tr>

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -10,7 +10,7 @@
             <!-- TABLE -->
             <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
                 <div class="browse-details">
-                    <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                    <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
                     <p class="govuk-body browse__body">You are viewing</p>
                     {% if browse_type == "browse" %}
                         {% with view_type='desktop' %}
@@ -54,7 +54,7 @@
                 <!-- TABLE -->
                 <div class="govuk-grid-column-full govuk-grid-column-full--browse">
                     <div class="mobile-details">
-                        <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                        <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
                         <p class="govuk-body browse__body">You are viewing</p>
                         {% if browse_type == "browse" %}
                             {% with view_type='mobile' %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -188,7 +188,7 @@
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--mobile">
-                    <dt class="govuk-summary-list__key govuk-summary-list__key--mobile-table">Date last modified</dt>
+                    <dt class="govuk-summary-list__key govuk-summary-list__key--mobile-table">Record date</dt>
                     <dd class="govuk-summary-list__value govuk-summary-list__value--mobile">
                         {{ record['date_last_modified'] }}
                     </dd>

--- a/app/templates/main/top-search.html
+++ b/app/templates/main/top-search.html
@@ -12,11 +12,11 @@
                         data-module="govuk-button"
                         type="submit">Search</button>
             </div>
-            <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
-            </p>
+            {% if session["user_type"] == "superuser" %}
+                <p class="govuk-body-s">Search by file name, transferring body, series or consignment reference.</p>
+            {% else %}
+                <p class="govuk-body-s">Search by file name, series or consignment reference.</p>
+            {% endif %}
         </form>
     </div>
 </div>

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -30,6 +30,7 @@ def mock_standard_user():
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
             session["user_groups"] = groups
+            session["user_type"] = "standard_user"
 
         mock_ayr_user = ayr_user_patcher.start()
         mock_keycloak = patcher.start()
@@ -63,6 +64,7 @@ def mock_superuser():
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
             session["user_groups"] = groups
+            session["user_type"] = "superuser"
 
         mock_ayr_user = ayr_user_patcher.start()
         mock_keycloak = patcher.start()

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -85,12 +85,13 @@ def verify_consignment_view_header_row(data):
     headers = table.find_all("th")
     expected_row = (
         [
-            "Last modified",
+            "Record date",
             "Filename",
             "Status",
             "Record opening date",
         ],
     )
+
     assert [
         header.text.replace("\n", " ").strip(" ") for header in headers
     ] == expected_row[0]
@@ -205,7 +206,7 @@ class TestBrowse:
 
         assert response.status_code == 200
         assert b"Search for digital records" in response.data
-        assert b"Records found 6" in response.data
+        assert b"Browse records 6" in response.data
 
     def test_browse_get_without_filter(
         self, client: FlaskClient, mock_superuser, browse_files
@@ -1375,7 +1376,7 @@ class TestBrowseTransferringBody:
 
         assert response.status_code == 200
         assert b"You are viewing" in response.data
-        assert b"Records found 3" in response.data
+        assert b"Browse records 3" in response.data
 
         expected_rows = [
             [
@@ -1535,7 +1536,7 @@ class TestBrowseTransferringBody:
 
         assert response.status_code == 200
         assert b"You are viewing" in response.data
-        assert b"Records found 3" in response.data
+        assert b"Browse records 3" in response.data
 
         html = response.data.decode()
 
@@ -2160,7 +2161,7 @@ class TestBrowseTransferringBody:
 
         assert response.status_code == 200
         assert b"You are viewing" in response.data
-        assert b"Records found 0" in response.data
+        assert b"Browse records 0" in response.data
 
         verify_transferring_body_view_header_row(response.data)
 
@@ -2182,7 +2183,7 @@ class TestSeries:
 
         assert response.status_code == 200
         assert b"You are viewing" in response.data
-        assert b"Records found 2" in response.data
+        assert b"Browse records 2" in response.data
 
         expected_rows = [
             [
@@ -2327,7 +2328,7 @@ class TestSeries:
 
         assert response.status_code == 200
         assert b"You are viewing" in response.data
-        assert b"Records found 2" in response.data
+        assert b"Browse records 2" in response.data
 
         html = response.data.decode()
 
@@ -2734,7 +2735,7 @@ class TestConsignment:
         Given a user accessing the browse page
         When they make a GET request with a consignment id
         Then they should see results based on consignment filter on browse page content
-        sorted by record status closed first as default.
+        sorted by record date most recent first as default.
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
 
@@ -2749,10 +2750,10 @@ class TestConsignment:
 
         expected_rows = [
             [
-                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                 "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                 "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'15/01/2023', 'second_file.ppt', 'Open', '-'"
             ],
         ]
@@ -2823,7 +2824,7 @@ class TestConsignment:
         When they make a GET request with a consignment id
         and use date from and date to filter values
         Then they should see the results by date las modified between date from and date to value
-        and sorted by record status ascending default
+        and sorted by record date most recent by default
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
 
@@ -2849,8 +2850,8 @@ class TestConsignment:
 
         expected_rows = [
             [
-                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
+                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'15/01/2023', 'second_file.ppt', 'Open', '-'"
             ],
         ]
@@ -2864,9 +2865,9 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and use date from filter with value and date last modified field
-        Then they should see the results by date last modified greater than or equal to date from value
-        and sorted by record status ascending default
+        and use date from filter with value and record date field
+        Then they should see the results by record date greater than or equal to date from value
+        and sorted by record date most recent by default
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
 
@@ -2889,10 +2890,10 @@ class TestConsignment:
 
         expected_rows = [
             [
-                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                 "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                 "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'15/01/2023', 'second_file.ppt', 'Open', '-'"
             ],
         ]
@@ -2906,9 +2907,9 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and use date to filter with value and date last modified field
-        Then they should see the results by date last modified less than or equal to date from value
-        and sorted by record status ascending default
+        and use date to filter with value and record date field
+        Then they should see the results by record date less than or equal to date from value
+        and sorted by record date most recent by default
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
 
@@ -2931,8 +2932,8 @@ class TestConsignment:
 
         expected_rows = [
             [
-                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
+                "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'15/01/2023', 'second_file.ppt', 'Open', '-'"
             ],
         ]
@@ -3012,8 +3013,8 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and select sorting option as date last modified descending
-        Then they should see records sorted by date last modified most recent first
+        and select sorting option as record date descending
+        Then they should see records sorted by record date most recent first
         on browse page content.
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
@@ -3045,8 +3046,8 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and select sorting option as date last modified ascending
-        Then they should see records sorted by date last modified oldest first
+        and select sorting option as record date ascending
+        Then they should see records sorted by record date oldest first
         on browse page content.
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
@@ -3227,9 +3228,9 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and use date from filter with value and date last modified field
+        and use date from filter with value and record date field
         and use sorting by record status filter descending
-        Then they should see the results by date last modified greater than or equal to date from value
+        Then they should see the results by record date greater than or equal to date from value
         and sorted by record status in reverse alphabetic order (Z to A)
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
@@ -3272,9 +3273,9 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and use date to filter with value and date last modified field
+        and use date to filter with value and record date field
         and use sorting by record status filter descending
-        Then they should see the results by date last modified less than or equal to date from value
+        Then they should see the results by record date less than or equal to date from value
         and sorted by record status in reverse alphabetic order (Z to A)
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
@@ -3315,7 +3316,7 @@ class TestConsignment:
         """
         Given a user accessing the browse page
         When they make a GET request with a consignment id
-        and use date last modified filter with value
+        and use record date filter with value
         Then if database does not have records and no results found returned
         they should see empty header row on browse transferring body page content.
         """

--- a/app/tests/test_queries.py
+++ b/app/tests/test_queries.py
@@ -3924,9 +3924,9 @@ class TestBrowseConsignment:
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with the consignment id
-            and sort by date last modified ascending
+            and sort by record date ascending
         Then it returns a Pagination object with 5 total results
-            ordered by their date last modified as oldest first(ascending)
+            ordered by their record date as oldest first(ascending)
         """
 
         mock_standard_user(
@@ -4027,9 +4027,9 @@ class TestBrowseConsignment:
         And the session contains user info for a standard user with access to the consignment's
             associated transferring body
         When I call the 'browse_data' function with the consignment id
-            and sort by date last modified descending
+            and sort by record date descending
         Then it returns a Pagination object with 5 total results
-            ordered by their date last modified as most recent first(descending)
+            ordered by their record date as most recent first(descending)
         """
 
         mock_standard_user(

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -316,9 +316,7 @@ def test_record_search_box(client, mock_superuser):
                         type="submit">Search</button>
             </div>
             <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
+                Search by file name, transferring body, series or consignment reference.
             </p>
         </form>
     </div>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -55,7 +55,45 @@ def test_search_with_no_results(client: FlaskClient, mock_superuser):
     assert b"0 record(s) found"
 
 
-def test_search_box(client, mock_superuser):
+def test_search_box_standard_user(client, mock_standard_user):
+    mock_standard_user(client)
+
+    response = client.get("/search")
+
+    assert response.status_code == 200
+
+    html = response.data.decode()
+
+    search_html = """<div class="search__container govuk-grid-column-full">
+    <div class="search__container__content">
+        <p class="govuk-body search__heading">Search for digital records</p>
+        <form method="get" action="/search">
+            <div class="govuk-form-group govuk-form-group__search-form">
+                <label for="searchInput"></label>
+                <input class="govuk-input govuk-!-width-three-quarters"
+                       id="searchInput"
+                       name="query"
+                       type="text">
+                <button class="govuk-button govuk-button__search-button"
+                        data-module="govuk-button"
+                        type="submit">Search</button>
+            </div>
+            <p class="govuk-body-s">
+                Search by file name, series or consignment reference.
+            </p>
+        </form>
+    </div>
+</div>"""
+
+    assert_contains_html(
+        search_html,
+        html,
+        "div",
+        {"class": "search__container govuk-grid-column-full"},
+    )
+
+
+def test_search_box_superuser(client, mock_superuser):
     mock_superuser(client)
 
     response = client.get("/search")
@@ -79,9 +117,7 @@ def test_search_box(client, mock_superuser):
                         type="submit">Search</button>
             </div>
             <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
+                Search by file name, transferring body, series or consignment reference.
             </p>
         </form>
     </div>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Last modified > Record date (tables + filters panel)
- Closure expiry > Record opening date (tables + filters panel)
- 'Records found XXX'. >>> Browse records XXX'. (On browse pages)
- SU text changed to "Search by file name, transferring body, series or consignment reference."
- AAU text changed to "Search by file name, series or consignment reference."
- Sort box text updates & consignment default sort changed to record date

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-718

## Screenshots of UI changes


### Before

### After
<img width="1566" alt="Screenshot 2024-02-16 at 10 15 52" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/12565070/ba22f57b-e794-46ad-8e3c-c3fe428fc57a">


- [ ] Requires env variable(s) to be updated
