### PR TITLE
AYR - 829- e2e tests for browse views

### DIFF
--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -60,14 +60,6 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                            <tr class="govuk-table__row govuk-table__row__browse--mobile">
-                                <td class="govuk-table__cell browse__mobile-table__bottom-row">
-                                    <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
-                                </td>
-                                <td class="govuk-table__cell govuk-table__cell--ayr browse__table__mobile--hidden"></td>
-                                <td class="govuk-table__cell browse__mobile-table__bottom-row"></td>
-                                <td class="govuk-table__cell right-align browse__mobile-table__bottom-row"></td>
-                            </tr>
                         {% endfor %}
                     </tbody>
                 </table>

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -202,6 +202,44 @@ class TestBrowse:
         verify_header_row(header_rows)
         assert rows == expected_rows
 
+    def test_browse_date_filter_validation_date_from(self, aau_user_page: Page):
+        aau_user_page.goto(f"{self.route_url}")
+        aau_user_page.locator("#date_from_day").fill("1")
+        aau_user_page.locator("#date_from_month").fill("12")
+        aau_user_page.locator("#date_from_year").fill("2024")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert aau_user_page.get_by_text(
+            "‘Date from’ must be in the past"
+        ).is_visible()
+
+    def test_browse_date_filter_validation_to_date(self, aau_user_page: Page):
+        aau_user_page.goto(f"{self.route_url}")
+        aau_user_page.locator("#date_to_day").fill("31")
+        aau_user_page.locator("#date_to_month").fill("12")
+        aau_user_page.locator("#date_to_year").fill("2024")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert aau_user_page.get_by_text(
+            "‘Date to’ must be in the past"
+        ).is_visible()
+
+    def test_browse_date_filter_validation_date_from_and_to_date(
+        self, aau_user_page: Page
+    ):
+        aau_user_page.goto(f"{self.route_url}")
+        aau_user_page.locator("#date_from_day").fill("1")
+        aau_user_page.locator("#date_from_month").fill("1")
+        aau_user_page.locator("#date_from_year").fill("2023")
+        aau_user_page.locator("#date_to_day").fill("31")
+        aau_user_page.locator("#date_to_month").fill("12")
+        aau_user_page.locator("#date_to_year").fill("2022")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert aau_user_page.get_by_text(
+            "‘Date from’ must be the same as or before ‘31/12/2022’"
+        ).is_visible()
+
     def test_browse_clear_filter_functionality(self, aau_user_page: Page):
         aau_user_page.goto(f"{self.route_url}")
         aau_user_page.get_by_label("Sort by").select_option(

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -16,13 +16,33 @@ class TestBrowse:
     def route_url(self):
         return "/browse"
 
-    def test_has_title(self, aau_user_page: Page):
+    def test_browse_has_title(self, aau_user_page: Page):
         aau_user_page.goto(f"{self.route_url}")
 
         assert (
             aau_user_page.title()
             == "Browse – AYR - Access Your Records – GOV.UK"
         )
+
+    def test_browse_no_results_found(self, aau_user_page: Page):
+        aau_user_page.locator("#series_filter").click()
+        aau_user_page.locator("#series_filter").fill("junk")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert aau_user_page.inner_html("text='No results found'")
+        assert aau_user_page.inner_html("text='Help with your search'")
+        assert aau_user_page.inner_html(
+            "text='Try changing or removing one or more applied filters.'"
+        )
+        assert aau_user_page.inner_html(
+            "text='Alternatively, use the breadcrumbs to navigate back to the browse view.'"
+        )
+
+    def test_browse_breadcrumb(self, aau_user_page: Page):
+        aau_user_page.goto(f"{self.route_url}")
+
+        assert aau_user_page.inner_html("text='You are viewing'")
+        assert aau_user_page.inner_html("text='Everything available to you'")
 
     def test_browse_filter_functionality_with_query_string_parameters(
         self, aau_user_page: Page
@@ -54,26 +74,6 @@ class TestBrowse:
 
         verify_header_row(header_rows)
         assert rows == expected_rows
-
-    def test_browse_no_results_returned(self, aau_user_page: Page):
-        aau_user_page.locator("#series_filter").click()
-        aau_user_page.locator("#series_filter").fill("junk")
-        aau_user_page.get_by_role("button", name="Apply filters").click()
-
-        assert aau_user_page.inner_html("text='No results found'")
-        assert aau_user_page.inner_html("text='Help with your search'")
-        assert aau_user_page.inner_html(
-            "text='Try changing or removing one or more applied filters.'"
-        )
-        assert aau_user_page.inner_html(
-            "text='Alternatively, use the breadcrumbs to navigate back to the browse view.'"
-        )
-
-    def test_browse_breadcrumb(self, aau_user_page: Page):
-        aau_user_page.goto(f"{self.route_url}")
-
-        assert aau_user_page.inner_html("text='You are viewing'")
-        assert aau_user_page.inner_html("text='Everything available to you'")
 
     def test_browse_sort_functionality_by_transferring_body_descending(
         self, aau_user_page: Page
@@ -114,9 +114,6 @@ class TestBrowse:
             "MOCK1 Department"
         )
         aau_user_page.get_by_role("button", name="Apply filters").click()
-        aau_user_page.get_by_label("Sort by").select_option(
-            "last_record_transferred-desc"
-        )
         aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
         header_rows = aau_user_page.locator(

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -1,6 +1,16 @@
 from playwright.sync_api import Page
 
 
+def verify_header_row(header_rows):
+    assert header_rows[0] == [
+        "Transferring body",
+        "Series",
+        "Last consignment transferred",
+        "Records held in series",
+        "Consignments within series",
+    ]
+
+
 class TestBrowse:
     @property
     def route_url(self):
@@ -22,107 +32,185 @@ class TestBrowse:
             "01=&date_from_month=07&date_from_year=2023&date_to_day=31&date_to_month=07&date_to_year=2023"
         )
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        header_rows = aau_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Last record transferred",
-            "Records held",
-            "Consignments within series",
+        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["MOCK1 Department", "MOCK1 123", "28/07/2023", "1", "1"]
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "1"
+    def test_browse_no_results_returned(self, aau_user_page: Page):
+        aau_user_page.locator("#series_filter").click()
+        aau_user_page.locator("#series_filter").fill("junk")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
 
-    def test_browse_sort_and_filter_functionality(self, aau_user_page: Page):
+        assert aau_user_page.inner_html("text='No results found'")
+        assert aau_user_page.inner_html("text='Help with your search'")
+        assert aau_user_page.inner_html(
+            "text='Try changing or removing one or more applied filters.'"
+        )
+        assert aau_user_page.inner_html(
+            "text='Alternatively, use the breadcrumbs to navigate back to the browse view.'"
+        )
+
+    def test_browse_breadcrumb(self, aau_user_page: Page):
         aau_user_page.goto(f"{self.route_url}")
-        aau_user_page.get_by_label("", exact=True).nth(1).select_option(
+
+        assert aau_user_page.inner_html("text='You are viewing'")
+        assert aau_user_page.inner_html("text='Everything available to you'")
+
+    def test_browse_sort_functionality_by_transferring_body_descending(
+        self, aau_user_page: Page
+    ):
+        aau_user_page.get_by_label("Sort by").select_option(
+            "transferring_body-desc"
+        )
+        aau_user_page.get_by_role("button", name="Apply", exact=True).click()
+
+        header_rows = aau_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 2
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
+            ["MOCK1 Department", "MOCK1 123", "28/07/2023", "1", "1"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
+
+    def test_browse_filter_functionality_with_transferring_body_filter(
+        self, aau_user_page: Page
+    ):
+        aau_user_page.locator("#transferring_body_filter").select_option(
             "MOCK1 Department"
         )
         aau_user_page.get_by_role("button", name="Apply filters").click()
         aau_user_page.get_by_label("Sort by").select_option(
             "last_record_transferred-desc"
         )
-        aau_user_page.get_by_role("button", name="Apply filters").click()
+        aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        header_rows = aau_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Last record transferred",
-            "Records held",
-            "Consignments within series",
+        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["MOCK1 Department", "MOCK1 123", "28/07/2023", "1", "1"]
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "1"
-
-    def test_browse_sort_and_filter_functionality_with_series_filter_wildcard_character(
+    def test_browse_filter_functionality_with_series_filter_wildcard_character(
         self, aau_user_page: Page
     ):
         aau_user_page.goto(f"{self.route_url}")
-        aau_user_page.get_by_label("", exact=True).nth(2).fill("1")
+        aau_user_page.locator("#series_filter").fill("1")
         aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.nth(0).locator("td")
+        header_rows = aau_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Last record transferred",
-            "Records held",
-            "Consignments within series",
+        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 2
+
+        expected_rows = [
+            ["MOCK1 Department", "MOCK1 123", "28/07/2023", "1", "1"],
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
         ]
 
-        assert rows.count() == 2
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "1"
+    def test_browse_filter_functionality_with_date_filter(
+        self, aau_user_page: Page
+    ):
+        aau_user_page.goto(f"{self.route_url}")
+        aau_user_page.locator("#date_from_day").fill("1")
+        aau_user_page.locator("#date_from_month").fill("1")
+        aau_user_page.locator("#date_from_year").fill("2024")
+        aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        cols = rows.nth(1).locator("td")
+        header_rows = aau_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert cols.nth(0).inner_text() == "Testing A"
-        assert cols.nth(1).inner_text() == "TSTA 1"
-        assert cols.nth(2).inner_text() == "25/01/2024"
-        assert cols.nth(3).inner_text() == "73"
-        assert cols.nth(4).inner_text() == "7"
+        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
     def test_browse_clear_filter_functionality(self, aau_user_page: Page):
         aau_user_page.goto(f"{self.route_url}")
         aau_user_page.get_by_label("Sort by").select_option(
             "transferring_body-desc"
         )
-        aau_user_page.get_by_role(
-            "button", name="Apply", exact=True
-        ).first.click()
-        aau_user_page.get_by_label("", exact=True).nth(1).select_option(
-            "Testing A"
-        )
-        aau_user_page.get_by_role("button", name="Apply filters").click()
+        aau_user_page.get_by_role("button", name="Apply", exact=True).click()
         aau_user_page.get_by_role("link", name="Clear filters").click()
         assert aau_user_page.inner_text("#series_filter") == ""
         assert aau_user_page.inner_text("#date_from_day") == ""

--- a/e2e_tests/test_browse_consignment.py
+++ b/e2e_tests/test_browse_consignment.py
@@ -300,6 +300,57 @@ class TestBrowseConsignment:
         verify_header_row(header_rows)
         assert rows == expected_rows
 
+    def test_browse_consignment_date_filter_validation_date_from(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.consignment_id}")
+        standard_user_page.locator("label").filter(
+            has_text="Date of record"
+        ).click()
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("12")
+        standard_user_page.locator("#date_from_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be in the past"
+        ).is_visible()
+
+    def test_browse_consignment_date_filter_validation_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.consignment_id}")
+        standard_user_page.locator("label").filter(
+            has_text="Date of record"
+        ).click()
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date to’ must be in the past"
+        ).is_visible()
+
+    def test_browse_consignment_date_filter_validation_date_from_and_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.consignment_id}")
+        standard_user_page.locator("label").filter(
+            has_text="Date of record"
+        ).click()
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2023")
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2022")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be the same as or before ‘31/12/2022’"
+        ).is_visible()
+
     def test_browse_consignment_clear_filter_functionality(
         self, standard_user_page: Page
     ):

--- a/e2e_tests/test_browse_series.py
+++ b/e2e_tests/test_browse_series.py
@@ -1,99 +1,254 @@
 from playwright.sync_api import Page
 
 
+def verify_header_row(header_rows):
+    assert header_rows[0] == [
+        "Transferring body",
+        "Series",
+        "Consignment transferred",
+        "Records in consignment",
+        "Consignment reference",
+    ]
+
+
 class TestBrowseSeries:
     @property
     def route_url(self):
         return "/browse/series"
 
+    @property
+    def series_id(self):
+        return "2a6ceedb-8a50-40fc-b7d4-300290ee0b63"
+
+    def test_browse_series_has_title(self, standard_user_page: Page):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        assert (
+            standard_user_page.title()
+            == "Browse – AYR - Access Your Records – GOV.UK"
+        )
+
+    def test_browse_series_404_for_no_access(self, standard_user_page: Page):
+        series_id = "c28cc3ab-c12a-4f06-82e1-18648c82a17f"
+
+        standard_user_page.goto(f"{self.route_url}/{series_id}")
+
+        assert standard_user_page.inner_html("text='Page not found'")
+        assert standard_user_page.inner_html(
+            "text='If you typed the web address, check it is correct.'"
+        )
+        assert standard_user_page.inner_html(
+            "text='If you pasted the web address, check you copied the entire address.'"
+        )
+
+    def test_browse_series_no_results_found(self, standard_user_page: Page):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        standard_user_page.locator("#date_to_day").fill("1")
+        standard_user_page.locator("#date_to_month").fill("1")
+        standard_user_page.locator("#date_to_year").fill("2022")
+
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.inner_html("text='No results found'")
+        assert standard_user_page.inner_html("text='Help with your search'")
+        assert standard_user_page.inner_html(
+            "text='Try changing or removing one or more applied filters.'"
+        )
+        assert standard_user_page.inner_html(
+            "text='Alternatively, use the breadcrumbs to navigate back to the browse view.'"
+        )
+
+    def test_browse_series_breadcrumb(self, standard_user_page: Page):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        assert standard_user_page.inner_html("text='You are viewing'")
+        assert standard_user_page.inner_html("text='Everything'")
+        assert standard_user_page.inner_html("text='Testing A'")
+        assert standard_user_page.inner_html("text='TSTA 1'")
+
+    def test_browse_series_no_pagination(self, standard_user_page: Page):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2024")
+
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert not standard_user_page.get_by_label("Page 1").is_visible()
+        assert not standard_user_page.get_by_label("Page 2").is_visible()
+        assert not standard_user_page.get_by_role(
+            "link", name="Nextpage"
+        ).is_visible()
+
+    def test_browse_series_has_pagination_with_next_page(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2023")
+
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_label("Page 1").is_visible()
+        assert standard_user_page.get_by_label("Page 2").is_visible()
+        assert standard_user_page.get_by_role(
+            "link", name="Nextpage"
+        ).is_visible()
+
+    def test_browse_series_has_pagination_with_previous_page(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2023")
+
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+        standard_user_page.get_by_role("link", name="Nextpage").click()
+
+        assert standard_user_page.get_by_label("Page 1").is_visible()
+        assert standard_user_page.get_by_label("Page 2").is_visible()
+        assert standard_user_page.get_by_role(
+            "link", name="Previouspage"
+        ).is_visible()
+
     def test_browse_series_filter_functionality_with_query_string_parameters(
-        self, aau_user_page: Page
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/c28cc3ab-c12a-4f06-82e1-18648c82a17f?sort=last_record_transferred-desc&date_from_day"
-            "=01&date_from_month=03&date_from_year=2023&date_to_day=&date_to_month=&date_to_year="
+        standard_user_page.goto(
+            f"{self.route_url}/{self.series_id}?sort=last_record_transferred-desc&date_from_day"
+            "=01&date_from_month=01&date_from_year=2023&date_to_day=31&date_to_month=12&date_to_year=2023"
         )
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Consignment transferred",
-            "Records in consignment",
-            "Consignment reference",
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 5
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "30/11/2023", "9", "TDR-2023-GXFH"],
+            ["Testing A", "TSTA 1", "18/10/2023", "7", "TDR-2023-BV6"],
+            ["Testing A", "TSTA 1", "09/08/2023", "15", "TDR-2023-TMT"],
+            ["Testing A", "TSTA 1", "09/08/2023", "15", "TDR-2023-TH4"],
+            ["Testing A", "TSTA 1", "29/03/2023", "6", "TDR-2023-BV5"],
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "TDR-2023-MNJ"
-
-    def test_browse_series_sort_and_filter_functionality(
-        self, aau_user_page: Page
+    def test_browse_series_sort_functionality_by_records_held_in_consignment_descending(
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/c28cc3ab-c12a-4f06-82e1-18648c82a17f"
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.get_by_label("Sort by").select_option(
+            "records_held-desc"
         )
-        aau_user_page.get_by_label("Day").first.fill("01")
-        aau_user_page.get_by_label("Month").first.fill("03")
-        aau_user_page.get_by_label("Year").first.fill("2023")
-        aau_user_page.get_by_role("button", name="Apply filters").click()
-        aau_user_page.get_by_label("Sort by").select_option(
-            "last_record_transferred-asc"
+        standard_user_page.get_by_role(
+            "button", name="Apply", exact=True
+        ).click()
+
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
         )
-        aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Consignment transferred",
-            "Records in consignment",
-            "Consignment reference",
+        assert len(rows) == 5
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],
+            ["Testing A", "TSTA 1", "09/08/2023", "15", "TDR-2023-TMT"],
+            ["Testing A", "TSTA 1", "09/08/2023", "15", "TDR-2023-TH4"],
+            ["Testing A", "TSTA 1", "30/11/2023", "9", "TDR-2023-GXFH"],
+            ["Testing A", "TSTA 1", "18/10/2023", "7", "TDR-2023-BV6"],
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "TDR-2023-MNJ"
+    def test_browse_series_filter_functionality_with_date_filter(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
     def test_browse_series_clear_filter_functionality(
-        self, aau_user_page: Page
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/c28cc3ab-c12a-4f06-82e1-18648c82a17f"
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.get_by_label("Sort by").select_option(
+            "records_held-desc"
         )
-        aau_user_page.get_by_label("Sort by").select_option("records_held-desc")
-        aau_user_page.get_by_role(
+        standard_user_page.get_by_role(
             "button", name="Apply", exact=True
-        ).first.click()
-        aau_user_page.get_by_label("Day").first.fill("01")
-        aau_user_page.get_by_role("button", name="Apply filters").click()
-        aau_user_page.get_by_role("link", name="Clear filters").click()
+        ).click()
+        standard_user_page.get_by_role("link", name="Clear filters").click()
 
-        assert aau_user_page.inner_text("#date_from_day") == ""
-        assert aau_user_page.inner_text("#date_from_month") == ""
-        assert aau_user_page.inner_text("#date_from_year") == ""
-        assert aau_user_page.inner_text("#date_to_day") == ""
-        assert aau_user_page.inner_text("#date_to_month") == ""
-        assert aau_user_page.inner_text("#date_to_year") == ""
+        assert standard_user_page.inner_text("#date_from_day") == ""
+        assert standard_user_page.inner_text("#date_from_month") == ""
+        assert standard_user_page.inner_text("#date_from_year") == ""
+        assert standard_user_page.inner_text("#date_to_day") == ""
+        assert standard_user_page.inner_text("#date_to_month") == ""
+        assert standard_user_page.inner_text("#date_to_year") == ""
         assert (
-            aau_user_page.get_by_label("", exact=True)
-            .nth(1)
-            .evaluate("el => el.options[el.selectedIndex].text")
+            standard_user_page.get_by_label("Sort by", exact=True).evaluate(
+                "el => el.options[el.selectedIndex].text"
+            )
             == "Records held in consignment (most first)"
         )

--- a/e2e_tests/test_browse_series.py
+++ b/e2e_tests/test_browse_series.py
@@ -228,6 +228,48 @@ class TestBrowseSeries:
         verify_header_row(header_rows)
         assert rows == expected_rows
 
+    def test_browse_series_date_filter_validation_date_from(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("12")
+        standard_user_page.locator("#date_from_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be in the past"
+        ).is_visible()
+
+    def test_browse_series_date_filter_validation_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date to’ must be in the past"
+        ).is_visible()
+
+    def test_browse_series_date_filter_validation_date_from_and_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.series_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2023")
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2022")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be the same as or before ‘31/12/2022’"
+        ).is_visible()
+
     def test_browse_series_clear_filter_functionality(
         self, standard_user_page: Page
     ):

--- a/e2e_tests/test_browse_transferring_body.py
+++ b/e2e_tests/test_browse_transferring_body.py
@@ -1,97 +1,276 @@
 from playwright.sync_api import Page
 
 
+def verify_header_row(header_rows):
+    assert header_rows[0] == [
+        "Transferring body",
+        "Series",
+        "Last consignment transferred",
+        "Records held in series",
+        "Consignments within series",
+    ]
+
+
 class TestBrowseTransferringBody:
     @property
     def route_url(self):
         return "/browse/transferring_body"
 
+    @property
+    def transferring_body_id(self):
+        return "c969a99f-dd61-4890-a8b4-6556d5d69915"
+
+    def test_browse_transferring_body_has_title(self, standard_user_page: Page):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+
+        assert (
+            standard_user_page.title()
+            == "Browse – AYR - Access Your Records – GOV.UK"
+        )
+
+    def test_browse_transferring_body_404_for_no_access(
+        self, standard_user_page: Page
+    ):
+        transferring_body_id = "6b63aa4d-7838-4010-b6f8-66fb3c07823d"
+
+        standard_user_page.goto(f"{self.route_url}/{transferring_body_id}")
+        assert standard_user_page.inner_html("text='Page not found'")
+        assert standard_user_page.inner_html(
+            "text='If you typed the web address, check it is correct.'"
+        )
+        assert standard_user_page.inner_html(
+            "text='If you pasted the web address, check you copied the entire address.'"
+        )
+
+    def test_browse_transferring_body_no_results_found(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#series_filter").click()
+        standard_user_page.locator("#series_filter").fill("junk")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.inner_html("text='No results found'")
+        assert standard_user_page.inner_html("text='Help with your search'")
+        assert standard_user_page.inner_html(
+            "text='Try changing or removing one or more applied filters.'"
+        )
+        assert standard_user_page.inner_html(
+            "text='Alternatively, use the breadcrumbs to navigate back to the browse view.'"
+        )
+
+    def test_browse_transferring_body_breadcrumb(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+
+        assert standard_user_page.inner_html("text='You are viewing'")
+        assert standard_user_page.inner_html("text='Everything'")
+        assert standard_user_page.inner_html("text='Testing A'")
+
+    def test_browse_transferring_body_no_pagination(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2022")
+
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert not standard_user_page.get_by_label("Page 1").is_visible()
+        assert not standard_user_page.get_by_label("Page 2").is_visible()
+        assert not standard_user_page.get_by_role(
+            "link", name="Nextpage"
+        ).is_visible()
+
     def test_browse_transferring_body_filter_functionality_with_query_string_parameters(
-        self, aau_user_page: Page
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/6b63aa4d-7838-4010-b6f8-66fb3c07823d?series_filter=&date_from_day"
-            "01=&date_from_month=07&date_from_year=2023&date_to_day=31&date_to_month=07&date_to_year=2023"
+        standard_user_page.goto(
+            f"{self.route_url}/{self.transferring_body_id}?series_filter=&date_from_day01=&"
+            f"date_from_month=01&date_from_year=2024&date_to_day=&date_to_month=&date_to_year="
         )
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Last record transferred",
-            "Records held",
-            "Consignments within series",
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "1"
-
-    def test_browse_transferring_body_sort_and_filter_functionality(
-        self, aau_user_page: Page
+    def test_browse_transferring_body_sort_functionality_by_series_descending(
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/6b63aa4d-7838-4010-b6f8-66fb3c07823d"
-        )
-        aau_user_page.get_by_label("", exact=True).nth(1).fill("mock")
-        aau_user_page.get_by_role("button", name="Apply filters").click()
-        aau_user_page.get_by_label("Sort by").select_option(
-            "last_record_transferred-desc"
-        )
-        aau_user_page.get_by_role("button", name="Apply filters").click()
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.get_by_label("Sort by").select_option("series-desc")
+        standard_user_page.get_by_role(
+            "button", name="Apply", exact=True
+        ).click()
 
-        table = aau_user_page.locator("#tbl_result").first
-        headers = table.locator("thead th").all_text_contents()
-        rows = table.locator("tbody tr")
-        cols = rows.first.locator("td")
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
 
-        assert headers == [
-            "Transferring body",
-            "Series",
-            "Last record transferred",
-            "Records held",
-            "Consignments within series",
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
         ]
 
-        assert rows.count() == 1
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
-        assert cols.nth(0).inner_text() == "MOCK1 Department"
-        assert cols.nth(1).inner_text() == "MOCK1 123"
-        assert cols.nth(2).inner_text() == "28/07/2023"
-        assert cols.nth(3).inner_text() == "1"
-        assert cols.nth(4).inner_text() == "1"
+    def test_browse_transferring_body_filter_functionality_with_series_filter(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#series_filter").fill("TSTA 1")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+        standard_user_page.get_by_role(
+            "button", name="Apply", exact=True
+        ).click()
+
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
+
+    def test_browse_transferring_body_filter_functionality_with_series_filter_wildcard_character(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#series_filter").fill("1")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
+
+    def test_browse_transferring_body_filter_functionality_with_date_filter(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        header_rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(0).map(el =>
+              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        rows = standard_user_page.locator(
+            "#tbl_result tr:visible"
+        ).evaluate_all(
+            """els => els.slice(1).map(el =>
+              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
+            )"""
+        )
+
+        assert len(rows) == 1
+
+        expected_rows = [
+            ["Testing A", "TSTA 1", "25/01/2024", "73", "7"],
+        ]
+
+        verify_header_row(header_rows)
+        assert rows == expected_rows
 
     def test_browse_transferring_body_clear_filter_functionality(
-        self, aau_user_page: Page
+        self, standard_user_page: Page
     ):
-        aau_user_page.goto(
-            f"{self.route_url}/6b63aa4d-7838-4010-b6f8-66fb3c07823d"
-        )
-        aau_user_page.get_by_label("Sort by").select_option("series-desc")
-        aau_user_page.get_by_role(
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.get_by_label("Sort by").select_option("series-desc")
+        standard_user_page.get_by_role(
             "button", name="Apply", exact=True
-        ).first.click()
-        aau_user_page.get_by_label("", exact=True).nth(1).fill("mock")
-        aau_user_page.get_by_role("button", name="Apply filters").click()
-        aau_user_page.get_by_role("link", name="Clear filters").click()
-
-        assert aau_user_page.inner_text("#series_filter") == ""
-        assert aau_user_page.inner_text("#date_from_day") == ""
-        assert aau_user_page.inner_text("#date_from_month") == ""
-        assert aau_user_page.inner_text("#date_from_year") == ""
-        assert aau_user_page.inner_text("#date_to_day") == ""
-        assert aau_user_page.inner_text("#date_to_month") == ""
-        assert aau_user_page.inner_text("#date_to_year") == ""
+        ).click()
+        standard_user_page.get_by_role("link", name="Clear filters").click()
+        assert standard_user_page.inner_text("#series_filter") == ""
+        assert standard_user_page.inner_text("#date_from_day") == ""
+        assert standard_user_page.inner_text("#date_from_month") == ""
+        assert standard_user_page.inner_text("#date_from_year") == ""
+        assert standard_user_page.inner_text("#date_to_day") == ""
+        assert standard_user_page.inner_text("#date_to_month") == ""
+        assert standard_user_page.inner_text("#date_to_year") == ""
         assert (
-            aau_user_page.get_by_label("Sort by", exact=True).evaluate(
+            standard_user_page.get_by_label("Sort by", exact=True).evaluate(
                 "el => el.options[el.selectedIndex].text"
             )
             == "Series (Z to A)"

--- a/e2e_tests/test_browse_transferring_body.py
+++ b/e2e_tests/test_browse_transferring_body.py
@@ -253,6 +253,48 @@ class TestBrowseTransferringBody:
         verify_header_row(header_rows)
         assert rows == expected_rows
 
+    def test_browse_transferring_body_date_filter_validation_date_from(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("12")
+        standard_user_page.locator("#date_from_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be in the past"
+        ).is_visible()
+
+    def test_browse_transferring_body_date_filter_validation_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2024")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date to’ must be in the past"
+        ).is_visible()
+
+    def test_browse_transferring_body_date_filter_validation_date_from_and_to_date(
+        self, standard_user_page: Page
+    ):
+        standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
+        standard_user_page.locator("#date_from_day").fill("1")
+        standard_user_page.locator("#date_from_month").fill("1")
+        standard_user_page.locator("#date_from_year").fill("2023")
+        standard_user_page.locator("#date_to_day").fill("31")
+        standard_user_page.locator("#date_to_month").fill("12")
+        standard_user_page.locator("#date_to_year").fill("2022")
+        standard_user_page.get_by_role("button", name="Apply filters").click()
+
+        assert standard_user_page.get_by_text(
+            "‘Date from’ must be the same as or before ‘31/12/2022’"
+        ).is_visible()
+
     def test_browse_transferring_body_clear_filter_functionality(
         self, standard_user_page: Page
     ):


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

1. added e2e tests for browse all, transferring body, series and consignment views including (title ,breadcrumb , pagination (no pagination, previous, next) (only for consignment view) , no/invalid access (except browse all view) , filter value in query string parameter, no results found , sorting , different filter options, date filter validations, clear filters)
3. removed unwanted <tr> tag on browse_consignment.html

## JIRA ticket

AYR - 829

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
