### PR TITLE
AYR-818/date-filter-fix-consignment

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -408,6 +408,7 @@ def build_browse_consignment_query(
                     == record_status.lower()
                 )
 
+        date_filter = None
         date_filter_field = filters.get("date_filter_field")
         if (
             date_filter_field
@@ -418,13 +419,14 @@ def build_browse_consignment_query(
                 filters.get("date_from"),
                 filters.get("date_to"),
             )
-            query = query.filter(date_filter)
         elif date_filter_field and date_filter_field.lower() == "opening_date":
             date_filter = _build_date_range_filter(
                 sub_query.c.opening_date,
                 filters.get("date_from"),
                 filters.get("date_to"),
             )
+
+        if date_filter is not None:
             query = query.filter(date_filter)
 
     if sorting_orders:

--- a/app/tests/test_date_validator.py
+++ b/app/tests/test_date_validator.py
@@ -1,4 +1,5 @@
 from datetime import date
+from unittest.mock import patch
 
 import pytest
 
@@ -466,17 +467,17 @@ class TestDateValidator:
             ),
             (
                 {
-                    "date_from_day": "01",
-                    "date_from_month": "08",
-                    "date_from_year": "2023",
+                    "date_from_day": "31",
+                    "date_from_month": "12",
+                    "date_from_year": "2022",
                     "date_to_day": "01",
                     "date_to_month": "12",
                     "date_to_year": "2022",
                 },
                 (
-                    1,
-                    8,
-                    2023,
+                    31,
+                    12,
+                    2022,
                     1,
                     12,
                     2022,
@@ -490,8 +491,10 @@ class TestDateValidator:
             ),
         ],
     )
+    @patch("app.main.util.date_validator.date")
     def test_validate_dates_full_test(
         self,
+        mock_date,
         request_args,
         expected_results,
     ):
@@ -501,6 +504,8 @@ class TestDateValidator:
         Then if date is not a valid date
         it returns various errors based on the data filter values
         """
+        mock_date.today.return_value = date(2023, 1, 1)
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
         assert validate_dates(request_args) == expected_results
 
     @pytest.mark.parametrize(
@@ -535,8 +540,8 @@ class TestDateValidator:
                     None,
                     None,
                     None,
-                    31,
-                    12,
+                    1,
+                    1,
                     2023,
                     {
                         "date_from": [],
@@ -548,7 +553,7 @@ class TestDateValidator:
                 {
                     "date_to_day": "",
                     "date_to_month": "2",
-                    "date_to_year": "2024",
+                    "date_to_year": "2020",
                 },
                 (
                     None,
@@ -556,7 +561,7 @@ class TestDateValidator:
                     None,
                     29,
                     2,
-                    2024,
+                    2020,
                     {
                         "date_from": [],
                         "date_to": [],
@@ -567,12 +572,12 @@ class TestDateValidator:
                 {
                     "date_from_day": "",
                     "date_from_month": "2",
-                    "date_from_year": "2023",
+                    "date_from_year": "2022",
                 },
                 (
                     1,
                     2,
-                    2023,
+                    2022,
                     None,
                     None,
                     None,
@@ -586,7 +591,7 @@ class TestDateValidator:
                 {
                     "date_to_day": "",
                     "date_to_month": "2",
-                    "date_to_year": "2023",
+                    "date_to_year": "2021",
                 },
                 (
                     None,
@@ -594,7 +599,7 @@ class TestDateValidator:
                     None,
                     28,
                     2,
-                    2023,
+                    2021,
                     {
                         "date_from": [],
                         "date_to": [],
@@ -605,15 +610,15 @@ class TestDateValidator:
                 {
                     "date_to_day": "",
                     "date_to_month": "",
-                    "date_to_year": "2024",
+                    "date_to_year": "2020",
                 },
                 (
                     None,
                     None,
                     None,
-                    date.today().day,
-                    date.today().month,
-                    2024,
+                    31,
+                    12,
+                    2020,
                     {
                         "date_from": [],
                         "date_to": [],
@@ -622,8 +627,10 @@ class TestDateValidator:
             ),
         ],
     )
+    @patch("app.main.util.date_validator.date")
     def test_validate_dates_return_complete_date_full_test(
         self,
+        mock_date,
         request_args,
         expected_results,
     ):
@@ -633,6 +640,8 @@ class TestDateValidator:
         Then specific date values i.e. month or year, month and year given
         it returns valid completed date for date filter values
         """
+        mock_date.today.return_value = date(2023, 1, 1)
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
         assert validate_dates(request_args) == expected_results
 
     @pytest.mark.parametrize(
@@ -665,18 +674,18 @@ class TestDateValidator:
                     "date_filter_field": "date_last_modified",
                     "date_from_day": "01",
                     "date_from_month": "08",
-                    "date_from_year": "2023",
+                    "date_from_year": "2022",
                     "date_to_day": "31",
                     "date_to_month": "08",
-                    "date_to_year": "2023",
+                    "date_to_year": "2022",
                 },
                 (
                     1,
                     8,
-                    2023,
+                    2022,
                     31,
                     8,
-                    2023,
+                    2022,
                     {
                         "date_from": [],
                         "date_to": [],
@@ -708,8 +717,10 @@ class TestDateValidator:
             ),
         ],
     )
+    @patch("app.main.util.date_validator.date")
     def test_validate_dates_with_browse_consignment(
         self,
+        mock_date,
         request_args,
         expected_results,
     ):
@@ -719,6 +730,8 @@ class TestDateValidator:
         Then it returns an error if no date filter field provided
         else it returns valid date filter values
         """
+        mock_date.today.return_value = date(2023, 1, 1)
+        mock_date.side_effect = lambda *args, **kw: date(*args, **kw)
         assert (
             validate_dates(request_args, browse_consignment=True)
             == expected_results


### PR DESCRIPTION
… date_filters to be used if not passed correct date, fixed the test case

<!-- Amend as appropriate -->

## Changes in this PR

1. fixed issue in queries.py for build_browse_consignment_query to avoid date_filters to be used if not passed correct date, 
2. fixed the test case in test_browse_consignment.py

## JIRA ticket

AYR - 818

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
