### PR TITLE
Downloaded file's filename is citeable reference, fallbacks to filename

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -557,7 +557,10 @@ def download_record(record_id: uuid.UUID):
 
     response = Response(
         s3_file_object["Body"].read(),
-        headers={"Content-Disposition": "attachment;filename=" + file.FileName},
+        headers={
+            "Content-Disposition": "attachment;filename="
+            + (file.CiteableReference or file.FileName)
+        },
     )
 
     return response


### PR DESCRIPTION
## Changes in this PR

- Make downloaded file's filename be the file's citeable reference if it exists, otherwise fallback to filename

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-646