### PR TITLE
Ayr 748/pre commit update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     -   id: check-merge-conflict
 
 - repo: https://github.com/Riverside-Healthcare/djLint
-  rev: v1.33.0
+  rev: v1.34.1
   hooks:
     - id: djlint-reformat
       args: ["--no-function-formatting"]
@@ -25,25 +25,25 @@ repos:
         args: ['--baseline', '.secrets.baseline']
 
 -   repo: https://github.com/pycqa/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
     - id: flake8
 
 -   repo: https://github.com/psf/black
-    rev: 23.10.0
+    rev: 24.2.0
     hooks:
     - id: black
       language_version: python3
 
 -   repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: isort (python)
         args: ["--profile", "black", "--filter-files"]
 
 -   repo: https://github.com/PyCQA/bandit
-    rev: 1.7.5
+    rev: 1.7.7
     hooks:
     -   id: bandit
         args: ["-c", "pyproject.toml", "--exclude", "node_modules/*", "-r", "."]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -65,3 +65,10 @@ repos:
         - stylelint-config-standard-scss@3.0.0
         - stylelint-config-standard-scss@^11.1.0
         - stylelint-selector-bem-pattern@^3.0.1
+
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: v3.1.0
+  hooks:
+    - id: prettier
+      types_or: [css, javascript, scss]
+      args: ['--write']

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,13 +57,12 @@ repos:
         pass_filenames: false
 
 - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-  rev: v15.11.0
+  rev: v16.2.1
   hooks:
     - id: stylelint
       additional_dependencies:
-        - stylelint@15.11.0
-        - stylelint-config-standard-scss@3.0.0
-        - stylelint-config-standard-scss@^11.1.0
+        - stylelint@16.2.1
+        - stylelint-config-standard-scss@^13.0.0
         - stylelint-selector-bem-pattern@^3.0.1
 
 - repo: https://github.com/pre-commit/mirrors-prettier

--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -521,10 +521,6 @@
   .govuk-grid-column-full {
     &--browse {
       display: block;
-
     }
   }
-
-
-
 }

--- a/app/static/src/scss/includes/_search.scss
+++ b/app/static/src/scss/includes/_search.scss
@@ -6,7 +6,6 @@
   }
 }
 
-
 @media screen and (width <=810px) {
   .govuk-grid-row {
     &--search {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- This adds a specific step to allow for prettier formatting of scss, css, js files which was being completed as part of npm run run lint. 
- Updated black, djLint, flake8, isort, bandit, pre-commit-stylelint versions

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-748

## Screenshots of UI changes
N/A

### Before

### After

- [ ] Requires env variable(s) to be updated
