### PR TITLE
AYR-810/ replace the term 'title' to 'File name' at all places

### DIFF
--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -35,7 +35,7 @@
                     <thead class="govuk-table__head">
                         <tr class="govuk-table__row">
                             <th scope="col" class="govuk-table__header">Date of record</th>
-                            <th scope="col" class="govuk-table__header browse__table__mobile--hidden">Title</th>
+                            <th scope="col" class="govuk-table__header browse__table__mobile--hidden">File name</th>
                             <th scope="col" class="govuk-table__header">Status</th>
                             <th scope="col" class="govuk-table__header browse__table__right-align">Record opening date</th>
                         </tr>

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -7,8 +7,8 @@
 } %}
 {% if record['closure_type'] | lower == 'closed' or (record['closure_type'] | lower == 'open' and record['closure_start_date'] != None) %}
     {% set list_items = {
-            "Title": record['file_name'],
-            "Alternative title": record['alternative_title'],
+            "File name": record['file_name'],
+            "Alternative file name": record['alternative_title'],
             "Description": record['description'],
             "Alternative description": record['alternative_description'],
             "Status": record['closure_type'],
@@ -22,7 +22,7 @@
             "Consignment reference": record['consignment_reference'],
             "File reference": record['file_reference'],
             "Former reference": record['former_reference'],
-            "Translated title": record['translated_title'],
+            "Translated file name": record['translated_title'],
             "Held by": record['held_by'],
             "Legal status": record['legal_status'],
             "Rights copyright": record['rights_copyright'],
@@ -30,7 +30,7 @@
         } %}
 {% else %}
     {% set list_items = {
-            "Title": record['file_name'],
+            "File name": record['file_name'],
             "Description": record['description'],
             "Status": record['closure_type'],
             "Date of record": record['date_last_modified'],
@@ -39,7 +39,7 @@
             "Consignment reference": record['consignment_reference'],
             "File reference": record['file_reference'],
             "Former reference": record['former_reference'],
-            "Translated title": record['translated_title'],
+            "Translated file name": record['translated_title'],
             "Held by": record['held_by'],
             "Legal status": record['legal_status'],
             "Rights copyright": record['rights_copyright'],

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -47,7 +47,7 @@
                             </th>
                             <th scope="col"
                                 class="govuk-table__header govuk-table__header--search-header govuk-table__header--search-header-title">
-                                Title
+                                File name
                             </th>
                             <th scope="col"
                                 class="govuk-table__header govuk-table__header--search-header">Status</th>

--- a/app/tests/test_browse_consignment.py
+++ b/app/tests/test_browse_consignment.py
@@ -23,7 +23,7 @@ def verify_consignment_view_header_row(data):
     expected_row = (
         [
             "Date of record",
-            "Title",
+            "File name",
             "Status",
             "Record opening date",
         ],

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -240,7 +240,7 @@ class TestRecord:
         <dl class="govuk-summary-list govuk-summary-list--record">
                         <div class="govuk-summary-list__row"></div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">File name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {file.FileName}
                 </dd>
@@ -294,7 +294,7 @@ class TestRecord:
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated file name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {record_files[0]["translated_title"].Value}
                 </dd>
@@ -367,13 +367,13 @@ class TestRecord:
         <dl class="govuk-summary-list govuk-summary-list--record">
                         <div class="govuk-summary-list__row"></div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">File name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {file.FileName}
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Alternative title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Alternative file name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {record_files[1]["alternative_title"].Value}
                 </dd>
@@ -451,7 +451,7 @@ class TestRecord:
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated file name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                         {record_files[1]["translated_title"].Value}
                 </dd>
@@ -526,13 +526,13 @@ class TestRecord:
         <dl class="govuk-summary-list govuk-summary-list--record">
                         <div class="govuk-summary-list__row"></div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">File name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {file.FileName}
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Alternative title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Alternative file name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                             {record_files[2]["alternative_title"].Value}
                 </dd>
@@ -610,7 +610,7 @@ class TestRecord:
                 </dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
-                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated title</dt>
+                <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Translated file name</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                         {record_files[2]["translated_title"].Value}
                 </dd>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -19,7 +19,7 @@ def verify_search_transferring_body_header_row(data):
         [
             "Series",
             "Consignment Reference",
-            "Title",
+            "File name",
             "Status",
             "Record opening date",
         ],
@@ -548,7 +548,7 @@ class TestSearchTransferringBody:
                     </th>
                     <th scope="col"
             class="govuk-table__header govuk-table__header--search-header govuk-table__header--search-header-title">
-                        Title
+                        File name
                     </th>
                     <th scope="col"
                         class="govuk-table__header govuk-table__header--search-header">Status</th>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
1. replaced the term 'title' to 'File name' at all places ( search transferring body template, record template, browse consignment template)
2. updated test cases to verify the 'title' changed to 'file name'.

## JIRA ticket

AYR -810

## Screenshots of UI changes

### Before

search transferring body view

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/8aae4111-794e-4893-8ec5-a782ebd70632)

browse consignment view

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/243b3923-6811-4891-8039-5f13409c7023)

record view - open status

![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/fa0f184c-659d-4155-a0e8-a0dbbb479c48)

record view - closed status
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/f4ff1b2e-2622-4715-b1ce-a4b4167d13b5)

### After

search transferring body view
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/0b9e0495-d5ac-4ba1-8a00-ea93a046b89a)

browse consignment view
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/3f2d1725-c741-4d4f-b69e-1b943547131a)

record view - open status
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/b83bf4a4-e0eb-4e90-9414-5c8cd742e101)

record view - closed status
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/f4e17f23-c01c-4dae-bee4-d3fef1e656d6)


- [ ] Requires env variable(s) to be updated
