### PR TITLE
search results summary query

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -94,6 +94,39 @@ def build_fuzzy_search_query(query_string: str, sorting_orders=None):
     return query
 
 
+def build_fuzzy_search_summary_query(query_string: str):
+    filter_value = str(f"%{query_string}%").lower()
+
+    fuzzy_filters = or_(
+        func.lower(Consignment.ConsignmentReference).like(filter_value),
+        func.lower(Body.Name).like(filter_value),
+        func.lower(Body.Description).like(filter_value),
+        func.lower(Series.Name).like(filter_value),
+        func.lower(Series.Description).like(filter_value),
+        func.lower(File.FileName).like(filter_value),
+    )
+
+    query = (
+        db.session.query(
+            Body.BodyId.label("transferring_body_id"),
+            Body.Name.label("transferring_body"),
+            func.count(File.FileName.label("file_name")).label("records_held"),
+        )
+        .join(Series, Series.BodyId == Body.BodyId)
+        .join(
+            Consignment,
+            Consignment.SeriesId == Series.SeriesId,
+        )
+        .join(File, File.ConsignmentId == Consignment.ConsignmentId)
+        .join(FileMetadata, File.FileId == FileMetadata.FileId, isouter=True)
+        .where(and_(func.lower(File.FileType) == "file", fuzzy_filters))
+        .group_by(Body.BodyId)
+        .order_by(Body.Name)
+    )
+
+    return query
+
+
 def build_browse_all_query(filters=None, sorting_orders=None):
     sub_query = (
         db.session.query(

--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -7,7 +7,9 @@ from app.main.db.models import Body, Consignment, File, FileMetadata, Series, db
 from app.main.util.date_formatter import validate_date_range
 
 
-def build_fuzzy_search_query(query_string: str, sorting_orders=None):
+def build_fuzzy_search_query(
+    query_string: str, transferring_body_id=None, sorting_orders=None
+):
     filter_value = str(f"%{query_string}%").lower()
 
     fuzzy_filters = or_(
@@ -81,15 +83,20 @@ def build_fuzzy_search_query(query_string: str, sorting_orders=None):
         ).label("opening_date"),
     )
 
+    if transferring_body_id:
+        query = query.filter(
+            sub_query.c.transferring_body_id == transferring_body_id
+        )
+
     if sorting_orders:
         query = _build_sorting_orders(query, sub_query, sorting_orders)
-    else:
-        query = query.order_by(
-            sub_query.c.transferring_body,
-            sub_query.c.series,
-            sub_query.c.consignment_reference,
-            sub_query.c.file_name,
-        )
+    # else:
+    #    query = query.order_by(
+    #        sub_query.c.transferring_body,
+    #        sub_query.c.series,
+    #        sub_query.c.consignment_reference,
+    #        sub_query.c.file_name,
+    #    )
 
     return query
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -351,6 +351,68 @@ def browse_consignment(_id: uuid.UUID):
 @bp.route("/search", methods=["GET"])
 @access_token_sign_in_required
 def search():
+    query = (
+        request.form.get("query", "").lower()
+        or request.args.get("query", "").lower()
+    )
+
+    ayr_user = AYRUser(session.get("user_groups"))
+
+    if ayr_user.is_standard_user:
+        transferring_body_id = str(
+            Body.query.filter(Body.Name == ayr_user.transferring_body.Name)
+            .first()
+            .BodyId
+        )
+
+        return redirect(
+            url_for(
+                "main.search_transferring_body",
+                _id=transferring_body_id,
+                query=query,
+            )
+        )
+    else:
+        return redirect(url_for("main.search_results_summary", query=query))
+
+
+@bp.route("/search_results_summary", methods=["GET"])
+@access_token_sign_in_required
+def search_results_summary():
+    form = SearchForm()
+    per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
+
+    query = (
+        request.form.get("query", "").lower()
+        or request.args.get("query", "").lower()
+    )
+    page = int(request.args.get("page", 1))
+
+    filters = {"query": query}
+
+    query = build_fuzzy_search_summary_query(query)
+    search_results = query.paginate(page=page, per_page=per_page)
+
+    total_records = db.session.query(
+        func.sum(query.subquery().c.records_held)
+    ).scalar()
+    if total_records:
+        num_records_found = total_records
+    else:
+        num_records_found = 0
+
+    return render_template(
+        "search-results-summary.html",
+        form=form,
+        filters=filters,
+        results=search_results,
+        num_records_found=num_records_found,
+    )
+
+
+@bp.route("/search/transferring_body/<uuid:_id>", methods=["GET"])
+@access_token_sign_in_required
+def search_transferring_body(_id: uuid.UUID):
     form = SearchForm()
     search_results = None
     per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
@@ -360,55 +422,56 @@ def search():
         or request.args.get("query", "").lower()
     )
     page = int(request.args.get("page", 1))
+
     filters = {"query": query}
     sorting_orders = build_sorting_orders(request.args)
 
-    ayr_user = AYRUser(session.get("user_groups"))
+    breadcrumb_values = {
+        0: {"transferring_body_id": _id},
+        1: {"transferring_body": Body.query.get(_id).Name},
+        2: {"query": ""},
+        3: {"search_terms": ""},
+    }
+
     if query:
-        if ayr_user.is_superuser:
-            query = build_fuzzy_search_summary_query(query)
-            search_results = query.all()
+        str_items = ""
+        query_items = query.strip().split(",")
+        # exclude any empty items
+        query_items = list(filter(None, query_items))
 
-            total_records = db.session.query(
-                func.sum(query.subquery().c.records_held)
-            ).scalar()
-            if total_records:
-                num_records_found = total_records
-            else:
-                num_records_found = 0
+        if len(query_items) > 0:
+            for i in range(len(query_items)):
+                if len(query_items[i].strip()) > 0:
+                    str_items = str_items + "‘" + query_items[i].strip() + "’"
+                    if i < len(query_items) - 1:
+                        str_items = str_items + " + "
 
-            return render_template(
-                "search-results-summary.html",
-                form=form,
-                filters=filters,
-                results=search_results,
-                num_records_found=num_records_found,
-            )
+        # update breadcrumb values with query and search terms
+        breadcrumb_values.update({2: {"query": query}})
+        breadcrumb_values.update({3: {"search_terms": str_items}})
+
+        fuzzy_search_query = build_fuzzy_search_query(
+            query,
+            transferring_body_id=_id,
+            sorting_orders=sorting_orders,
+        )
+
+        search_results = fuzzy_search_query.paginate(
+            page=page, per_page=per_page
+        )
+
+        total_records = fuzzy_search_query.count()
+        if total_records:
+            num_records_found = total_records
         else:
-            fuzzy_search_query = build_fuzzy_search_query(
-                query,
-                sorting_orders=sorting_orders,
-            )
-            # added a filter for transferring body - for standard user to return only matching rows
-            fuzzy_search_query = fuzzy_search_query.where(
-                Body.Name == ayr_user.transferring_body.Name
-            )
-
-            search_results = fuzzy_search_query.paginate(
-                page=page, per_page=per_page
-            )
-
-            total_records = fuzzy_search_query.count()
-            if total_records:
-                num_records_found = total_records
-            else:
-                num_records_found = 0
+            num_records_found = 0
 
     return render_template(
-        "search.html",
+        "search-transferring-body.html",
         form=form,
         current_page=page,
         filters=filters,
+        breadcrumb_values=breadcrumb_values,
         results=search_results,
         num_records_found=num_records_found,
         sorting_orders=sorting_orders,

--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -2,6 +2,7 @@
 {% set transferring_body_url = browse_url ~ "/transferring_body/" %}
 {% set series_url = browse_url ~ "/series/" %}
 {% set consignment_url = browse_url ~ "/consignment/" %}
+{% set search_result_summary_url = "/search_results_summary?query=" %}
 <div class="govuk-breadcrumbs  {{ 'govuk-breadcrumbs--file' if 'record' in dict }}">
     <ol class="govuk-breadcrumbs__list">
         {% for key, value in dict.items() %}
@@ -18,6 +19,9 @@
                     {% elif key == "consignment" %}
                         <a class="govuk-breadcrumbs__link--record--consignment"
                            href="{{ consignment_url ~ value[0] }}">{{ value[1] }}</a>
+                    {% elif key == "summary" %}
+                        <a class="govuk-breadcrumbs__link--record--transferring-body"
+                           href="{{ search_result_summary_url ~ value[0] }}">Results summary</a>
                     {% endif %}
                 </li>
             {% else %}

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -13,6 +13,7 @@
                 <div class="govuk-grid-column-full">
                     {% if filters["query"]|length >0 %}
                         <h2 class="govuk-heading-m">Results found {{ num_records_found }}</h2>
+                        <p class="govuk-body browse__body">You are viewing</p>
                         <!-- BREAD CRUMB -->
                         {% with dict = breadcrumbs %}
                             {% include "breadcrumb.html" %}
@@ -28,13 +29,17 @@
                                 {% for record in results %}
                                     <tr class="govuk-table__row">
                                         <td class="govuk-table__cell govuk-body govuk-!-font-size-14">
-                                            <a href="{{ url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">{{ record['transferring_body'] }}</a>
+                                            <a href="{{ url_for('main.search_transferring_body', _id=record['transferring_body_id'] , query=filters['query']) }}">{{ record['transferring_body'] }}</a>
                                         </td>
                                         <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ record['records_held'] }}</td>
                                     </tr>
                                 {% endfor %}
                             </tbody>
                         </table>
+                        <!-- PAGINATION -->
+                        {% with view_name='main.search_results_summary' %}
+                            {% include "pagination.html" %}
+                        {% endwith %}
                     {% endif %}
                 </div>
             </div>

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -1,0 +1,43 @@
+{% set breadcrumbs = {"everything": "Everything", "body": "Results summary"} %}
+{% extends "base.html" %}
+{%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{% block pageTitle %}Dashboard – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block beforeContent %}{{ super() }}{% endblock %}
+{% block content %}
+    <div class="govuk-grid-row govuk-grid-row--search">
+        {{ super() }}
+        <div class="govuk-width-container">
+            <div class="govuk-grid-row">{% include "top-search.html" %}</div>
+            <div class="mobile__search__container-block"></div>
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    {% if filters["query"]|length >0 %}
+                        <h2 class="govuk-heading-m">Results found {{ num_records_found }}</h2>
+                        <!-- BREAD CRUMB -->
+                        {% with dict = breadcrumbs %}
+                            {% include "breadcrumb.html" %}
+                        {% endwith %}
+                        <table class="govuk-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row govuk-!-font-size-14">
+                                    <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Results found within each Transferring body</th>
+                                    <th scope="col" class="govuk-table__header govuk-!-font-weight-bold">Records found</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body">
+                                {% for record in results %}
+                                    <tr class="govuk-table__row">
+                                        <td class="govuk-table__cell govuk-body govuk-!-font-size-14">
+                                            <a href="{{ url_for('main.browse', transferring_body_id=record['transferring_body_id']) }}">{{ record['transferring_body'] }}</a>
+                                        </td>
+                                        <td class="govuk-table__cell govuk-body govuk-!-font-size-14">{{ record['records_held'] }}</td>
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -1,3 +1,13 @@
+{% set superuser_breadcrumbs = {
+    "everything": "Everything",
+    "summary": [breadcrumb_values[2]["query"], "Results summary"],
+    "body": [breadcrumb_values[0]["transferring_body_id"], breadcrumb_values[1]["transferring_body"]],
+    "search_terms": breadcrumb_values[3]["search_terms"],
+} %}
+{% set standard_user_breadcrumbs = {
+    "body": [breadcrumb_values[0]["transferring_body_id"], breadcrumb_values[1]["transferring_body"]],
+    "search_terms": breadcrumb_values[3]["search_terms"],
+} %}
 {% extends "base.html" %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
 {% block pageTitle %}Dashboard – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
@@ -19,13 +29,26 @@
         <div class="govuk-width-container">
             <div class="govuk-grid-row">{% include "top-search.html" %}</div>
             <div class="mobile__search__container-block"></div>
-            <h2 class="govuk-heading-m">Records found {{ num_records_found }}</h2>
-            <!-- SORT -->
-            <div class="govuk-form-group sort-container__form">
-                {% with dict = sorting_list %}
-                    {% include "sorting-list.html" %}
-                {% endwith %}
-            </div>
+            {% if filters["query"]|length >0 %}
+                <h2 class="govuk-heading-m">Records found {{ num_records_found }}</h2>
+                <p class="govuk-body browse__body">You are viewing</p>
+                <!-- BREAD CRUMB -->
+                {% if session["user_type"] == "superuser" %}
+                    {% with dict = superuser_breadcrumbs %}
+                        {% include "breadcrumb.html" %}
+                    {% endwith %}
+                {% else %}
+                    {% with dict = standard_user_breadcrumbs %}
+                        {% include "breadcrumb.html" %}
+                    {% endwith %}
+                {% endif %}
+                <!-- SORT -->
+                <div class="govuk-form-group sort-container__form">
+                    {% with dict = sorting_list %}
+                        {% include "sorting-list.html" %}
+                    {% endwith %}
+                </div>
+            {% endif %}
             <!-- TABLE -->
             <div class="govuk-grid-row">
                 <div class="govuk-grid-column-full govuk-grid-column-full--search-results">
@@ -69,7 +92,7 @@
                             </tbody>
                         </table>
                         <!-- PAGINATION -->
-                        {% with view_name='main.search' %}
+                        {% with view_name='main.search_transferring_body', id = request.view_args['_id'] %}
                             {% include "pagination.html" %}
                         {% endwith %}
                     {% endif %}

--- a/app/templates/main/search.html
+++ b/app/templates/main/search.html
@@ -19,7 +19,7 @@
         <div class="govuk-width-container">
             <div class="govuk-grid-row">{% include "top-search.html" %}</div>
             <div class="mobile__search__container-block"></div>
-            <h2 class="govuk-heading-m govuk-heading-m--search-results">Records found {{ num_records_found }}</h2>
+            <h2 class="govuk-heading-m">Records found {{ num_records_found }}</h2>
             <!-- SORT -->
             <div class="govuk-form-group sort-container__form">
                 {% with dict = sorting_list %}

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -309,6 +309,8 @@ def test_expected_unprotected_routes_decorated_by_access_token_sign_in_required(
     """
     expected_protected_routes = [
         "main.search",
+        "main.search_results_summary",
+        "main.search_transferring_body",
         "main.record",
         "main.download_record",
         "main.sign_out",

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -591,7 +591,6 @@ class TestSearch:
         Then they should be redirected to search results summary screen
         with search results summary page content
         """
-
         mock_superuser(client)
 
         form_data = {"query": "fi"}

--- a/e2e_tests/test_search.py
+++ b/e2e_tests/test_search.py
@@ -1,233 +1,245 @@
 from playwright.sync_api import Page, expect
 
 
-def test_search_end_to_end(authenticated_page: Page):
-    """
-    Given a user on the search page
-    When they interact with the search form and submit a query
-    Then the table should contain the expected headers and entries.
-    """
-    authenticated_page.goto("/search")
+class TestSearch:
+    @property
+    def route_url(self):
+        return "/search"
 
-    expect(
-        authenticated_page.get_by_role("heading").get_by_text(
-            "Search", exact=True
+    def test_search_end_to_end(self, authenticated_page: Page):
+        """
+        Given a user on the search page
+        When they interact with the search form and submit a query
+        Then the table should contain the expected headers and entries.
+        """
+        authenticated_page.goto(f"{self.route_url}")
+
+        expect(
+            authenticated_page.get_by_role("heading").get_by_text(
+                "Search", exact=True
+            )
+        ).to_be_visible()
+        expect(
+            authenticated_page.locator("text=Search for digital records")
+        ).to_be_visible()
+
+        # Interact with the search form and submit a query
+        authenticated_page.fill("#searchInput", "Test description")
+        expect(authenticated_page.locator("#searchInput")).to_have_value(
+            "Test description"
         )
-    ).to_be_visible()
-    expect(
-        authenticated_page.locator("text=Search for digital records")
-    ).to_be_visible()
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
 
-    # Interact with the search form and submit a query
-    authenticated_page.fill("#searchInput", "Test description")
-    expect(authenticated_page.locator("#searchInput")).to_have_value(
-        "Test description"
-    )
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-
-    expect(authenticated_page.locator("#searchInput")).not_to_have_value(
-        "Test description"
-    )
-
-    table = authenticated_page.locator("table")
-    # Use JavaScript to extract the text of header elements (th) within the table
-    header_texts = table.evaluate(
-        '(table) => Array.from(table.querySelectorAll("th")).map(th => th.textContent)'
-    )
-    # List of expected header values
-    expected_headers = [
-        "Transferring body",
-        "Series",
-        "Consignment reference",
-        "File name",
-    ]
-    for expected_header in expected_headers:
-        assert expected_header in header_texts
-
-    # Use JavaScript to extract the text of table cell elements (td) within the table
-    cell_texts = table.evaluate(
-        '(table) => Array.from(table.querySelectorAll("td")).map(td => td.textContent)'
-    )
-
-    expected_entries = [
-        "Testing A",
-        "TSTA 1",
-        "TDR-2023-H2QS",
-        "file-a1.txt",
-        "Testing A",
-        "TSTA 1",
-        "TDR-2023-H2QS",
-        "file-a2.txt",
-    ]
-    assert expected_entries == cell_texts
-
-
-def test_pagination_available(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+        expect(authenticated_page.locator("#searchInput")).not_to_have_value(
+            "Test description"
         )
-        == "Pagination"
-    )
 
-
-def test_pagination_check_only_one_page_returned(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Test description")
-    expect(authenticated_page.locator("#searchInput")).to_have_value(
-        "Test description"
-    )
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    pagination_element = authenticated_page.query_selector(
-        "nav.govuk-pagination"
-    )
-    assert not pagination_element
-
-
-def test_pagination_get_first_page(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+        table = authenticated_page.locator("table")
+        # Use JavaScript to extract the text of header elements (th) within the table
+        header_texts = table.evaluate(
+            '(table) => Array.from(table.querySelectorAll("th")).map(th => th.textContent)'
         )
-        == "Pagination"
-    )
-    url = "/search?page=1&query=testing+a"
-    assert (
-        authenticated_page.locator(
-            ".govuk-pagination__link"
-        ).first.get_attribute("href")
-        == url
-    )
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Nextpage"
-    expect(authenticated_page.get_by_text("Records found 5"))
-    rows = authenticated_page.locator(".govuk-table__row").all()
-    assert len(rows) == 6  # including header row
+        # List of expected header values
+        expected_headers = [
+            "Transferring body",
+            "Series",
+            "Consignment reference",
+            "File name",
+        ]
+        for expected_header in expected_headers:
+            assert expected_header in header_texts
 
-
-def test_pagination_get_previous_page(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    page_links = authenticated_page.locator(".govuk-pagination__link").all()
-    authenticated_page.get_by_role("link").get_by_text(
-        page_links[1].inner_text()
-    ).click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+        # Use JavaScript to extract the text of table cell elements (td) within the table
+        cell_texts = table.evaluate(
+            '(table) => Array.from(table.querySelectorAll("td")).map(td => td.textContent)'
         )
-        == "Pagination"
-    )
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Previouspage"
 
+        expected_entries = [
+            "Testing A",
+            "TSTA 1",
+            "TDR-2023-H2QS",
+            "file-a1.txt",
+            "Testing A",
+            "TSTA 1",
+            "TDR-2023-H2QS",
+            "file-a2.txt",
+        ]
+        assert expected_entries == cell_texts
 
-def test_pagination_get_next_page(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+    def test_pagination_available(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
         )
-        == "Pagination"
-    )
-    url = "/search?page=1&query=testing+a"
-    assert (
-        authenticated_page.locator(
-            ".govuk-pagination__link"
-        ).first.get_attribute("href")
-        == url
-    )
-    authenticated_page.get_by_role("link").get_by_text(" 2 ").click()
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Previouspage"
-    if len(links) > 1:
-        assert links[1].inner_text() == "Nextpage"
 
-
-def test_pagination_get_ellipses_page(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+    def test_pagination_check_only_one_page_returned(
+        self, authenticated_page: Page
+    ):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Test description")
+        expect(authenticated_page.locator("#searchInput")).to_have_value(
+            "Test description"
         )
-        == "Pagination"
-    )
-    page_links = authenticated_page.locator(".govuk-pagination__link").all()
-    last_page = page_links[len(page_links) - 1].inner_text()
-    assert page_links[0].inner_text() == "1"
-    assert page_links[1].inner_text() == "2"
-    assert page_links[3].inner_text() == last_page
-    ellipsis_link = authenticated_page.locator(
-        ".govuk-pagination__item--ellipses"
-    ).all()
-    assert ellipsis_link[0].inner_text() == "…"
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Nextpage"
-
-
-def test_pagination_click_previous_link(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        pagination_element = authenticated_page.query_selector(
+            "nav.govuk-pagination"
         )
-        == "Pagination"
-    )
+        assert not pagination_element
 
-    authenticated_page.get_by_role("link").get_by_text(" 2 ").click()
-
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Previouspage"
-
-    url = "/search?page=1&query=testing+a"
-    authenticated_page.expect_response(url)
-
-
-def test_pagination_click_next_link(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+    def test_pagination_get_first_page(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
         )
-        == "Pagination"
-    )
-
-    authenticated_page.get_by_role("link").get_by_text(" 1 ").click()
-
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Nextpage"
-
-    url = "/search?page=2&query=testing+a"
-    authenticated_page.expect_response(url)
-
-
-def test_pagination_get_last_page(authenticated_page: Page):
-    authenticated_page.goto("/search")
-    authenticated_page.fill("#searchInput", "Testing A")
-    authenticated_page.get_by_role("button").get_by_text("Search").click()
-    assert (
-        authenticated_page.locator(".govuk-pagination").first.get_attribute(
-            "aria-label"
+        url = "/search?page=1&query=testing+a"
+        assert (
+            authenticated_page.locator(
+                ".govuk-pagination__link"
+            ).first.get_attribute("href")
+            == url
         )
-        == "Pagination"
-    )
-    page_links = authenticated_page.locator(".govuk-pagination__link").all()
-    last_page = page_links[len(page_links) - 1].inner_text()
-    authenticated_page.get_by_role("link").get_by_text(last_page).click()
-    links = authenticated_page.locator(".govuk-pagination__link-title").all()
-    assert links[0].inner_text() == "Previouspage"
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Nextpage"
+        expect(authenticated_page.get_by_text("Records found 5"))
+        rows = authenticated_page.locator(".govuk-table__row").all()
+        assert len(rows) == 6  # including header row
+
+    def test_pagination_get_previous_page(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        page_links = authenticated_page.locator(".govuk-pagination__link").all()
+        authenticated_page.get_by_role("link").get_by_text(
+            page_links[1].inner_text()
+        ).click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Previouspage"
+
+    def test_pagination_get_next_page(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+        url = "/search?page=1&query=testing+a"
+        assert (
+            authenticated_page.locator(
+                ".govuk-pagination__link"
+            ).first.get_attribute("href")
+            == url
+        )
+        authenticated_page.get_by_role("link").get_by_text(" 2 ").click()
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Previouspage"
+        if len(links) > 1:
+            assert links[1].inner_text() == "Nextpage"
+
+    def test_pagination_get_ellipses_page(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+        page_links = authenticated_page.locator(".govuk-pagination__link").all()
+        last_page = page_links[len(page_links) - 1].inner_text()
+        assert page_links[0].inner_text() == "1"
+        assert page_links[1].inner_text() == "2"
+        assert page_links[3].inner_text() == last_page
+        ellipsis_link = authenticated_page.locator(
+            ".govuk-pagination__item--ellipses"
+        ).all()
+        assert ellipsis_link[0].inner_text() == "…"
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Nextpage"
+
+    def test_pagination_click_previous_link(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+
+        authenticated_page.get_by_role("link").get_by_text(" 2 ").click()
+
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Previouspage"
+
+        url = "/search?page=1&query=testing+a"
+        authenticated_page.expect_response(url)
+
+    def test_pagination_click_next_link(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+
+        authenticated_page.get_by_role("link").get_by_text(" 1 ").click()
+
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Nextpage"
+
+        url = "/search?page=2&query=testing+a"
+        authenticated_page.expect_response(url)
+
+    def test_pagination_get_last_page(self, authenticated_page: Page):
+        authenticated_page.goto(f"{self.route_url}")
+        authenticated_page.fill("#searchInput", "Testing A")
+        authenticated_page.get_by_role("button").get_by_text("Search").click()
+        assert (
+            authenticated_page.locator(".govuk-pagination").first.get_attribute(
+                "aria-label"
+            )
+            == "Pagination"
+        )
+        page_links = authenticated_page.locator(".govuk-pagination__link").all()
+        last_page = page_links[len(page_links) - 1].inner_text()
+        authenticated_page.get_by_role("link").get_by_text(last_page).click()
+        links = authenticated_page.locator(
+            ".govuk-pagination__link-title"
+        ).all()
+        assert links[0].inner_text() == "Previouspage"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

1. created a new search results summary screen
2. created a new search results summary query in queries.py
3. updated search route in routes.py for all access users to redirect on search results summary screen
4. added test cases for build_fuzzy_search_results_summary_query
5. added test cases for search results summary screen in test_search.py

## JIRA ticket

AYR - 761

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
