### PR TITLE
AYR-806- bug fix for links for series and consignment view on search transferring body page 

### DIFF
--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -73,10 +73,10 @@
                                     {% for record in results %}
                                         <tr class="govuk-table__row">
                                             <td class="govuk-table__cell govuk-table__cell--search-results">
-                                                <a href="{{ url_for('main.browse', series_id=record['series_id']) }}">{{ record["series"] }}</a>
+                                                <a href="{{ url_for('main.browse_series', _id=record['series_id']) }}">{{ record["series"] }}</a>
                                             </td>
                                             <td class="govuk-table__cell govuk-table__cell--search-results govuk-table__cell--search-results-no-wrap">
-                                                <a href="{{ url_for('main.browse', consignment_id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
+                                                <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
                                             </td>
                                             <td class="govuk-table__cell govuk-table__cell--search-results">
                                                 <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>


### PR DESCRIPTION
…erring-body.html

<!-- Amend as appropriate -->

## Changes in this PR

in search-transferring-body template, fixed links for series and consignment to redirect the user to correct route

## JIRA ticket

AYR -806

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
