### PR TITLE
update labels, save groups in session, change default consignment sort

### DIFF
--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -59,6 +59,11 @@ def access_token_sign_in_required(view_func):
                 keycloak_openid = get_keycloak_instance_from_flask_config()
                 decoded_access_token = keycloak_openid.introspect(access_token)
                 session["user_groups"] = decoded_access_token["groups"]
+                ayr_user = AYRUser(session.get("user_groups"))
+                if ayr_user.is_superuser:
+                    session["user_type"] = "superuser"
+                else:
+                    session["user_type"] = "standard_user"
 
             ayr_user = AYRUser(session["user_groups"])
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -87,6 +87,11 @@ def callback():
     session["refresh_token"] = access_token_response["refresh_token"]
     decoded_access_token = keycloak_openid.introspect(session["access_token"])
     session["user_groups"] = decoded_access_token["groups"]
+    ayr_user = AYRUser(session.get("user_groups"))
+    if ayr_user.is_superuser:
+        session["user_type"] = "superuser"
+    else:
+        session["user_type"] = "standard_user"
 
     return redirect(url_for("main.browse"))
 
@@ -310,7 +315,7 @@ def browse_consignment(_id: uuid.UUID):
 
     # set default sort
     if len(sorting_orders) == 0:
-        sorting_orders["closure_type"] = "asc"
+        sorting_orders["date_last_modified"] = "desc"
 
     query = build_browse_consignment_query(
         consignment_id=_id,

--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -24,6 +24,11 @@
   &-form-group {
     &__search-form {
       margin-bottom: 0;
+      margin-right: -8rem;
+
+      @include on-mobile {
+        margin-right: 0;
+      }
     }
   }
 

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -5,13 +5,14 @@
     "consignment": breadcrumb_values[4]["consignment_reference"]
 } %}
 {% set sorting_list = {
-    "Record status (closed first)": "closure_type-asc",
-    "Record status (open first)": "closure_type-desc",
-    "Record opening date (soonest first)": "opening_date-asc",
-    "Date last modified (most recent first)": "date_last_modified-desc",
-    "Date last modified (oldest first)": "date_last_modified-asc",
-    "Record filename (A to Z)": "file_name-asc",
-    "Record filename (Z to A)": "file_name-desc"
+    "Record date (most recent first)": "date_last_modified-desc",
+    "Record date (oldest first)": "date_last_modified-asc",
+    "Filename (A to Z)": "file_name-asc",
+    "Filename (Z to A)": "file_name-desc",
+    "Record opening (sooner)": "opening_date-asc",
+    "Record opening (later)": "opening_date-desc",
+    "Record status (closed)": "closure_type-asc",
+    "Record status (open)": "closure_type-desc"
 } %}
 <!-- BREAD CRUMB -->
 {% with dict = breadcrumbs %}
@@ -31,7 +32,7 @@
             <table class="govuk-table browse-grid__table" id="tbl_result">
                 <thead class="govuk-table__head">
                     <tr class="govuk-table__row">
-                        <th scope="col" class="govuk-table__header">Last modified</th>
+                        <th scope="col" class="govuk-table__header">Record date</th>
                         <th scope="col" class="govuk-table__header">Filename</th>
                         <th scope="col" class="govuk-table__header">Status</th>
                         <th scope="col" class="govuk-table__header">Record opening date</th>
@@ -116,7 +117,7 @@
                                             type="radio" value="date_last_modified" {% if
                                             filters["date_filter_field"]=='date_last_modified' %}checked{% endif %}>
                                             <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
-                                                   for="date_last_modified">File last modified</label>
+                                                   for="date_last_modified">Record date</label>
                                         </div>
                                         <div class="govuk-radios__item">
                                             <input class="govuk-radios__input" id="opening_date" name="date_filter_field" type="radio"
@@ -208,7 +209,7 @@
                                                                         filters["date_filter_field"]=='date_last_modified' %}checked{% endif %}>
                                                                         <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
                                                                                for="date_last_modified">
-                                                                            File last modified
+                                                                            Record date
                                                                         </label>
                                                                     </div>
                                                                     <div class="govuk-radios__item">
@@ -217,7 +218,7 @@
                                                                             %}checked{% endif %}>
                                                                             <label class="govuk-label govuk-radios__label govuk-radios__label--consignment"
                                                                                    for="opening_date">
-                                                                                Closure expiry
+                                                                                Record opening date
                                                                             </label>
                                                                         </div>
                                                                     </div>
@@ -248,9 +249,9 @@
                                         <table class="govuk-table govuk-mobile-table" id="tbl_result">
                                             <thead class="govuk-table__head govuk-mobile-table__head-border">
                                                 <tr class="govuk-table__row">
-                                                    <th scope="col" class="govuk-table__header">Last modified</th>
+                                                    <th scope="col" class="govuk-table__header">Record date</th>
                                                     <th scope="col" class="govuk-table__header govuk-table__header__right">Status</th>
-                                                    <th scope="col" class="govuk-table__header govuk-table__header__right">Closure expiry</th>
+                                                    <th scope="col" class="govuk-table__header govuk-table__header__right">Record opening date</th>
                                                 </tr>
                                             </thead>
                                             <tbody class="govuk-table__body">

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -143,7 +143,7 @@
         <table class="govuk-table govuk-mobile-table" id="tbl_result">
             <thead class="govuk-table__head govuk-mobile-table__head-border">
                 <tr class="govuk-table__row">
-                    <th scope="col" class="govuk-table__header">Series / Last consignment transferred</th>
+                    <th scope="col" class="govuk-table__header">Series / Consignment transferred</th>
                     <th scope="col" class="govuk-table__header govuk-table__header__right">Records in series</th>
                     <th scope="col" class="govuk-table__header govuk-table__header__right">Consignments within series</th>
                 </tr>

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -10,7 +10,7 @@
             <!-- TABLE -->
             <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
                 <div class="browse-details">
-                    <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                    <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
                     <p class="govuk-body browse__body">You are viewing</p>
                     {% if browse_type == "browse" %}
                         {% with view_type='desktop' %}
@@ -44,7 +44,7 @@
                 <!-- TABLE -->
                 <div class="govuk-grid-column-full govuk-grid-column-full--browse">
                     <div class="mobile-details">
-                        <h1 class="govuk-heading-l browse__records-found__text">Records found {{ num_records_found }}</h1>
+                        <h1 class="govuk-heading-l browse__records-found__text">Browse records {{ num_records_found }}</h1>
                         <p class="govuk-body browse__body">You are viewing</p>
                         {% if browse_type == "browse" %}
                             {% with view_type='mobile' %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -188,7 +188,7 @@
                     </dd>
                 </div>
                 <div class="govuk-summary-list__row govuk-summary-list__row--mobile">
-                    <dt class="govuk-summary-list__key govuk-summary-list__key--mobile-table">Date last modified</dt>
+                    <dt class="govuk-summary-list__key govuk-summary-list__key--mobile-table">Record date</dt>
                     <dd class="govuk-summary-list__value govuk-summary-list__value--mobile">
                         {{ record['date_last_modified'] }}
                     </dd>

--- a/app/templates/main/top-search.html
+++ b/app/templates/main/top-search.html
@@ -13,11 +13,11 @@
                         data-module="govuk-button"
                         type="submit">Search</button>
             </div>
-            <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
-            </p>
+            {% if session["user_type"] == "superuser" %}
+                <p class="govuk-body-s">Search by file name, transferring body, series or consignment reference.</p>
+            {% else %}
+                <p class="govuk-body-s">Search by file name, series or consignment reference.</p>
+            {% endif %}
         </form>
     </div>
 </div>

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -30,6 +30,7 @@ def mock_standard_user():
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
             session["user_groups"] = groups
+            session["user_type"] = "standard_user"
 
         mock_ayr_user = ayr_user_patcher.start()
         mock_keycloak = patcher.start()
@@ -63,6 +64,7 @@ def mock_superuser():
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
             session["user_groups"] = groups
+            session["user_type"] = "superuser"
 
         mock_ayr_user = ayr_user_patcher.start()
         mock_keycloak = patcher.start()

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -221,9 +221,10 @@ class TestAccessTokenSignInRequiredDecorator:
             with client.session_transaction() as session:
                 session["access_token"] = "inactive_access_token"
                 session["refresh_token"] = "active_refresh_token"
+                session["user_type"] = "standard_user"
 
             valid_groups = [
-                "/ayr_user_type/view_dept",
+                "/ayr_user_type/view_all",
                 "/transferring_body_user/foo",
             ]
 
@@ -252,6 +253,7 @@ class TestAccessTokenSignInRequiredDecorator:
                     == "new_active_refresh_token"
                 )
                 assert updated_session["user_groups"] == valid_groups
+                assert updated_session["user_type"] == "superuser"
 
     @staticmethod
     @patch(

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -146,7 +146,7 @@ class TestBrowse:
         assert response.status_code == 200
 
         assert b"Search for digital records" in response.data
-        assert b"Records found 27" in response.data
+        assert b"Browse records 27" in response.data
 
     @pytest.mark.parametrize(
         "query_params, expected_results",

--- a/app/tests/test_browse_consignment.py
+++ b/app/tests/test_browse_consignment.py
@@ -16,7 +16,7 @@ def verify_consignment_view_header_row(data):
     headers = table.find_all("th")
     expected_row = (
         [
-            "Last modified",
+            "Record date",
             "Filename",
             "Status",
             "Record opening date",
@@ -108,10 +108,10 @@ class TestConsignment:
                 "",
                 [
                     [
-                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                         "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                         "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'15/01/2023', 'second_file.ppt', 'Open', '-'"
                     ],
                 ],
@@ -120,10 +120,10 @@ class TestConsignment:
                 "date_from_day=01&date_from_month=01&date_from_year=2020",
                 [
                     [
-                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                         "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                         "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'15/01/2023', 'second_file.ppt', 'Open', '-'"
                     ],
                 ],
@@ -132,10 +132,10 @@ class TestConsignment:
                 "date_to_day=10&date_to_month=03&date_to_year=2023",
                 [
                     [
-                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                         "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                         "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'15/01/2023', 'second_file.ppt', 'Open', '-'"
                     ],
                 ],
@@ -145,10 +145,10 @@ class TestConsignment:
                 "&date_to_month=03&date_to_year=2023",
                 [
                     [
-                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
+                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
                         "'12/04/2023', 'fourth_file.xls', 'Closed', '12/04/2023', "
                         "'10/03/2023', 'third_file.docx', 'Closed', '10/03/2023', "
-                        "'20/05/2023', 'fifth_file.doc', 'Open', '-', "
+                        "'25/02/2023', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'15/01/2023', 'second_file.ppt', 'Open', '-'"
                     ],
                 ],

--- a/app/tests/test_record_page.py
+++ b/app/tests/test_record_page.py
@@ -317,9 +317,7 @@ def test_record_top_search(client, mock_superuser):
                         type="submit">Search</button>
             </div>
             <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
+                Search by file name, transferring body, series or consignment reference.
             </p>
         </form>
     </div>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -95,9 +95,7 @@ class TestSearch:
                         type="submit">Search</button>
             </div>
             <p class="govuk-body-s">
-                Search using a record metadata term, for example – transferring body, series,
-                consignment
-                ref etc.
+                Search by file name, transferring body, series or consignment reference.
             </p>
         </form>
     </div>
@@ -136,6 +134,82 @@ class TestSearch:
 
         assert response.status_code == 200
         assert b"Records found 0"
+
+    def test_search_box_standard_user(
+        self, client: FlaskClient, mock_standard_user
+    ):
+        mock_standard_user(client)
+
+        response = client.get(f"{self.route_url}")
+
+        assert response.status_code == 200
+
+        html = response.data.decode()
+
+        search_html = """<div class="search__container govuk-grid-column-full">
+        <div class="search__container__content">
+            <p class="govuk-body search__heading">Search for digital records</p>
+            <form method="get" action="/search">
+                <div class="govuk-form-group govuk-form-group__search-form">
+                    <label for="searchInput"></label>
+                    <input class="govuk-input govuk-!-width-three-quarters"
+                        id="searchInput"
+                        name="query"
+                        type="text" value=""/>
+                    <button class="govuk-button govuk-button__search-button"
+                            data-module="govuk-button"
+                            type="submit">Search</button>
+                </div>
+                <p class="govuk-body-s">
+                    Search by file name, series or consignment reference.
+                </p>
+            </form>
+        </div>
+    </div>"""
+
+        assert_contains_html(
+            search_html,
+            html,
+            "div",
+            {"class": "search__container govuk-grid-column-full"},
+        )
+
+    def test_search_box_super_user(self, client: FlaskClient, mock_superuser):
+        mock_superuser(client)
+
+        response = client.get(f"{self.route_url}")
+
+        assert response.status_code == 200
+
+        html = response.data.decode()
+
+        search_html = """<div class="search__container govuk-grid-column-full">
+        <div class="search__container__content">
+            <p class="govuk-body search__heading">Search for digital records</p>
+            <form method="get" action="/search">
+                <div class="govuk-form-group govuk-form-group__search-form">
+                    <label for="searchInput"></label>
+                    <input class="govuk-input govuk-!-width-three-quarters"
+                        id="searchInput"
+                        name="query"
+                        type="text" value=""/>
+                    <button class="govuk-button govuk-button__search-button"
+                            data-module="govuk-button"
+                            type="submit">Search</button>
+                </div>
+                <p class="govuk-body-s">
+                    Search by file name, transferring body, series or consignment reference.
+                </p>
+            </form>
+        </div>
+    </div>"""
+
+        assert_contains_html(
+            search_html,
+            html,
+            "div",
+            {"class": "search__container govuk-grid-column-full"},
+        )
 
     @pytest.mark.parametrize(
         "query_params, expected_results",

--- a/e2e_tests/test_browse_consignment.py
+++ b/e2e_tests/test_browse_consignment.py
@@ -20,7 +20,7 @@ class TestBrowseConsignment:
         cols = rows.first.locator("td")
 
         assert headers == [
-            "Last modified",
+            "Record date",
             "Filename",
             "Status",
             "Record opening date",
@@ -54,7 +54,7 @@ class TestBrowseConsignment:
         cols = rows.first.locator("td")
 
         assert headers == [
-            "Last modified",
+            "Record date",
             "Filename",
             "Status",
             "Record opening date",


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Last modified > Record date (tables + filters panel)
- Closure expiry > Record opening date (tables + filters panel)
- 'Records found XXX'. >>> Browse records XXX'. (On browse pages)
- SU text changed to "Search by file name, transferring body, series or consignment reference."
- AAU text changed to "Search by file name, series or consignment reference."
- Sort box text updates & consignment default sort changed to record date
- Set group in session on token refresh


## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-718

## Screenshots of UI changes

### Before

### After
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/12565070/42b31d29-45ed-4afd-b75a-ee89e9f591b0)


- [ ] Requires env variable(s) to be updated
