### PR TITLE
Change from 93vw to 100% to remove overflow bug

### DIFF
--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -419,7 +419,7 @@
   }
 
   .search__container__content {
-    width: 93vw;
+    width: 100%;
     margin: -15px;
     padding: 15px;
     display: flex;


### PR DESCRIPTION
## Changes in this PR

Switch from 93vw to 100% width for main search box to stop the box overflowing the screen on smaller widths.

## JIRA ticket

[none]

## Screenshots of UI changes

### Before

![test-one np ayr nationalarchives gov uk_browse](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/5471b3d0-9cc3-4d0c-81da-7be75deb9c29)

### After

![test-one np ayr nationalarchives gov uk_browse (1)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/ee24ef54-9281-4fbe-b168-d1b44849aed8)

- [ ] Requires env variable(s) to be updated