### PR TITLE
Fix invalid address HTML in accessibility statement

### DIFF
--- a/app/templates/main/accessibility.html
+++ b/app/templates/main/accessibility.html
@@ -78,8 +78,8 @@
         <a href="mailto:tdr@nationalarchives.gov.uk" class="govuk-link">tdr@nationalarchives.gov.uk</a>
     </p>
     <h3 class="govuk-heading-s">Write to</h3>
-    <p class="govuk-body">
-        <address>
+    <address>
+        <p class="govuk-body">
             Digital Access Team c/o
             <br>
             Digital Archiving Department
@@ -92,8 +92,8 @@
             <br>
             TW9 4DU
             <br>
-        </address>
-    </p>
+        </p>
+    </address>
     <p class="govuk-body">We'll consider your request and get back to you.</p>
     <h2 class="govuk-heading-m">Enforcement prodcedure</h2>
     <p class="govuk-body">


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

`<p>` elements can only contain [phrasing content](https://developer.mozilla.org/en-US/docs/Web/HTML/Content_categories#phrasing_content) and `<address>` is flow content. It works the other way around though.

This also fixes the styles as Chrome was popping the `<address>` outside of the `.govuk-body` element to keep it valid.

## JIRA ticket

[none]

## Screenshots of UI changes

### Before

![test-one np ayr nationalarchives gov uk_accessibility (1)](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/89e3e95a-eb2b-4697-88da-b2ac8584e0b3)

### After

![test-one np ayr nationalarchives gov uk_accessibility](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/2356642/8bc4d970-ba61-4f7b-a934-488544b8411a)

- [ ] Requires env variable(s) to be updated
