### PR TITLE
filter tray search term styling updated

### DIFF
--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -46,6 +46,26 @@
   }
 }
 
+.button-search-term {
+  border: none;
+  text-decoration: none;
+  background-color: inherit;
+
+  :hover {
+    background-color: #0b0c0c;
+  }
+
+  a {
+    border: none;
+    text-decoration: none;
+    color: #0b0c0c;
+
+    :visited {
+      color: #0b0c0c;
+    }
+  }
+}
+
 .govuk-table__cell {
   &--search-results {
     font-size: 1rem;
@@ -127,13 +147,6 @@
   width: 4rem;
 }
 
-.ayr-filter-tags {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  padding-top: 0.9rem;
-}
-
 img.cancel-filter {
   fill: black;
   width: 20px;
@@ -208,9 +221,32 @@ a.govuk-link {
 }
 
 .close-icon {
-  fill: black; /* This sets the color of the SVG */
-  width: 24px; /* This sets the width of the SVG */
-  height: 24px; /* This sets the height of the SVG */
+  fill: black;
+  width: 24px;
+  height: 24px;
   cursor: pointer;
-  padding-left: 5px; /* Changes the cursor to a pointer when hovering over the SVG */
+  padding-left: 5px;
+}
+
+.ayr-filter-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding-top: 0.9rem;
+
+  :hover {
+    cursor: pointer;
+    background-color: #0b0c0c;
+    color: white;
+
+    a {
+      color: white;
+    }
+
+    img.close-icon {
+      filter: invert(100%) sepia(0%) saturate(7476%) hue-rotate(110deg)
+        brightness(98%) contrast(108%);
+      background-color: white;
+    }
+  }
 }

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -59,6 +59,7 @@
     border: none;
     text-decoration: none;
     color: #0b0c0c;
+    font-size: 1rem;
 
     :visited {
       color: #0b0c0c;
@@ -222,10 +223,10 @@ a.govuk-link {
 
 .close-icon {
   fill: black;
-  width: 24px;
-  height: 24px;
+  width: 1.125rem;
+  height: 1.125rem;
   cursor: pointer;
-  padding-left: 5px;
+  padding-left: 3px;
 }
 
 .ayr-filter-tags {

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -136,14 +136,16 @@
                                             {% else %}
                                                 {% set search_term_url = url_for('main.search_transferring_body', _id = request.view_args['_id'], query=new_query) %}
                                             {% endif %}
-                                            <a href="{{ search_term_url }}">
-                                                {{ search_terms[i] }}
-                                                <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}"
-                                                     height="24px"
-                                                     width="30px"
-                                                     class="close-icon"
-                                                     alt="">
-                                            </a>
+                                            <button type="submit"
+                                                    class="button-search-term"
+                                                    data-module="search-term-button">
+                                                <a href="{{ search_term_url }}">{{ search_terms[i] }}</a>
+                                            </button>
+                                            <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}"
+                                                 height="24px"
+                                                 width="30px"
+                                                 class="close-icon"
+                                                 alt="">
                                         </div>
                                     {% endfor %}
                                 </div>

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -142,8 +142,8 @@
                                                 <a href="{{ search_term_url }}">{{ search_terms[i] }}</a>
                                             </button>
                                             <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}"
-                                                 height="24px"
-                                                 width="30px"
+                                                 height="1rem"
+                                                 width="1rem"
                                                  class="close-icon"
                                                  alt="">
                                         </div>

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -241,7 +241,7 @@ class TestRecord:
         assert response.status_code == 200
 
         html = response.data.decode()
-        breakpoint()
+
         expected_record_summary_html = f"""
         <dl class="govuk-summary-list govuk-summary-list--record">
                         <div class="govuk-summary-list__row"></div>

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -241,7 +241,7 @@ class TestRecord:
         assert response.status_code == 200
 
         html = response.data.decode()
-
+        breakpoint()
         expected_record_summary_html = f"""
         <dl class="govuk-summary-list govuk-summary-list--record">
                         <div class="govuk-summary-list__row"></div>
@@ -282,7 +282,7 @@ class TestRecord:
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Consignment ref.</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Consignment reference</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {file.consignment.ConsignmentReference}
                 </dd>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1205,49 +1205,53 @@ class TestSearchTransferringBody:
 
         search_filter_html = f"""
         <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters">
-           <div class="search-all-filter-container">
-              <div class="browse-filter__header">
-                 <h2 class="govuk-heading-m govuk-heading-m--search">Search within results</h2>
-              </div>
-              <div class="govuk-form-group govuk-form-group--search-all-filter">
-                  <label class="govuk-label" for="search_filter"></label>
-                  <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
-                        id="search_filter"
-                        name="search_filter"
-                        type="text">
-              </div>
-              <div class="search-form__buttons">
-              <button type="submit"
-                    class="govuk-button govuk-button__search-filters-form-apply-button"
-                    data-module="govuk-button">Apply</button>
-              <a class="govuk-link govuk-link--transferring-filter"
-                href="{self.route_url}/{transferring_body_id}">Clear all</a>
-              </div>
-              <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
-              <div class="ayr-filter-tags">
-                 <div class="search-term">
-                    <a href="{self.route_url}/{transferring_body_id}?query={term2}">
-                         {term1}
-                         <img src="/assets/image/cancel-filters.svg"
-                             height="24px"
-                             width="30px"
-                             class="close-icon"
-                             alt="">
-                    </a>
-                 </div>
-                 <div class="search-term">
-                    <a href="{self.route_url}/{transferring_body_id}?query={term1}">
-                         {term2}
-                         <img src="/assets/image/cancel-filters.svg"
-                             height="24px"
-                             width="30px"
-                             class="close-icon"
-                             alt="">
-                     </a>
-                 </div>
-              </div>
-           </div>
-        </div>"""
+                            <div class="search-all-filter-container">
+                                <div class="browse-filter__header">
+                                    <h2 class="govuk-heading-m govuk-heading-m--search">Search within results</h2>
+                                </div>
+                                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                                    <label class="govuk-label" for="search_filter"></label>
+                                    <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
+                                    id="search_filter"
+                                    name="search_filter"
+                                    type="text">
+                                </div>
+                                <div class="search-form__buttons">
+                                    <button type="submit"
+                                    class="govuk-button govuk-button__search-filters-form-apply-button"
+                                    data-module="govuk-button">Apply</button>
+                                    <a class="govuk-link govuk-link--transferring-filter"
+                                    href="{self.route_url}/{transferring_body_id}">Clear all</a>
+                                </div>
+                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+                                <div class="ayr-filter-tags">
+                                        <div class="search-term">
+                                            <button type="submit"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                        <a href="{self.route_url}/{transferring_body_id}?query={term2}">{term1}</a>
+                                            </button>
+                                            <img src="/assets/image/cancel-filters.svg"
+                                            height="1rem"
+                                            width="1rem"
+                                            class="close-icon"
+                                            alt="">
+                                        </div>
+                                        <div class="search-term">
+                                            <button type="submit"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                            <a href="{self.route_url}/{transferring_body_id}?query={term1}">{term2}</a>
+                                            </button>
+                                            <img src="/assets/image/cancel-filters.svg"
+                                            height="1rem"
+                                            width="1rem"
+                                            class="close-icon"
+                                            alt="">
+                                        </div>
+                                </div>
+                            </div>
+                        </div>"""
 
         assert_contains_html(
             search_filter_html,
@@ -1291,37 +1295,41 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         search_filter_html = f"""<div class="ayr-filter-tags">
-                 <div class="search-term">
-                    <a href="{self.route_url}/{transferring_body_id}?query={term2},{term3}">
-                         {term1}
-                         <img src="/assets/image/cancel-filters.svg"
-                             height="24px"
-                             width="30px"
-                             class="close-icon"
-                             alt="">
-                    </a>
-                 </div>
-                 <div class="search-term">
-                    <a href="{self.route_url}/{transferring_body_id}?query={term1},{term3}">
-                         {term2}
-                         <img src="/assets/image/cancel-filters.svg"
-                             height="24px"
-                             width="30px"
-                             class="close-icon"
-                             alt="">
-                     </a>
-                 </div>
-                 <div class="search-term">
-                    <a href="{self.route_url}/{transferring_body_id}?query={term1},{term2}">
-                         {term3}
-                         <img src="/assets/image/cancel-filters.svg"
-                             height="24px"
-                             width="30px"
-                             class="close-icon"
-                             alt="">
-                    </a>
-                 </div>
-              </div>"""
+                                        <div class="search-term">
+                                            <button type="submit"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                    <a href="{self.route_url}/{transferring_body_id}?query={term2},{term3}">{term1}</a>
+                                            </button>
+                                            <img src="/assets/image/cancel-filters.svg"
+                                            height="1rem"
+                                            width="1rem"
+                                            class="close-icon"
+                                            alt="">
+                                        </div>
+                                        <div class="search-term">
+                                            <button type="submit"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                    <a href="{self.route_url}/{transferring_body_id}?query={term1},{term3}">{term2}</a>
+                                            </button>
+                                            <img src="/assets/image/cancel-filters.svg"
+                                            height="1rem"
+                                            width="1rem"
+                                            class="close-icon"
+                                            alt="">
+                                        </div>
+                                        <div class="search-term">
+                                            <button type="submit"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                    <a href="{self.route_url}/{transferring_body_id}?query={term1},{term2}">{term3}</a>
+                                            </button>
+                                            <img src="/assets/image/cancel-filters.svg"
+                                            height="1rem"
+                                            width="1rem"
+                                            class="close-icon"
+                                            alt="">"""
 
         assert_contains_html(
             search_filter_html,


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Updated the filter tray, specifically the search term box styling. 
- When a users' cursor hovers on the search term box it turns black, and so does the cancel-filter icon. 
- Updated search-.py test cases on the search filter tray. 
- Fixed record.py test (test_record_summary_list_open_file) 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-780
## Screenshots of UI changes

### Before
<img width="330" alt="Screenshot 2024-03-05 at 18 05 17" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/2135710c-2cd0-4a1c-b9ea-8db6f231d3ef">

### After
<img width="348" alt="Screenshot 2024-03-05 at 18 05 25" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/8519c2cc-6d7c-45b7-a999-58c9530f9e66">

- [ ] Requires env variable(s) to be updated
