### PR TITLE
Update s3 key pattern to use FileId, not FilePath

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -278,16 +278,14 @@ def download_record(record_id: uuid.UUID):
 
     s3 = boto3.client("s3")
     bucket = current_app.config["RECORD_BUCKET_NAME"]
-    file_metadata = get_file_metadata(record_id)
-    consignment_reference = file_metadata["consignment"]
-    file_path = file_metadata["file_path"]
-    key = f'{consignment_reference}/{file_path.rstrip("/")}'
-    file_name = file_metadata["file_name"]
-    file = s3.get_object(Bucket=bucket, Key=key)
+
+    key = f"{file.consignment.ConsignmentReference}/{file.FileId}"
+
+    s3_file_object = s3.get_object(Bucket=bucket, Key=key)
 
     response = Response(
-        file["Body"].read(),
-        headers={"Content-Disposition": "attachment;filename=" + file_name},
+        s3_file_object["Body"].read(),
+        headers={"Content-Disposition": "attachment;filename=" + file.FileName},
     )
 
     return response


### PR DESCRIPTION
## Changes in this PR

- Updated s3 key pattern to use FileId, not FilePath to be in line with new format of file keys of objects we store in s3

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-706