### PR TITLE
AYR-977 - 'search transferring body' view overlapping filter tray on table

### DIFF
--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -106,6 +106,11 @@
       &:visited {
         color: #1d70b8;
       }
+
+      // this is a temp fix, the overall problem is that .govuk-table__cell is overwritten in multiple places, should be fixed with css refactoring
+      &.word-break {
+        word-break: break-word;
+      }
     }
   }
 }

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -100,7 +100,8 @@
                                                             <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row search__table__mobile--hidden">
-                                                            <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                            <a class="word-break"
+                                                               href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
                                                             <strong class="{% if record['closure_type'] == 'Open' %}govuk-tag govuk-tag--green{% elif record['closure_type'] == 'Closed' %}govuk-tag govuk-tag--red{% elif record['closure_type'] is none %}{% endif %}">
@@ -117,7 +118,8 @@
                                                     </tr>
                                                     <tr class="govuk-table__row search__mobile-row">
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row">
-                                                            <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                            <a class="word-break"
+                                                               href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -618,7 +618,7 @@ class TestSearchTransferringBody:
             </td>
             <td class="govuk-table__cell govuk-table__cell--search-results
             search__mobile-table__top-row search__table__mobile--hidden">
-                <a href="{record_route_url}/{file_id}">first_file.docx</a>
+                <a class="word-break" href="{record_route_url}/{file_id}">first_file.docx</a>
             </td>
             <td class="govuk-table__cell govuk-table__cell--search-results
             search__mobile-table__top-row">
@@ -634,7 +634,7 @@ class TestSearchTransferringBody:
             <tr class="govuk-table__row search__mobile-row">
             <td class="govuk-table__cell govuk-table__cell--search-results
             search__mobile-table__middle-row">
-                <a href="{record_route_url}/{file_id}">
+                <a class="word-break" href="{record_route_url}/{file_id}">
                 first_file.docx
                 </a>
             </td>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

There existed an edge case where file name links with no spaces were making the file name column oversized, thus leading to the results table overflowing out of its container, the change to fix this was making the file name anchor link word-break when too large.

note: During the CSS refactor the parent class of this anchor should be completely changed, given that its used and overwritten multiple times throughout the application - having it in one place and re-using it in the future should be much better.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-977

## Screenshots of UI changes

### Before
<img width="1475" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/25c59819-3623-4457-a957-e66ff9235eaa">
<img width="351" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/6bab6f76-c037-4f83-a1d6-2103cc390d97">


### After
<img width="1475" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/55f24be0-62b3-4d0b-88c7-ce227a3695a5">
<img width="354" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/e11fe636-8dbe-49c4-9b5b-96eaeb67d609">


- [ ] Requires env variable(s) to be updated
