### PR TITLE
Bug: Fix authorization on browse routes

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -184,12 +184,14 @@ def browse_transferring_body(_id: uuid.UUID):
     Returns:
         A rendered HTML page with transferring body records.
     """
-    form = SearchForm()
+    body = Body.query.get(_id)
+    validate_body_user_groups_or_404(body.Name)
 
+    breadcrumb_values = {0: {"transferring_body": body.Name}}
+
+    form = SearchForm()
     page = int(request.args.get("page", 1))
     per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
-
-    breadcrumb_values = {0: {"transferring_body": Body.query.get(_id).Name}}
 
     date_validation_errors = []
     from_date = None
@@ -256,17 +258,19 @@ def browse_series(_id: uuid.UUID):
     Returns:
         A rendered HTML page with series records.
     """
-    form = SearchForm()
-    page = int(request.args.get("page", 1))
-    per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
-
     series = Series.query.get(_id)
     body = series.body
+    validate_body_user_groups_or_404(body.Name)
+
     breadcrumb_values = {
         0: {"transferring_body_id": body.BodyId},
         1: {"transferring_body": body.Name},
         2: {"series": series.Name},
     }
+
+    form = SearchForm()
+    page = int(request.args.get("page", 1))
+    per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
 
     date_validation_errors = []
     from_date = None
@@ -333,12 +337,10 @@ def browse_consignment(_id: uuid.UUID):
     Returns:
         A rendered HTML page with consignment records.
     """
-    form = SearchForm()
-    page = int(request.args.get("page", 1))
-    per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
-
     consignment = Consignment.query.get(_id)
     body = consignment.series.body
+    validate_body_user_groups_or_404(body.Name)
+
     series = consignment.series
     breadcrumb_values = {
         0: {"transferring_body_id": body.BodyId},
@@ -347,6 +349,10 @@ def browse_consignment(_id: uuid.UUID):
         3: {"series": series.Name},
         4: {"consignment_reference": consignment.ConsignmentReference},
     }
+
+    form = SearchForm()
+    page = int(request.args.get("page", 1))
+    per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
 
     date_validation_errors = []
     from_date = None
@@ -430,10 +436,10 @@ def search():
 def search_results_summary():
     form = SearchForm()
     per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
+    page = int(request.args.get("page", 1))
 
     query = request.form.get("query", "") or request.args.get("query", "")
 
-    page = int(request.args.get("page", 1))
     filters = {"query": query.strip()}
     search_results = None
     num_records_found = 0

--- a/app/tests/test_browse_transferring_body.py
+++ b/app/tests/test_browse_transferring_body.py
@@ -3,6 +3,12 @@ from bs4 import BeautifulSoup
 from flask.testing import FlaskClient
 
 from app.tests.assertions import assert_contains_html
+from app.tests.factories import (
+    BodyFactory,
+    ConsignmentFactory,
+    FileFactory,
+    SeriesFactory,
+)
 from app.tests.test_browse import verify_data_rows
 
 
@@ -267,3 +273,25 @@ class TestBrowseTransferringBody:
 
         verify_transferring_body_view_header_row(response.data)
         verify_data_rows(response.data, expected_results)
+
+    def test_browse_transferring_body_standard_user_accessing_different_transferring_body(
+        self,
+        client: FlaskClient,
+        mock_standard_user,
+    ):
+        """
+        Given a Body with Name "foo" and id body_id
+        And a standard user with access to Body "bar"
+        When they make a GET request to `browse/transferring_body/{body_id}`
+        Then they should receive a 404 response
+        """
+        body = BodyFactory(Name="foo")
+        FileFactory(
+            consignment=ConsignmentFactory(series=SeriesFactory(body=body))
+        )
+
+        mock_standard_user(client, "bar")
+
+        response = client.get(f"{self.route_url}/{body.BodyId}")
+
+        assert response.status_code == 404


### PR DESCRIPTION
## Changes in this PR
Fix:
- Made sure browse_consignment, browse_series and browse_transferring_body routes return 404 if a standard user tries to access a resource that is part of a transferrring body they do not have access to

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-819