### PR TITLE
AYR-827/ replace the term 'Record opening' to 'Record opening date' 

### DIFF
--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -14,8 +14,8 @@
     "Consignment reference (oldest)": "consignment_reference-asc",
     "Title (A to Z)": "file_name-asc",
     "Title (Z to A)": "file_name-desc",
-    "Record opening (sooner)": "opening_date-desc",
-    "Record opening (later)": "opening_date-asc",
+    "Record opening date (sooner)": "opening_date-desc",
+    "Record opening date (later)": "opening_date-asc",
     "Record status (closed)": "closure_type-asc",
     "Record status (open)": "closure_type-desc"
 } %}
@@ -52,7 +52,7 @@
                             <th scope="col"
                                 class="govuk-table__header govuk-table__header--search-header">Status</th>
                             <th scope="col"
-                                class="govuk-table__header govuk-table__header--search-header">Record opening</th>
+                                class="govuk-table__header govuk-table__header--search-header">Record opening date</th>
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body">

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -21,7 +21,7 @@ def verify_search_transferring_body_header_row(data):
             "Consignment Reference",
             "Title",
             "Status",
-            "Record opening",
+            "Record opening date",
         ],
     )
     assert [
@@ -554,7 +554,7 @@ class TestSearchTransferringBody:
                         class="govuk-table__header govuk-table__header--search-header">Status</th>
                     <th scope="col"
                         class="govuk-table__header govuk-table__header--search-header">
-                        Record opening
+                        Record opening date
                     </th>
                 </tr>
             </thead>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
1. replaced the term 'Record opening' to 'Record opening date'  on search-transferring-body template

## JIRA ticket

AYR-827

## Screenshots of UI changes

### Before

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/8b95690d-0b1f-4c1a-8574-92b8525c32e2)


### After

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/34c54c29-c7b3-404b-82ab-a9b5c9bca235)


- [ ] Requires env variable(s) to be updated
