### PR TITLE
Ayr 785/record desktop and mobile view styling

### DIFF
--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -460,7 +460,7 @@
   }
 
   .govuk-summary-list__row {
-    display: flex;
+    /* display: flex; */
     flex-wrap: wrap;
     justify-content: space-between;
   }

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -228,6 +228,34 @@
     flex-direction: column;
     margin-top: 0;
   }
+
+  .govuk-grid-column-two-thirds {
+    &--record-table {
+      display: flex;
+      flex-direction: column;
+      width: 100% !important;
+      order: 4;
+    }
+  }
+
+  .govuk-summary-list {
+    &--record {
+      table-layout: auto;
+    }
+
+    &__key--record-table {
+      white-space: nowrap;
+      width: 0;
+      text-align: left;
+      font-size: 1rem;
+      margin-left: 0;
+    }
+
+    &__value--record {
+      font-size: 1rem;
+      text-align: left;
+    }
+  }
 }
 
 // DISABLE MOBILE STYLES //
@@ -235,49 +263,46 @@
 //  MOBILE STYLES //
 
 @media screen and (width <=810px) {
+  .govuk-grid-column-two-thirds {
+    &--record-table {
+      display: flex;
+      flex-direction: column;
+      width: 100% !important;
+      order: 4;
+    }
+  }
+
   .govuk-grid-column-full__page-nav {
     order: 2;
     margin-bottom: 0.5rem;
     padding-left: 2rem;
   }
 
-  .govuk-grid-row {
-    &--mobile {
-      display: flex;
-      flex-direction: column;
-    }
-  }
-
-  .govuk-grid-column-two-thirds {
-    &--record-table {
-      display: flex;
-      flex-direction: column;
-      width: 100%;
-      order: 4;
-    }
-  }
-
   .govuk-summary-list {
-    &--record-mobile {
-      display: auto;
+    &__row {
+      &--mobile {
+        table-layout: auto;
+      }
     }
 
     &__key--mobile-table {
       white-space: nowrap;
       width: 0;
-      text-align: right;
+      text-align: left;
       font-size: 1rem;
+      margin-left: 0;
     }
 
     &__value--mobile {
       font-size: 1rem;
+      text-align: left;
     }
+  }
 
-    &__row--mobile {
-      /* &:last-child {
-        border-bottom: 2px solid #000;
-      } */
-      display: block;
+  .govuk-grid-row {
+    &--mobile {
+      display: flex;
+      flex-direction: column;
     }
   }
 
@@ -349,5 +374,49 @@
 
   .search__container__content {
     margin-top: 0;
+  }
+}
+
+@media (640px <= width <= 400px) {
+  .govuk-grid-column-two-thirds {
+    &--record-table {
+      display: flex;
+      flex-direction: column;
+      width: 100% !important;
+      order: 4;
+    }
+  }
+
+  .govuk-grid-row {
+    &--mobile {
+      display: flex;
+      flex-direction: column;
+    }
+  }
+
+  .govuk-summary-list {
+    &__row {
+      &--mobile {
+        display: table;
+        width: 100% !important;
+        table-layout: fixed;
+        border-collapse: collapse;
+        margin-bottom: 10px;
+      }
+    }
+
+    &__key--mobile-table {
+      white-space: nowrap;
+      width: 0;
+      text-align: left;
+      font-size: 1rem;
+      margin-left: 0;
+    }
+
+    &__value--mobile {
+      font-size: 1rem;
+      text-align: left;
+      display: table-cell;
+    }
   }
 }

--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -108,7 +108,7 @@
   &__key--record-table {
     white-space: nowrap;
     width: 0;
-    text-align: right;
+    text-align: left;
     font-size: 1rem;
     margin-left: 0;
   }
@@ -118,11 +118,11 @@
     text-align: left;
   }
 
-  &__row--record {
+  /* &__row--record {
     &:last-child {
       border-bottom: 2px solid #000;
     }
-  }
+  } */
 }
 
 .rights-container {
@@ -193,20 +193,22 @@
   &--red {
     font-size: 1rem;
     text-transform: capitalize;
-    color: #000;
-    font-weight: 100;
+    color: #942514;
+    font-weight: 400;
+    letter-spacing: 0;
   }
 
   &--green {
     font-size: 1rem;
     text-transform: capitalize;
-    color: #000;
-    font-weight: 100;
+    color: #005a30;
+    font-weight: 400;
+    letter-spacing: 0;
   }
 }
 
-.record-page {
-  margin-top: -2rem;
+.ayr-opening-date {
+  padding-left: 1rem;
 }
 
 /* Default styles for desktop */
@@ -272,9 +274,9 @@
     }
 
     &__row--mobile {
-      &:last-child {
+      /* &:last-child {
         border-bottom: 2px solid #000;
-      }
+      } */
       display: block;
     }
   }

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -23,7 +23,7 @@
                             {% if dict.get('opening_date') %}<span>Record opening date {{ dict.get('opening_date') }}</span>{% endif %}
                         {% endif %}
                     {% else %}
-                        —
+                        <span>Not provided</span>
                     {% endif %}
                 </dd>
             </div>
@@ -43,7 +43,7 @@
                             {{ value }}
                         {% endif %}
                     {% else %}
-                        —
+                        <span>Not provided</span>
                     {% endif %}
                 </dd>
             </div>

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -1,12 +1,21 @@
 {% for key, value in dict.items() %}
     {% if key != "opening_date" %}
-        <div class="govuk-summary-list__row govuk-summary-list__row--record">
-            <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">{{ key }}</dt>
-            <dd class="govuk-summary-list__value govuk-summary-list__value--record">
-                {% if value %}
-                    {% if key == "Status" %}
-                        {% if (value | lower == "closed") %}
-                            <span class="govuk-tag govuk-tag--red"><strong>{{ value }}</strong></span>
+        {% if view_type == "desktop" %}
+            <div class="govuk-summary-list__row govuk-summary-list__row--record">
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">{{ key }}</dt>
+                <dd class="govuk-summary-list__value govuk-summary-list__value--record">
+                    {% if value %}
+                        {% if key == "Status" %}
+                            {% if (value | lower == "closed") %}
+                                <span class="govuk-tag govuk-tag--red">{{ value }}</span>
+                            {% else %}
+                                <span class="govuk-tag govuk-tag--green">{{ value }}</span>
+                            {% endif %}
+                            {% if dict.get("Closure start date") %}
+                                {% if dict.get('opening_date') %}
+                                    <span class="ayr-opening-date">Record opening date {{ dict.get('opening_date') }}</span>
+                                {% endif %}
+                            {% endif %}
                         {% else %}
                             <span class="govuk-tag govuk-tag--green"><strong>{{ value }}</strong></span>
                         {% endif %}
@@ -14,12 +23,30 @@
                             {% if dict.get('opening_date') %}<span>Record opening date {{ dict.get('opening_date') }}</span>{% endif %}
                         {% endif %}
                     {% else %}
-                        {{ value }}
+                        —
                     {% endif %}
-                {% else %}
-                    -
-                {% endif %}
-            </dd>
-        </div>
+                </dd>
+            </div>
+        {% else %}
+            <div class="govuk-summary-list__row govuk-summary-list__row--mobile">
+                <dt class="govuk-summary-list__key govuk-summary-list__key--mobile-table">{{ key }}</dt>
+                <dd class="govuk-summary-list__value govuk-summary-list__value--mobile">
+                    {% if value %}
+                        {% if key == "Status" %}
+                            {% if value == "Closed" %}
+                                <span class="govuk-tag govuk-tag--red">{{ value }}</span>
+                                {% if dict.get('opening_date') %}<span>Record opening date {{ dict.get('opening_date') }}</span>{% endif %}
+                            {% else %}
+                                <span class="govuk-tag govuk-tag--green">{{ value }}</span>
+                            {% endif %}
+                        {% else %}
+                            {{ value }}
+                        {% endif %}
+                    {% else %}
+                        —
+                    {% endif %}
+                </dd>
+            </div>
+        {% endif %}
     {% endif %}
 {% endfor %}

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -259,7 +259,7 @@ class TestRecord:
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
-                <span class="govuk-tag govuk-tag--green"><strong>{record_files[0]["closure_type"].Value}</strong></span>
+                <span class="govuk-tag govuk-tag--green">{record_files[0]["closure_type"].Value}</span>
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
@@ -398,7 +398,7 @@ class TestRecord:
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
-                <span class="govuk-tag govuk-tag--green"><strong>{record_files[1]["closure_type"].Value}</strong></span>
+                <span class="govuk-tag govuk-tag--green">{record_files[1]["closure_type"].Value}</span>
 <span>Record opening date {opening_date}</span></dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
@@ -557,7 +557,7 @@ class TestRecord:
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
-                <span class="govuk-tag govuk-tag--red"><strong>{record_files[2]["closure_type"].Value}</strong></span>
+                <span class="govuk-tag govuk-tag--red">{record_files[2]["closure_type"].Value}</span>
 <span>Record opening date {opening_date}</span></dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Styled record page in line with designs
- Styled record mobile table view via media queries 
- Updated record.py tests 
## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-785
## Screenshots of UI changes

### Before

### After

<img width="1102" alt="Screenshot 2024-03-11 at 13 42 54" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/66abeebf-8e70-45bd-81cb-63a94daa2c3e">
<img width="786" alt="Screenshot 2024-03-11 at 13 43 07" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/8302ff26-8992-480a-ad04-072e571bf8ea">
<img width="601" alt="Screenshot 2024-03-11 at 13 43 17" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/208cdcce-b66d-4a73-bb60-f5720d5e588b">
<img width="407" alt="Screenshot 2024-03-11 at 13 43 31" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/8f9238c7-011c-459c-a58e-609a54b8bc00">

- [ ] Requires env variable(s) to be updated
