### PR TITLE
AYR-841/ Non text content (accessibility) 

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -169,7 +169,7 @@
                          height="100px"
                          width="100px"
                          src="{{ url_for('static', filename='image/the-national-archives-logo.svg') }}"
-                         alt="The National Archives Logo">
+                         alt="">
                 </div>
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                     <h2 class="govuk-visually-hidden">Support links</h2>

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -76,7 +76,7 @@
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
-                         alt="filter-icon">
+                         alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
                     <label class="govuk-label" for="transferring_body_filter">Transferring body</label>

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -86,7 +86,7 @@
                          height="32px"
                          width="32px"
                          class="consignment-filter__icon"
-                         alt="filter-icon">
+                         alt="">
                 </div>
                 <!-- RECORD STATUS -->
                 <h3 class="govuk-heading-s govuk-heading-s--consignment-filter">Record status</h3>

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -69,7 +69,7 @@
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
-                         alt="filter-icon">
+                         alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date consignment transferred</h3>
                 {% include "date-filters.html" %}

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -70,7 +70,7 @@
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
-                         alt="filter-icon">
+                         alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">Series</h3>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">

--- a/e2e_tests/test_login.py
+++ b/e2e_tests/test_login.py
@@ -36,18 +36,21 @@ def test_sign_in_succeeds_when_valid_credentials(page: Page):
         access_token, options={"verify_signature": False}
     )
     assert set(decoded_token_dict.keys()) == {
-        "exp",
-        "iat",
-        "auth_time",
-        "jti",
         "iss",
-        "sub",
-        "typ",
-        "azp",
-        "session_state",
-        "scope",
         "sid",
+        "iat",
+        "typ",
+        "exp",
+        "azp",
+        "preferred_username",
+        "sub",
+        "auth_time",
+        "session_state",
+        "jti",
+        "scope",
         "groups",
+        "upn",
+        "address",
     }
 
 

--- a/e2e_tests/test_login.py
+++ b/e2e_tests/test_login.py
@@ -36,21 +36,18 @@ def test_sign_in_succeeds_when_valid_credentials(page: Page):
         access_token, options={"verify_signature": False}
     )
     assert set(decoded_token_dict.keys()) == {
-        "iss",
-        "sid",
-        "iat",
-        "typ",
         "exp",
-        "azp",
-        "preferred_username",
-        "sub",
+        "iat",
         "auth_time",
-        "session_state",
         "jti",
+        "iss",
+        "sub",
+        "typ",
+        "azp",
+        "session_state",
         "scope",
+        "sid",
         "groups",
-        "upn",
-        "address",
     }
 
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- As per accessibility report, task was to use the null alt attribute “” to hide the image from screen reader users.
- Did this across all relevant pages;  browse views, and for the footer. 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-841
## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
