### PR TITLE
Remove display property that causes date fields to collapse on smaller screens

### DIFF
--- a/app/static/src/scss/includes/_browse-all.scss
+++ b/app/static/src/scss/includes/_browse-all.scss
@@ -224,7 +224,6 @@
 .govuk-date-input {
   &--browse-all-date-to {
     margin-left: 0;
-    display: inline-flex;
   }
 
   &__item--browse-all {


### PR DESCRIPTION
## Changes in this PR

Removed the `display: inline-flex;` that causes the fields in the "date to" to get misaligned on smaller screens and then collapse on really small screens.

## JIRA ticket

[none]

## Screenshots of UI changes

### Before 1

![test-one np ayr nationalarchives gov uk_browse (0)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/46377f26-fa44-4edc-bda3-7104d92c38c4)

### After 1

![test-one np ayr nationalarchives gov uk_browse (1)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/5f25bd61-770a-4d91-878f-fd7fd67a01be)

### Before 2

![test-one np ayr nationalarchives gov uk_browse (2)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/ae31512c-c86c-4432-8968-ab120a50a76f)

### After 2

![test-one np ayr nationalarchives gov uk_browse (3)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/529613c7-dfc2-450e-9d6d-a1f1c96f0fe0)

- [ ] Requires env variable(s) to be updated