### PR TITLE
AYR-963/fix download record with file extension

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -637,11 +637,18 @@ def download_record(record_id: uuid.UUID):
 
     s3_file_object = s3.get_object(Bucket=bucket, Key=key)
 
+    download_filename = file.FileName
+
+    if file.CiteableReference:
+        if len(file.FileName.rsplit(".", 1)) > 1:
+            download_filename = (
+                file.CiteableReference + "." + file.FileName.rsplit(".", 1)[1]
+            )
+
     response = Response(
         s3_file_object["Body"].read(),
         headers={
-            "Content-Disposition": "attachment;filename="
-            + (file.CiteableReference or file.FileName)
+            "Content-Disposition": "attachment;filename=" + download_filename
         },
     )
 

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -1,4 +1,5 @@
 import boto3
+from flask.testing import FlaskClient
 from moto import mock_aws
 
 from app.tests.factories import FileFactory
@@ -12,125 +13,159 @@ def create_mock_s3_bucket_with_object(bucket_name, file):
 
     bucket = s3.create_bucket(Bucket=bucket_name)
 
-    object = s3.Object(
+    file_object = s3.Object(
         bucket_name, f"{file.consignment.ConsignmentReference}/{file.FileId}"
     )
-    object.put(Body="record")
+    file_object.put(Body="record")
     return bucket
 
 
-def test_invalid_id_raises_404(client):
-    """
-    Given a UUID, `invalid_file_id`, not corresponding to the id
-        of a file in the database
-    When a GET request is made to `/download/invalid_file_id`
-    Then a 404 http response is returned
-    """
-    response = client.get("/download/some-id")
+class TestDownload:
+    @property
+    def route_url(self):
+        return "/download"
 
-    assert response.status_code == 404
+    def test_invalid_id_raises_404(self, client: FlaskClient):
+        """
+        Given a UUID, not corresponding to the id of a file in the database
+        When a GET request is made to download route
+        Then a 404 http response is returned
+        """
+        response = client.get(f"{self.route_url}/some-id")
 
+        assert response.status_code == 404
 
-@mock_aws
-def test_downloads_record_successfully_for_user_with_access_to_files_transferring_body(
-    app, client, mock_standard_user
-):
-    """
-    Given a File in the database with corresponding file in the s3 bucket
-    When a standard user with access to the file's transferring body makes a
-        request to download record
-    Then the response status code should be 200
-    And the file should contain the expected content
-    And the the downloaded filename should be the File's CiteableReference
-    """
-    bucket_name = "test_bucket"
-    file = FileFactory(
-        FileType="file",
-    )
-    create_mock_s3_bucket_with_object(bucket_name, file)
-    app.config["RECORD_BUCKET_NAME"] = bucket_name
+    @mock_aws
+    def test_download_record_standard_user_with_citable_reference_with_file_extension(
+        self, app, client, mock_standard_user
+    ):
+        """
+        Given a File in the database with corresponding file in the s3 bucket
+        When a standard user with access to the file's transferring body makes a
+            request to download record
+        Then the response status code should be 200
+        And the file should contain the expected content
+        And the downloaded filename should be the File's CiteableReference with extension
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(FileType="file", FileName="testfile.doc")
 
-    mock_standard_user(client, file.consignment.series.body.Name)
-    response = client.get(f"/download/{file.FileId}")
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-    assert response.status_code == 200
-    assert (
-        response.headers["Content-Disposition"]
-        == f"attachment;filename={file.CiteableReference}"
-    )
-    assert response.data == b"record"
+        mock_standard_user(client, file.consignment.series.body.Name)
+        response = client.get(f"{self.route_url}/{file.FileId}")
 
+        assert response.status_code == 200
 
-@mock_aws
-def test_downloads_record_successfully_for_user_with_access_to_files_transferring_body_without_citable_reference(
-    app, client, mock_standard_user
-):
-    """
-    Given a File in the database with corresponding file in the s3 bucket
-        without a CiteableReference
-    When a standard user with access to the file's transferring body makes a
-        request to download record
-    Then the response status code should be 200
-    And the file should contain the expected content
-    And the the downloaded filename should be File's FileName
-    """
-    bucket_name = "test_bucket"
-    file = FileFactory(FileType="file", CiteableReference=None)
-    create_mock_s3_bucket_with_object(bucket_name, file)
-    app.config["RECORD_BUCKET_NAME"] = bucket_name
+        assert (
+            response.headers["Content-Disposition"]
+            == f"attachment;filename={file.CiteableReference}.doc"
+        )
+        assert response.data == b"record"
 
-    mock_standard_user(client, file.consignment.series.body.Name)
-    response = client.get(f"/download/{file.FileId}")
+    @mock_aws
+    def test_download_record_standard_user_with_citable_reference_without_file_extension(
+        self, app, client, mock_standard_user
+    ):
+        """
+        Given a File in the database with corresponding file in the s3 bucket
+        When a standard user with access to the file's transferring body makes a
+            request to download record
+        Then the response status code should be 200
+        And the file should contain the expected content
+        And the downloaded filename should be the filename with extension
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file",
+        )
 
-    assert response.status_code == 200
-    assert (
-        response.headers["Content-Disposition"]
-        == f"attachment;filename={file.FileName}"
-    )
-    assert response.data == b"record"
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
 
+        mock_standard_user(client, file.consignment.series.body.Name)
+        response = client.get(f"{self.route_url}/{file.FileId}")
 
-@mock_aws
-def test_raises_404_for_user_without_access_to_files_transferring_body(
-    app, client, mock_standard_user
-):
-    """
-    Given a File in the database
-    When a standard user without access to the file's consignment body makes a
-        request to download record
-    Then the response status code should be 404
-    """
-    bucket_name = "test_bucket"
-    file = FileFactory(
-        FileType="file",
-    )
-    create_mock_s3_bucket_with_object(bucket_name, file)
-    app.config["RECORD_BUCKET_NAME"] = bucket_name
+        assert response.status_code == 200
 
-    mock_standard_user(client, "different_body")
-    response = client.get(f"/download/{file.FileId}")
+        assert (
+            response.headers["Content-Disposition"]
+            == f"attachment;filename={file.FileName}"
+        )
+        assert response.data == b"record"
 
-    assert response.status_code == 404
+    @mock_aws
+    def test_download_record_standard_user_without_citable_reference(
+        self, app, client, mock_standard_user
+    ):
+        """
+        Given a File in the database with corresponding file in the s3 bucket
+            without a CiteableReference
+        When a standard user with access to the file's transferring body makes a
+            request to download record
+        Then the response status code should be 200
+        And the file should contain the expected content
+        And the downloaded filename should be fileName with extension
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file", FileName="testfile.doc", CiteableReference=None
+        )
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
 
+        mock_standard_user(client, file.consignment.series.body.Name)
+        response = client.get(f"{self.route_url}/{file.FileId}")
 
-@mock_aws
-def test_downloads_record_successfully_for_all_access_user(
-    app, client, mock_all_access_user
-):
-    """
-    Given a File in the database
-    And an all_access_user
-    When the all_access_user makes a request to download record
-    Then the response status code should be 200
-    """
-    bucket_name = "test_bucket"
-    file = FileFactory(
-        FileType="file",
-    )
-    create_mock_s3_bucket_with_object(bucket_name, file)
-    app.config["RECORD_BUCKET_NAME"] = bucket_name
+        assert response.status_code == 200
 
-    mock_all_access_user(client)
-    response = client.get(f"/download/{file.FileId}")
+        assert (
+            response.headers["Content-Disposition"]
+            == f"attachment;filename={file.FileName}"
+        )
+        assert response.data == b"record"
 
-    assert response.status_code == 200
+    @mock_aws
+    def test_raises_404_for_standard_user_without_access_to_files_transferring_body(
+        self, app, client, mock_standard_user
+    ):
+        """
+        Given a File in the database
+        When a standard user without access to the file's consignment body makes a
+            request to download record
+        Then the response status code should be 404
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file",
+        )
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+
+        mock_standard_user(client, "different_body")
+        response = client.get(f"{self.route_url}/{file.FileId}")
+
+        assert response.status_code == 404
+
+    @mock_aws
+    def test_download_record_for_all_access_user_valid_response(
+        self, app, client, mock_all_access_user
+    ):
+        """
+        Given a File in the database
+        And an all_access_user
+        When the all_access_user makes a request to download record
+        Then the response status code should be 200
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file",
+        )
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+
+        mock_all_access_user(client)
+        response = client.get(f"{self.route_url}/{file.FileId}")
+
+        assert response.status_code == 200

--- a/e2e_tests/test_record.py
+++ b/e2e_tests/test_record.py
@@ -192,4 +192,4 @@ class TestRecord:
         with standard_user_page.expect_download() as download_record:
             standard_user_page.get_by_text("Download record").click()
         download = download_record.value
-        assert "TSTA 1_ZD5B3S" == download.suggested_filename
+        assert "TSTA 1_ZD5B3S.doc" == download.suggested_filename


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
1. updated download route logic to add file extension when citeable_reference used in routes.py
2. updated related test cases in test_download.py and e2e_tests/test_record.py

## JIRA ticket

AYR - 963

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
