### PR TITLE
AYR-957 - Close sessions on e2e test teardown

### DIFF
--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -41,7 +41,8 @@ def aau_user_page(create_user_page) -> Page:
     username = os.environ.get("AYR_AAU_USER_USERNAME")
     password = os.environ.get("AYR_AAU_USER_PASSWORD")
     page = create_user_page(username, password)
-    return page
+    yield page
+    page.goto("/sign-out")
 
 
 @pytest.fixture
@@ -49,7 +50,8 @@ def standard_user_page(create_user_page) -> Page:
     username = os.environ.get("AYR_STANDARD_USER_USERNAME")
     password = os.environ.get("AYR_STANDARD_USER_PASSWORD")
     page = create_user_page(username, password)
-    return page
+    yield page
+    page.goto("/sign-out")
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

For each of the "..._user_page" fixture files inside of conftest.py:

- changed the return of the page to a yield, essentially putting the rest of the function on standby until the function its returning a value to has a chance to run
- added a goto after the yield to redirect to the sign out page, effectively ending the session

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-957

## Screenshots of UI changes

No visual changes to the app

### Before

N/A

### After

N/A

- [ ] Requires env variable(s) to be updated
