### PR TITLE
AYR-837 : Accessibility - reflow 

### DIFF
--- a/app/static/src/scss/includes/_header.scss
+++ b/app/static/src/scss/includes/_header.scss
@@ -8,9 +8,11 @@
   font-family: Arial, sans-serif !important;
 
   &__logo--ayr {
+    width: 100%;
     @include on-mobile {
       padding: 0;
       margin: 0;
+      width: 100%;
     }
   }
 
@@ -19,7 +21,7 @@
   }
 
   &__logotype--ayr {
-    white-space: nowrap;
+    white-space: normal;
     margin-top: 0;
     margin-bottom: 0;
 


### PR DESCRIPTION
… to normal and setting eh width to 100%

<!-- Amend as appropriate -->

## Changes in this PR

-  Set the whitespace on the TNA header to 'normal' so that it doesn't overflow when magnified at 400%. 
- Set the width of the header container to 100% in desktop view so that the header doesn't wrap. 

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-837
## Screenshots of UI changes

### Before

### After
<img width="1627" alt="Screenshot 2024-03-25 at 13 24 28" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/76947367/93569d7b-d30c-4904-8434-168bdd5c2357">

- [ ] Requires env variable(s) to be updated
