### PR TITLE
AYR-934/browse_all_and_browse_transferring_body_content changes

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -1,14 +1,14 @@
 {% set sorting_list = {
     "Transferring body (A to Z)": "transferring_body-asc",
     "Transferring body (Z to A)": "transferring_body-desc",
-    "Series (A to Z)": "series-asc",
-    "Series (Z to A)": "series-desc",
-    "Date consignment transferred (most recent first)": "last_record_transferred-desc",
-    "Date consignment transferred (oldest first)": "last_record_transferred-asc",
-    "Records held in series (most first)": "records_held-desc",
-    "Records held in series (least first)": "records_held-asc"
+    "Series reference (A to Z)": "series-asc",
+    "Series reference (Z to A)": "series-desc",
+    "Transfer date (newest)": "last_record_transferred-desc",
+    "Transfer date (oldest)": "last_record_transferred-asc",
+    "Record total (most)": "records_held-desc",
+    "Record total (least)": "records_held-asc"
 } %}
-<p class="govuk-body govuk-body--browse-all-signpost">Everything available to you</p>
+<p class="govuk-body govuk-body--browse-all-signpost">All available records</p>
 <form action="{{ url_for('main.browse', _anchor='browse-records') }}"
       method="get">
     <div class="browse-layout">
@@ -28,20 +28,20 @@
                         <tr class="govuk-table__row">
                             <th scope="col"
                                 class="govuk-table__header browse-grid__key__transferring-body browse__all__mobile__header">
-                                Transferring body / Series
+                                Transferring body / Series reference
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse-grid__key__transferring-body browse__all__desktop__header">
                                 Transferring body
                             </th>
-                            <th scope="col" class="govuk-table__header browse__all__desktop__header">Series</th>
+                            <th scope="col" class="govuk-table__header browse__all__desktop__header">Series reference</th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__all__desktop__header browse__all__mobile__header">
-                                Last consignment transferred
+                                Last transfer date
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__table__mobile--hidden browse__all__desktop__header">
-                                Records held in series
+                                Record total
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__table__mobile--hidden browse__all__desktop__header">
@@ -106,7 +106,7 @@
                          alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="transferring_body_filter">Transferring body</label>
+                    <label class="govuk-label" for="transferring_body_filter">Select transferring body</label>
                 </h3>
                 <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
                     <select class="govuk-select govuk-select__filters-form-transferring-body-select"
@@ -129,7 +129,7 @@
             </div>
             <div class="browse-all-filter-container browse-all-filter-container--file-type">
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="series_filter">Series</label>
+                    <label class="govuk-label" for="series_filter">Series reference</label>
                 </h3>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">
                     <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
@@ -140,7 +140,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date consignment transferred</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -1,14 +1,14 @@
 {% set breadcrumbs = {
-    "everything":"Everything",
+    "everything":"All available records",
     "body": breadcrumb_values[0]["transferring_body"]
 } %}
 {% set sorting_list = {
-    "Series (A to Z)": "series-asc",
-    "Series (Z to A)": "series-desc",
-    "Date consignment transferred (most recent first)": "last_record_transferred-desc",
-    "Date consignment transferred (oldest first)": "last_record_transferred-asc",
-    "Records held in series (most first)": "records_held-desc",
-    "Records held in series (least first)": "records_held-asc"
+    "Series reference (A to Z)": "series-asc",
+    "Series reference (Z to A)": "series-desc",
+    "Transfer date (newest)": "last_record_transferred-desc",
+    "Transfer date (oldest)": "last_record_transferred-asc",
+    "Record total (most)": "records_held-desc",
+    "Record total (least)": "records_held-asc"
 } %}
 <!-- BREAD CRUMB -->
 {% with dict = breadcrumbs %}
@@ -36,18 +36,20 @@
                                 Transferring body
                             </th>
                             <th scope="col"
-                                class="govuk-table__header browse__transferring-body__desktop__header">Series</th>
+                                class="govuk-table__header browse__transferring-body__desktop__header">
+                                Series reference
+                            </th>
                             <th scope="col"
                                 class="govuk-table__header browse__transferring-body__mobile__header">
-                                Series / Last consignment transferred
+                                Series reference / Last transfer date
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__transferring-body__desktop__header">
-                                Last consignment transferred
+                                Last transfer date
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__transferring-body__desktop__header browse__transferring-body__mobile__header">
-                                Records held in series
+                                Record total
                             </th>
                             <th scope="col"
                                 class="govuk-table__header browse__table__right-align browse__transferring-body__desktop__header browse__transferring-body__mobile__header">
@@ -103,7 +105,7 @@
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
                     <label class="govuk-label govuk-heading-s govuk-heading-s--series"
-                           for="series_filter">Series</label>
+                           for="series_filter">Series reference</label>
                 </h3>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">
                     <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
@@ -114,7 +116,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date consignment transferred</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -18,9 +18,9 @@ def verify_browse_view_header_row(data):
     expected_row = (
         [
             "Transferring body",
-            "Series",
-            "Last consignment transferred",
-            "Records held in series",
+            "Series reference",
+            "Last transfer date",
+            "Record total",
             "Consignments within series",
         ],
     )
@@ -157,7 +157,7 @@ class TestBrowse:
         assert response.status_code == 200
         assert b"Search for digital records" in response.data
         assert b"You are viewing" in response.data
-        assert b"Everything available to you" in response.data
+        assert b"All available records" in response.data
 
     def test_browse_filter_no_results(
         self, client: FlaskClient, mock_all_access_user

--- a/app/tests/test_browse_consignment.py
+++ b/app/tests/test_browse_consignment.py
@@ -56,7 +56,8 @@ class TestConsignment:
         Given a user accessing the browse page
         When they make a GET request with a consignment id
         Then they should see results based on consignment filter on browse page content.
-        And breadcrumb should show 'Everything' > transferring body name > series name > consignment reference
+        And breadcrumb should show 'All available records' > transferring body name > series name
+        > consignment reference
         """
         consignment_id = browse_consignment_files[0].consignment.ConsignmentId
 

--- a/app/tests/test_browse_transferring_body.py
+++ b/app/tests/test_browse_transferring_body.py
@@ -26,9 +26,9 @@ def verify_transferring_body_view_header_row(data):
     expected_row = (
         [
             "Transferring body",
-            "Series",
-            "Last consignment transferred",
-            "Records held in series",
+            "Series reference",
+            "Last transfer date",
+            "Record total",
             "Consignments within series",
         ],
     )
@@ -52,7 +52,7 @@ class TestBrowseTransferringBody:
         Given a user accessing the browse page
         When they make a GET request with a transferring body id
         Then they should see results based on transferring body filter on browse page content.
-        And breadcrumb should show 'Everything' > transferring body name
+        And breadcrumb should show 'All available records' > transferring body name
         """
         transferring_body_id = browse_transferring_body_files[
             0
@@ -74,7 +74,7 @@ class TestBrowseTransferringBody:
         <div class="govuk-breadcrumbs">
             <ol class="govuk-breadcrumbs__list">
                 <li class="govuk-breadcrumbs__list-item">
-                <a class="govuk-breadcrumbs__link--record" href="/browse">Everything</a>
+                <a class="govuk-breadcrumbs__link--record" href="/browse">All available records</a>
                 </li>
                 <li class="govuk-breadcrumbs__list-item">
                 <span class="govuk-breadcrumbs__link govuk-breadcrumbs__link--record">

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -1,22 +1,12 @@
 from playwright.sync_api import Page
 
 
-def verify_header_row(header_rows):
-    assert header_rows[0] == [
-        "Transferring body",
-        "Series",
-        "Last consignment transferred",
-        "Records held in series",
-        "Consignments within series",
-    ]
-
-
 def verify_browse_all_header_row(header_rows):
     assert header_rows == [
         "Transferring body",
-        "Series",
-        "Last consignment transferred",
-        "Records held in series",
+        "Series reference",
+        "Last transfer date",
+        "Record total",
         "Consignments within series",
     ]
 
@@ -44,7 +34,7 @@ class TestBrowse:
         aau_user_page.goto(f"{self.route_url}")
 
         assert aau_user_page.inner_html("text='You are viewing'")
-        assert aau_user_page.inner_html("text='Everything available to you'")
+        assert aau_user_page.inner_html("text='All available records'")
 
     def test_browse_filter_functionality_with_query_string_parameters(
         self, aau_user_page: Page

--- a/e2e_tests/test_browse_transferring_body.py
+++ b/e2e_tests/test_browse_transferring_body.py
@@ -4,9 +4,9 @@ from playwright.sync_api import Page
 def verify_header_row(header_rows):
     assert header_rows[0] == [
         "Transferring body",
-        "Series",
-        "Last consignment transferred",
-        "Records held in series",
+        "Series reference",
+        "Last transfer date",
+        "Record total",
         "Consignments within series",
     ]
 
@@ -57,7 +57,7 @@ class TestBrowseTransferringBody:
         standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
 
         assert standard_user_page.inner_html("text='You are viewing'")
-        assert standard_user_page.inner_html("text='Everything'")
+        assert standard_user_page.inner_html("text='All available records'")
         assert standard_user_page.inner_html("text='Testing A'")
 
     def test_browse_transferring_body_no_pagination(
@@ -329,5 +329,5 @@ class TestBrowseTransferringBody:
             standard_user_page.get_by_label("Sort by", exact=True).evaluate(
                 "el => el.options[el.selectedIndex].text"
             )
-            == "Series (Z to A)"
+            == "Series reference (Z to A)"
         )


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
1. updated content in browse-all.html and browse-transferring-body.html, 
2. updated relevant test cases in test_browse.py and test_browse_transferring_body.py
3. updated e2e test cases in test_browse.py and test_browse_transferring_body.py

## JIRA ticket

AYR - 934

## Screenshots of UI changes

### Before
browse - AAU user
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/0233fd6f-05af-42c0-b0f5-39fde24877d0)

browse - standard user
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/f1a5feea-716d-4a4a-a26c-32465ff2a4f5)

### After
browse - AAU user
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/7631d908-94ff-4f23-926a-cc9c2784e2d5)

browse - standard user
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/107114665/6632d2ea-2f3e-4ef6-8904-4a7a62e6fb35)

- [ ] Requires env variable(s) to be updated
