### PR TITLE
Ayr 721/add no caching headers to routes that require authentication

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -122,4 +122,17 @@ def create_app(config_class, database_uri=None):
         authenticated_view = getattr(g, "access_token_sign_in_required", False)
         return dict(authenticated_view=authenticated_view)
 
+    @app.after_request
+    def add_no_caching_headers(r):
+        """
+        Add headers to tell browsers not to cache the pages to protected routes
+        """
+        if g.get("access_token_sign_in_required"):
+            r.headers["Cache-Control"] = (
+                "public, max-age=0, no-cache, no-store, must-revalidate"
+            )
+            r.headers["Pragma"] = "no-cache"
+            r.headers["Expires"] = "0"
+        return r
+
     return app

--- a/app/tests/test_access_token_sign_in_required.py
+++ b/app/tests/test_access_token_sign_in_required.py
@@ -445,3 +445,51 @@ def test_no_sign_out_button_on_unprotected_view_that_uses_base_template(app):
 
     assert response.status_code == 200
     assert "Sign out" not in response.data.decode()
+
+
+def test_no_cache_headers_set_on_response_for_protected_view(app):
+    """
+    Given a view that is protected by the 'access_token_sign_in_required' decorator,
+    When a user accesses the view,
+    Then the response headers should contain
+        "Expires", "Pragma" or "Cache-Control" entries that instruct browsers not to cache
+        the response
+    """
+    view_name = "/protected_view"
+
+    @app.route(view_name)
+    @access_token_sign_in_required
+    def protected_base_view():
+        return "Protected View"
+
+    with app.test_client() as client:
+        response = client.get(view_name)
+
+    assert (
+        response.headers["Cache-Control"]
+        == "public, max-age=0, no-cache, no-store, must-revalidate"
+    )
+    assert response.headers["Pragma"] == "no-cache"
+    assert response.headers["Expires"] == "0"
+
+
+def test_no_cache_headers_not_set_on_response_for_unprotected_view(app):
+    """
+    Given a view that is NOT protected by the 'access_token_sign_in_required' decorator,
+    When a user accesses the view,
+    Then the response headers should not contain
+        "Expires", "Pragma" or "Cache-Control" entries
+    """
+    view_name = "/unprotected_view"
+
+    @app.route(view_name)
+    def unprotected_base_view():
+        return "Unprotected View"
+
+    with app.test_client() as client:
+        response = client.get(view_name)
+
+    assert all(
+        key not in response.headers
+        for key in ["Expires", "Pragma", "Cache-Control"]
+    )


### PR DESCRIPTION
## Changes in this PR
- added "no caching" headers to routes that require authentication to instruct browsers not to cache our authenticated pages so that when a user logs out and clicks back on browser, they cant see the private data. 

Of course the browser could ignore these instructions and we cant confirm 100% that a page wasnt cached by any server along the way but its as good as we can do.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-721