### PR TITLE
Replace superuser with all_access_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,13 +397,13 @@ This also will generate a test coverage report.
 We have 2 fixtures used for mocking a user and their permissions in our non end to end, flask tests:
 
 - `mock_standard_user`
-- `mock_superuser`
+- `mock_all_access_user`
 
 which can be called like
 
 `mock_standard_user(client, "foo")`
 
-`mock_superuser(client)`
+`mock_all_access_user(client)`
 
 respectively.
 
@@ -412,13 +412,13 @@ These mock the `get_user_groups` permissions helper which abstracts away the ext
 - `mock_standard_user` gives the user and results in an AYRUser where:
   - `can_access_ayr`: True
   - `is_standard_user`: True
-  - `is_superuser`: False
+  - `is_all_access_user`: False
   - `transferring_bodies`: same list as pass in as second arg to mock_standard_user
 
 - `mock_standard_user` gives the user and results in an AYRUser where:
   - `can_access_ayr`: True
   - `is_standard_user`: False
-  - `is_superuser`: True
+  - `is_all_access_user`: True
   - `transferring_bodies`: None
 
 ### End To End Tests

--- a/app/main/authorize/access_token_sign_in_required.py
+++ b/app/main/authorize/access_token_sign_in_required.py
@@ -60,8 +60,8 @@ def access_token_sign_in_required(view_func):
                 decoded_access_token = keycloak_openid.introspect(access_token)
                 session["user_groups"] = decoded_access_token["groups"]
                 ayr_user = AYRUser(session.get("user_groups"))
-                if ayr_user.is_superuser:
-                    session["user_type"] = "superuser"
+                if ayr_user.is_all_access_user:
+                    session["user_type"] = "all_access_user"
                 else:
                     session["user_type"] = "standard_user"
 

--- a/app/main/authorize/ayr_user.py
+++ b/app/main/authorize/ayr_user.py
@@ -14,10 +14,10 @@ class AYRUser:
 
     @property
     def can_access_ayr(self):
-        return self.is_superuser or self.is_standard_user
+        return self.is_all_access_user or self.is_standard_user
 
     @property
-    def is_superuser(self) -> bool:
+    def is_all_access_user(self) -> bool:
         return "/ayr_user_type/view_all" in self.groups
 
     @property

--- a/app/main/authorize/permissions_helpers.py
+++ b/app/main/authorize/permissions_helpers.py
@@ -18,7 +18,7 @@ def validate_body_user_groups_or_404(
     """
     ayr_user = AYRUser(session.get("user_groups"))
 
-    if ayr_user.is_superuser:
+    if ayr_user.is_all_access_user:
         return
 
     if transferring_body_name != ayr_user.transferring_body.Name:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -89,8 +89,8 @@ def callback():
     decoded_access_token = keycloak_openid.introspect(session["access_token"])
     session["user_groups"] = decoded_access_token["groups"]
     ayr_user = AYRUser(session.get("user_groups"))
-    if ayr_user.is_superuser:
-        session["user_type"] = "superuser"
+    if ayr_user.is_all_access_user:
+        session["user_type"] = "all_access_user"
     else:
         session["user_type"] = "standard_user"
 
@@ -116,7 +116,7 @@ def browse():
             f"/browse/transferring_body/{ayr_user.transferring_body.BodyId}"
         )
     else:
-        # all access user (superuser)
+        # all access user (all_access_user)
         for body in Body.query.all():
             transferring_bodies.append(body.Name)
 

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -1,5 +1,5 @@
 {% set breadcrumbs = {} %}
-{% if session["user_type"] == "superuser" %}
+{% if session["user_type"] == "all_access_user" %}
     {%- set _ = breadcrumbs.update({'everything': "Everything"}) -%}
     {%- set _ = breadcrumbs.update({'summary': [breadcrumb_values[0]["query"], "Results summary"]}) -%}
 {% endif %}

--- a/app/templates/main/top-search.html
+++ b/app/templates/main/top-search.html
@@ -13,7 +13,7 @@
                         data-module="govuk-button"
                         type="submit">Search</button>
             </div>
-            {% if session["user_type"] == "superuser" %}
+            {% if session["user_type"] == "all_access_user" %}
                 <p class="govuk-body-s">Search by file name, transferring body, series or consignment reference.</p>
             {% else %}
                 <p class="govuk-body-s">Search by file name, series or consignment reference.</p>

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -51,20 +51,20 @@ def mock_standard_user():
 
 
 @pytest.fixture(scope="function")
-def mock_superuser():
+def mock_all_access_user():
     ayr_user_patcher = patch("app.main.authorize.permissions_helpers.AYRUser")
     patcher = patch(
         "app.main.authorize.access_token_sign_in_required.get_keycloak_instance_from_flask_config"
     )
 
-    def _mock_superuser(client: FlaskClient):
+    def _mock_all_access_user(client: FlaskClient):
         groups = ["/ayr_user_type/view_all"]
 
         with client.session_transaction() as session:
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
             session["user_groups"] = groups
-            session["user_type"] = "superuser"
+            session["user_type"] = "all_access_user"
 
         mock_ayr_user = ayr_user_patcher.start()
         mock_keycloak = patcher.start()
@@ -75,7 +75,7 @@ def mock_superuser():
             "groups": groups,
         }
 
-    yield _mock_superuser
+    yield _mock_all_access_user
 
     ayr_user_patcher.stop()
     patcher.stop()

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -253,7 +253,7 @@ class TestAccessTokenSignInRequiredDecorator:
                     == "new_active_refresh_token"
                 )
                 assert updated_session["user_groups"] == valid_groups
-                assert updated_session["user_type"] == "superuser"
+                assert updated_session["user_type"] == "all_access_user"
 
     @staticmethod
     @patch(

--- a/app/tests/test_ayr_user.py
+++ b/app/tests/test_ayr_user.py
@@ -7,24 +7,24 @@ class TestAYRUser:
         groups = ["/ayr_user_type/view_dept"]
         user = AYRUser(groups)
         assert user.is_standard_user
-        assert not user.is_superuser
+        assert not user.is_all_access_user
 
     def test_type_of_user_when_ayr_user_type_view_all_group(self):
         groups = ["/ayr_user_type/view_all"]
         user = AYRUser(groups)
-        assert user.is_superuser
+        assert user.is_all_access_user
         assert not user.is_standard_user
 
     def test_type_of_user_when_no_valid_ayr_user_group(self):
         groups = ["/ayr_user_type/foo"]
         user = AYRUser(groups)
-        assert not user.is_superuser
+        assert not user.is_all_access_user
         assert not user.is_standard_user
 
-    def test_can_access_ayr_when_superuser_and_no_bodies(self):
+    def test_can_access_ayr_when_all_access_user_and_no_bodies(self):
         groups = ["/ayr_user_type/view_all"]
         user = AYRUser(groups)
-        assert user.is_superuser
+        assert user.is_all_access_user
         assert user.transferring_body is None
         assert user.can_access_ayr
 
@@ -36,10 +36,10 @@ class TestAYRUser:
         assert user.transferring_body == body
         assert user.can_access_ayr
 
-    def test_cannot_access_ayr_when_superuser_and_some_bodies(self, app):
+    def test_cannot_access_ayr_when_all_access_user_and_some_bodies(self, app):
         groups = ["/ayr_user_type/view_all", "/transferring_body_user/foo"]
         user = AYRUser(groups)
-        assert user.is_superuser
+        assert user.is_all_access_user
         assert user.transferring_body is None
         assert user.can_access_ayr
 
@@ -74,7 +74,7 @@ class TestAYRUser:
         user = AYRUser(groups)
         assert user.transferring_body is None
 
-    def test_when_superuser_transferring_bodies_is_none(self, client):
+    def test_when_all_access_user_transferring_bodies_is_none(self, client):
         groups = ["/ayr_user_type/view_all", "/transferring_body_user/foo"]
         user = AYRUser(groups)
         assert user.transferring_body is None

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -76,13 +76,13 @@ class TestBrowse:
             "Location"
         ] == self.transferring_body_route_url + "/" + str(body.BodyId)
 
-    def test_browse_get_view(self, client: FlaskClient, mock_superuser):
+    def test_browse_get_view(self, client: FlaskClient, mock_all_access_user):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request
         Then they should see the browse page content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         response = client.get(f"{self.route_url}")
 
@@ -91,16 +91,16 @@ class TestBrowse:
         assert b"You are viewing" in response.data
         assert b"Everything available to you" in response.data
 
-    def test_browse_check_transferring_bodies_list_filled_for_super_user(
-        self, client: FlaskClient, browse_files, mock_superuser
+    def test_browse_check_transferring_bodies_list_filled_for_all_access_user(
+        self, client: FlaskClient, browse_files, mock_all_access_user
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request
         Then they should see the browse page content
         and transferring body dropdown will be filled with list of all transferring bodies available in database
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         response = client.get(f"{self.route_url}")
 
@@ -131,14 +131,14 @@ class TestBrowse:
         )
 
     def test_browse_submit_search_query(
-        self, client: FlaskClient, mock_superuser, browse_files
+        self, client: FlaskClient, mock_all_access_user, browse_files
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a POST request
         Then they should see results in content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         query = "test"
         response = client.get(f"{self.route_url}", data={"query": query})
@@ -405,13 +405,13 @@ class TestBrowse:
     def test_browse_full_test(
         self,
         client: FlaskClient,
-        mock_superuser,
+        mock_all_access_user,
         browse_files,
         query_params,
         expected_results,
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request
         and provide different filter values
         and sorting orders (asc, desc)
@@ -419,7 +419,7 @@ class TestBrowse:
         matching filter value(s) and the result sorted in sorting order
         on browse page content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         response = client.get(f"{self.route_url}?{query_params}")
 
@@ -429,15 +429,15 @@ class TestBrowse:
         verify_data_rows(response.data, expected_results)
 
     def test_browse_display_first_page(
-        self, client: FlaskClient, app, mock_superuser, browse_files
+        self, client: FlaskClient, app, mock_all_access_user, browse_files
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request with page as a query string parameter
         Then they should see first page with five records on browse page content
         (excluding previous and incl. next page option).
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         app.config["DEFAULT_PAGE_SIZE"] = 2
 
@@ -465,14 +465,14 @@ class TestBrowse:
         assert next_option.text.replace("\n", "").strip("") == "Nextpage"
 
     def test_browse_display_middle_page(
-        self, client: FlaskClient, app, mock_superuser, browse_files
+        self, client: FlaskClient, app, mock_all_access_user, browse_files
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request with page as a query string parameter
         Then they should see first page with five records on browse page content (incl. previous and next page options).
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         app.config["DEFAULT_PAGE_SIZE"] = 2
 
@@ -507,15 +507,15 @@ class TestBrowse:
         )
 
     def test_browse_display_last_page(
-        self, client: FlaskClient, app, mock_superuser, browse_files
+        self, client: FlaskClient, app, mock_all_access_user, browse_files
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request with page as a query string parameter
         Then they should see last page with n records on browse page content
         (incl. previous and excluding next page option).
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         app.config["DEFAULT_PAGE_SIZE"] = 2
 
@@ -546,14 +546,14 @@ class TestBrowse:
         assert not next_option
 
     def test_browse_display_multiple_pages(
-        self, client: FlaskClient, app, mock_superuser, browse_files
+        self, client: FlaskClient, app, mock_all_access_user, browse_files
     ):
         """
-        Given a superuser accessing the browse page
+        Given an all_access_user accessing the browse page
         When they make a GET request with page as a query string parameter
         Then they should see first page with five records on browse page content (incl. previous and next page options).
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         app.config["DEFAULT_PAGE_SIZE"] = 2
 

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -114,13 +114,13 @@ def test_raises_404_for_user_without_access_to_files_transferring_body(
 
 
 @mock_aws
-def test_downloads_record_successfully_for_superuser(
-    app, client, mock_superuser
+def test_downloads_record_successfully_for_all_access_user(
+    app, client, mock_all_access_user
 ):
     """
     Given a File in the database
-    And a superuser
-    When the superuser makes a request to download record
+    And an all_access_user
+    When the all_access_user makes a request to download record
     Then the response status code should be 200
     """
     bucket_name = "test_bucket"
@@ -130,7 +130,7 @@ def test_downloads_record_successfully_for_superuser(
     create_mock_s3_bucket_with_object(bucket_name, file)
     app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-    mock_superuser(client)
+    mock_all_access_user(client)
     response = client.get(f"/download/{file.FileId}")
 
     assert response.status_code == 200

--- a/app/tests/test_permissions_helpers.py
+++ b/app/tests/test_permissions_helpers.py
@@ -38,14 +38,14 @@ def test_raises_404_for_body_name_in_database_but_user_does_not_have_access_to(
         validate_body_user_groups_or_404("foo")
 
 
-def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_for_superuser(
-    client, mock_superuser
+def test_does_not_raise_404_for_body_name_not_in_database_or_assigned_to_user_for_all_access_user(
+    client, mock_all_access_user
 ):
     """
-    Given a superuser
+    Given an all_access_user
     When validate_body_user_groups_or_404 is called with any body name, e.g. 'foo'
     Then the function should not raise a 404 exception
     """
-    mock_superuser(client)
+    mock_all_access_user(client)
 
     validate_body_user_groups_or_404("foo")

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -30,7 +30,7 @@ class TestRecord:
         assert response.status_code == 404
 
     def test_record_top_search(
-        self, client: FlaskClient, mock_superuser, record_files
+        self, client: FlaskClient, mock_all_access_user, record_files
     ):
         """
         Given a File in the database
@@ -39,7 +39,7 @@ class TestRecord:
         And the HTML content should show top search component
         on the page
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         file = record_files[0]["file_object"]
 

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -73,15 +73,15 @@ class TestSearchRedirect:
     def route_url(self):
         return "/search"
 
-    def test_search_route_redirect_superuser(
-        self, client: FlaskClient, mock_superuser
+    def test_search_route_redirect_all_access_user(
+        self, client: FlaskClient, mock_all_access_user
     ):
         """
-        Given a superuser accessing the search route
+        Given an all_access_user accessing the search route
         When they make a GET request
         Then they should see the search results summary page content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         query = "fi"
         form_data = {"query": query}
@@ -132,26 +132,28 @@ class TesthSearchResultsSummary:
         return "/browse"
 
     def test_search_results_summary_get(
-        self, client: FlaskClient, mock_superuser
+        self, client: FlaskClient, mock_all_access_user
     ):
         """
-        Given a superuser accessing the search results summary page
+        Given an all_access_user accessing the search results summary page
         When they make a GET request
         Then they should see the search form and page content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
         response = client.get(f"{self.route_url}")
 
         assert response.status_code == 200
         assert b"Search for digital records" in response.data
 
-    def test_search_results_summary_top_search(self, client, mock_superuser):
+    def test_search_results_summary_top_search(
+        self, client, mock_all_access_user
+    ):
         """
-        Given a superuser accessing the search results summary page
+        Given an all_access_user accessing the search results summary page
         When they make a GET request
         Then they should see the top search component available on search page content.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         response = client.get(f"{self.route_url}")
 
@@ -188,14 +190,14 @@ class TesthSearchResultsSummary:
         )
 
     def test_search_results_summary_no_query(
-        self, client: FlaskClient, mock_superuser
+        self, client: FlaskClient, mock_all_access_user
     ):
         """
-        Given a superuser accessing the search results summary page
+        Given an all_access_user accessing the search results summary page
         When they make a GET request without a query
         Then they should not see any results on the page.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
         form_data = {"foo": "bar"}
         response = client.get(f"{self.route_url}", data=form_data)
 
@@ -203,14 +205,14 @@ class TesthSearchResultsSummary:
         assert b"records found" not in response.data
 
     def test_search_results_summary_with_no_results(
-        self, client: FlaskClient, mock_superuser
+        self, client: FlaskClient, mock_all_access_user
     ):
         """
-        Given a superuser with a search results summary query
+        Given an all_access_user with a search results summary query
         When they make a request on the search results summary page, and no results are found
         Then they should see not see any results on the page.
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         form_data = {"query": "bar"}
         response = client.get(f"{self.route_url}", data=form_data)
@@ -219,15 +221,18 @@ class TesthSearchResultsSummary:
         assert b"Records found 0"
 
     def test_search_results_summary_with_results_single_term(
-        self, client: FlaskClient, mock_superuser, browse_consignment_files
+        self,
+        client: FlaskClient,
+        mock_all_access_user,
+        browse_consignment_files,
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search results summary page with the single search term
         Then they should be redirected to search results summary screen
         with search results summary page content
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         form_data = {"query": "fi"}
 
@@ -245,15 +250,18 @@ class TesthSearchResultsSummary:
         verify_data_rows(response.data, expected_rows)
 
     def test_search_results_summary_with_results_multiple_terms(
-        self, client: FlaskClient, mock_superuser, browse_consignment_files
+        self,
+        client: FlaskClient,
+        mock_all_access_user,
+        browse_consignment_files,
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search results summary page with the single search term
         Then they should be redirected to search results summary screen
         with search results summary page content
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         form_data = {"query": "fi, body"}
 
@@ -271,16 +279,19 @@ class TesthSearchResultsSummary:
         verify_data_rows(response.data, expected_rows)
 
     def test_search_results_summary_breadcrumbs(
-        self, client: FlaskClient, mock_superuser, browse_consignment_files
+        self,
+        client: FlaskClient,
+        mock_all_access_user,
+        browse_consignment_files,
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search results summary page with the search term
         Then they should be redirected to search results summary screen
         and see breadcrumb values Everything > Results summary
         with search results summary page content
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         form_data = {"query": "fi"}
 
@@ -927,17 +938,20 @@ class TestSearchTransferringBody:
         )
         assert not next_option
 
-    def test_search_transferring_body_breadcrumbs_superuser_single_term(
-        self, client: FlaskClient, mock_superuser, browse_consignment_files
+    def test_search_transferring_body_breadcrumbs_all_access_user_single_term(
+        self,
+        client: FlaskClient,
+        mock_all_access_user,
+        browse_consignment_files,
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search transferring body page with the search term
         Then they should be redirected to search transferring body screen
         with search results summary page content
         and see a bread crumbs rendered as Everything > Results summary > Transferring body > ‘Search term’
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         query = "fi"
         form_data = {"query": query}
@@ -979,17 +993,20 @@ class TestSearchTransferringBody:
             {"class": "govuk-breadcrumbs"},
         )
 
-    def test_search_transferring_body_breadcrumbs_superuser_multiple_terms(
-        self, client: FlaskClient, mock_superuser, browse_consignment_files
+    def test_search_transferring_body_breadcrumbs_all_access_user_multiple_terms(
+        self,
+        client: FlaskClient,
+        mock_all_access_user,
+        browse_consignment_files,
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search transferring body page with the search term
         Then they should be redirected to search transferring body screen
         with search results summary page content
         and see a bread crumbs rendered as Everything > Results summary > Transferring body > ‘Search term’
         """
-        mock_superuser(client)
+        mock_all_access_user(client)
 
         term1 = "fi"
         term2 = "second"
@@ -1131,7 +1148,7 @@ class TestSearchTransferringBody:
         self, client: FlaskClient, mock_standard_user, browse_consignment_files
     ):
         """
-        Given a superuser
+        Given an all_access_user
         When they make a request on the search transferring body page with the search term
         Then they should be redirected to search transferring body screen
         with search results summary page content

--- a/app/tests/test_sign_in.py
+++ b/app/tests/test_sign_in.py
@@ -19,7 +19,7 @@ def test_sign_in(mock_keycloak, client):
 
 
 @patch("app.main.routes.get_keycloak_instance_from_flask_config")
-def test_callback_route_superuser(mock_keycloak, client):
+def test_callback_route_all_access_user(mock_keycloak, client):
     mock_keycloak.return_value.token.return_value = {
         "access_token": "valid_access_token",
         "refresh_token": "valid_refresh_token",
@@ -39,7 +39,7 @@ def test_callback_route_superuser(mock_keycloak, client):
 
     with client.session_transaction() as sess:
         assert "user_type" in sess
-        assert sess["user_type"] == "superuser"
+        assert sess["user_type"] == "all_access_user"
 
 
 @patch("app.main.routes.get_keycloak_instance_from_flask_config")


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Replace references to superuser with all_access_user to be in line with the naming we want for this user type (as outlined by the keycloak group name we use for it).

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-764