### PR TITLE
AYR-1004 - Reactor search page styles

### DIFF
--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -17,7 +17,7 @@
 // DESKTOP STYLES
 
 .govuk {
-  &-grid-column-full__browse-details {
+  &-grid-column-full__page_container {
     padding: 0;
   }
 

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -8,7 +8,7 @@
         {% include "top-search.html" %}
         {% if results %}
             <!-- TABLE -->
-            <div class="govuk-grid-column-full govuk-grid-column-full__browse-details">
+            <div class="govuk-grid-column-full govuk-grid-column-full__page_container">
                 <div class="browse-details">
                     <h1 class="govuk-heading-l browse__records-found__text"
                         id="browse-records">

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -26,7 +26,7 @@
                 {% endwith %}
                 {% if num_records_found > 0 %}
                     <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds__search-results-summary">
-                        <table class="govuk-table govuk-table--results-summary"
+                        <table class="govuk-table browse-grid__table"
                                id="tbl_result"
                                aria-label="Record search results">
                             <thead class="govuk-table__head">

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -1,6 +1,27 @@
 {% extends "base.html" %}
 {% block pageTitle %}Search results – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {%- from 'govuk_frontend_jinja/components/inset-text/macro.html' import govukInsetText -%}
+{% set breadcrumbs = {} %}
+{% if session["user_type"] == "all_access_user" %}
+    {%- set _ = breadcrumbs.update({'everything': "All available records"}) -%}
+    {%- set _ = breadcrumbs.update({'summary': [breadcrumb_values[0]["query"], "Results summary"]}) -%}
+{% endif %}
+{%- set _ = breadcrumbs.update({'body': [breadcrumb_values[1]["transferring_body_id"], breadcrumb_values[2]["transferring_body"]] }) -%}
+{% if breadcrumb_values[3] %}
+    {%- set _ = breadcrumbs.update({'search_terms': breadcrumb_values[3]["search_terms"]}) -%}
+{% endif %}
+{% set sorting_list = {
+    "Series reference (A to Z)": "series-asc",
+    "Series reference (Z to A)": "series-desc",
+    "Consignment reference (newest)": "consignment_reference-desc",
+    "Consignment reference (oldest)": "consignment_reference-asc",
+    "File name (A to Z)": "file_name-asc",
+    "File name (Z to A)": "file_name-desc",
+    "Record opening date (sooner)": "opening_date-desc",
+    "Record opening date (later)": "opening_date-asc",
+    "Record status (closed)": "closure_type-asc",
+    "Record status (open)": "closure_type-desc"
+} %}
 {% block beforeContent %}{{ super() }}{% endblock %}
 {% block content %}
     <!-- SEARCH  -->
@@ -8,7 +29,7 @@
         {{ super() }}
         {% include "top-search.html" %}
         <!-- TABLE -->
-        <div class="govuk-grid-column-full govuk-grid-column-full--mobile-search">
+        <div class="govuk-grid-column-full govuk-grid-column-full__page_container">
             <div class="browse-details">
                 <h1 class="govuk-heading-l browse__records-found__text"
                     id="browse-records">
@@ -19,72 +40,197 @@
                     {% endif %}
                 </h1>
                 <p class="govuk-body browse__body">You are viewing</p>
-                {% set breadcrumbs = {} %}
-                {% if session["user_type"] == "all_access_user" %}
-                    {%- set _ = breadcrumbs.update({'everything': "All available records"}) -%}
-                    {%- set _ = breadcrumbs.update({'summary': [breadcrumb_values[0]["query"], "Results summary"]}) -%}
-                {% endif %}
-                {%- set _ = breadcrumbs.update({'body': [breadcrumb_values[1]["transferring_body_id"], breadcrumb_values[2]["transferring_body"]] }) -%}
-                {% if breadcrumb_values[3] %}
-                    {%- set _ = breadcrumbs.update({'search_terms': breadcrumb_values[3]["search_terms"]}) -%}
-                {% endif %}
-                {% set sorting_list = {
-                    "Series reference (A to Z)": "series-asc",
-                    "Series reference (Z to A)": "series-desc",
-                    "Consignment reference (newest)": "consignment_reference-desc",
-                    "Consignment reference (oldest)": "consignment_reference-asc",
-                    "File name (A to Z)": "file_name-asc",
-                    "File name (Z to A)": "file_name-desc",
-                    "Record opening date (sooner)": "opening_date-desc",
-                    "Record opening date (later)": "opening_date-asc",
-                    "Record status (closed)": "closure_type-asc",
-                    "Record status (open)": "closure_type-desc"
-                } %}
                 <!-- BREAD CRUMB -->
                 {% with dict = breadcrumbs %}
                     {% include "breadcrumb.html" %}
                 {% endwith %}
                 <form action="{{ url_for('main.search_transferring_body', _id = request.view_args['_id'], _anchor='browse-records') }}"
                       method="get">
-                    <input type="hidden" name="query" value="{{ filters['query'] }}">
-                    <div class="search-layout">
+                    <div class="browse-layout">
+                        <!-- SORT -->
                         {% if num_records_found > 0 %}
-                            <!-- SORT -->
                             <div class="govuk-form-group sort-container__form">
                                 {% with dict = sorting_list %}
                                     {% include "sorting-list.html" %}
                                 {% endwith %}
                             </div>
+                            <input type="hidden" name="query" value="{{ filters['query'] }}">
+                            <div class="govuk-grid-column-two-thirds browse-grid--two-thirds browse-grid--mobile-table">
+                                <table class="govuk-table browse-grid__table"
+                                       id="tbl_result"
+                                       aria-label="Browse records">
+                                    <thead class="govuk-table__head">
+                                        <tr class="govuk-table__row">
+                                            <th scope="col"
+                                                class="govuk-table__header browse-grid__key__transferring-body browse__all__desktop__header">
+                                                Series reference
+                                            </th>
+                                            <th scope="col"
+                                                class="govuk-table__header govuk-table__header--search-header search__mobile-heading">
+                                                Series reference / File name / Consignment reference
+                                            </th>
+                                            <th scope="col"
+                                                class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
+                                                Consignment reference
+                                            </th>
+                                            <th scope="col"
+                                                class="govuk-table__header govuk-table__header--search-header govuk-table__header--search-header-title search__desktop-heading">
+                                                File name
+                                            </th>
+                                            <th scope="col"
+                                                class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
+                                                Status
+                                            </th>
+                                            <th scope="col"
+                                                class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
+                                                Record opening date
+                                            </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody class="govuk-table__body">
+                                        <div class="main-content" id="main-content" role="main">
+                                            {% for record in results %}
+                                                <tr class="govuk-table__row top-row">
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
+                                                        <a href="{{ url_for('main.browse_series', _id=record['series_id']) }}">{{ record["series"] }}</a>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results govuk-table__cell--search-results-no-wrap search__mobile-table__top-row search__table__mobile--hidden">
+                                                        <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row search__table__mobile--hidden">
+                                                        <a class="word-break"
+                                                           href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
+                                                        <strong class="{% if record['closure_type'] == 'Open' %}govuk-tag govuk-tag--green{% elif record['closure_type'] == 'Closed' %}govuk-tag govuk-tag--red{% elif record['closure_type'] is none %}{% endif %}">
+                                                            {{ record['closure_type'] }}
+                                                        </strong>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results right-align search__mobile-table__top-row">
+                                                        {% if record['opening_date'] %}
+                                                            {{ record['opening_date'] }}
+                                                        {% else %}
+                                                            -
+                                                        {% endif %}
+                                                    </td>
+                                                </tr>
+                                                <tr class="govuk-table__row search__mobile-row">
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row">
+                                                        <a class="word-break"
+                                                           href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>
+                                                </tr>
+                                                <tr class="govuk-table__row search__mobile-row">
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results govuk-table__cell--search-results-no-wrap">
+                                                        <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
+                                                    </td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results"></td>
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results"></td>
+                                                </tr>
+                                            {% endfor %}
+                                        </div>
+                                    </tbody>
+                                </table>
+                                <!-- PAGINATION -->
+                                {% with view_name='main.search_transferring_body', id = request.view_args['_id'] %}
+                                    {% include "pagination.html" %}
+                                {% endwith %}
+                                <!-- END PAGINATION -->
+                            </div>
+                        {% else %}
+                            {% with view_type = "search" %}
+                                {% include "no-results-found.html" %}
+                            {% endwith %}
+                        {% endif %}
+                        <!-- FILTERS -->
+                        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
+                            <div class="browse-all-filter-container">
+                                <div class="browse-filter__header">
+                                    <h2 class="govuk-heading-m govuk-heading-m--search">
+                                        <label class="govuk-label govuk-heading-m govuk-heading-m--search"
+                                               for="search_filter">Search within results</label>
+                                    </h2>
+                                </div>
+                                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                                    <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
+                                           id="search_filter"
+                                           name="search_filter"
+                                           type="text">
+                                </div>
+                                <div class="search-form__buttons">
+                                    <button type="submit"
+                                            class="govuk-button govuk-button__search-filters-form-apply-button"
+                                            data-module="govuk-button">Apply terms</button>
+                                    <a class="govuk-link govuk-link--transferring-filter"
+                                       href="{% if session['user_type'] == 'all_access_user' %}{{ url_for('main.browse', _anchor='browse-records') }}{% else %}{{ url_for('main.browse_transferring_body', _id = request.view_args['_id'], _anchor='browse-records') }}{% endif %}">Clear all terms</a>
+                                </div>
+                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+                                <div class="ayr-filter-tags">
+                                    {% for i in range(search_terms | length) %}
+                                        <div class="search-term">
+                                            {% if i == 0 %}
+                                                {% set new_query = filters['query'].replace(search_terms[i] ~ ',','') %}
+                                            {% else %}
+                                                {% set new_query = filters['query'].replace(',' ~ search_terms[i],'') %}
+                                            {% endif %}
+                                            {% if search_terms | length == 1 %}
+                                                {% set search_term_url = url_for('main.browse_transferring_body', _id = request.view_args['_id']) %}
+                                            {% else %}
+                                                {% set search_term_url = url_for('main.search_transferring_body', _id = request.view_args['_id'], query=new_query) %}
+                                            {% endif %}
+                                            <button type="button"
+                                                    class="button-search-term"
+                                                    data-module="search-term-button">
+                                                <a href="{{ search_term_url }}">
+                                                    {{ search_terms[i] }}
+                                                    <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}"
+                                                         height="30px"
+                                                         width="30px"
+                                                         class="close-icon"
+                                                         alt="">
+                                                </a>
+                                            </button>
+                                        </div>
+                                    {% endfor %}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </form>
+                <!-- <form action="{{ url_for('main.search_transferring_body', _id = request.view_args['_id'], _anchor='browse-records') }}" method="get">
+                    <input type="hidden" name="query" value="{{ filters['query'] }}">
+                    <div class="search-layout">
+                            {% if num_records_found > 0 %}
+
+                            <div class="govuk-form-group sort-container__form">
+                                {% with dict = sorting_list %}
+                                    {% include "sorting-list.html" %}
+                                {% endwith %}
+                            </div>
+
                             <div class="govuk-grid-row">
-                                <!-- TABLE -->
                                 <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds--search-results mobile-table">
-                                    <table class="govuk-table"
-                                           id="tbl_result"
-                                           aria-label="Record search results">
+                                    <table class="govuk-table browse-grid__table" id="tbl_result" aria-label="Record search results">
                                         <thead class="govuk-table__head">
                                             <tr class="govuk-table__row">
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
                                                     Series reference
                                                 </th>
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header search__mobile-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header search__mobile-heading">
                                                     Series reference / File name / Consignment reference
                                                 </th>
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
                                                     Consignment reference
                                                 </th>
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header govuk-table__header--search-header-title search__desktop-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header govuk-table__header--search-header-title search__desktop-heading">
                                                     File name
                                                 </th>
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
                                                     Status
                                                 </th>
-                                                <th scope="col"
-                                                    class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
+                                                <th scope="col" class="govuk-table__header govuk-table__header--search-header search__desktop-heading search__mobile-heading">
                                                     Record opening date
                                                 </th>
                                             </tr>
@@ -100,8 +246,7 @@
                                                             <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row search__table__mobile--hidden">
-                                                            <a class="word-break"
-                                                               href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                            <a class="word-break" href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
                                                             <strong class="{% if record['closure_type'] == 'Open' %}govuk-tag govuk-tag--green{% elif record['closure_type'] == 'Closed' %}govuk-tag govuk-tag--red{% elif record['closure_type'] is none %}{% endif %}">
@@ -118,8 +263,7 @@
                                                     </tr>
                                                     <tr class="govuk-table__row search__mobile-row">
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row">
-                                                            <a class="word-break"
-                                                               href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
+                                                            <a class="word-break" href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                                         </td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>
                                                         <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__middle-row"></td>
@@ -135,37 +279,28 @@
                                             </div>
                                         </tbody>
                                     </table>
-                                    <!-- PAGINATION -->
                                     {% with view_name='main.search_transferring_body', id = request.view_args['_id'] %}
                                         {% include "pagination.html" %}
                                     {% endwith %}
-                                </div>
+                            </div>
                             {% else %}
                                 {% with view_type = "search" %}
                                     {% include "no-results-found.html" %}
                                 {% endwith %}
                             {% endif %}
-                            <!-- FILTER TRAY -->
-                            <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters mobile-filters">
+                            <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
                                 <div class="search-all-filter-container">
                                     <div class="browse-filter__header">
                                         <h2 class="govuk-heading-m govuk-heading-m--search">
-                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search"
-                                                   for="search_filter">Search within results</label>
+                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search" for="search_filter">Search within results</label>
                                         </h2>
                                     </div>
                                     <div class="govuk-form-group govuk-form-group--search-all-filter">
-                                        <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
-                                               id="search_filter"
-                                               name="search_filter"
-                                               type="text">
+                                        <input class="govuk-input govuk-!-width-full govuk-input--search-all-input" id="search_filter" name="search_filter" type="text">
                                     </div>
                                     <div class="search-form__buttons">
-                                        <button type="submit"
-                                                class="govuk-button govuk-button__search-filters-form-apply-button"
-                                                data-module="govuk-button">Apply terms</button>
-                                        <a class="govuk-link govuk-link--transferring-filter"
-                                           href="{% if session['user_type'] == 'all_access_user' %}{{ url_for('main.browse', _anchor='browse-records') }}{% else %}{{ url_for('main.browse_transferring_body', _id = request.view_args['_id'], _anchor='browse-records') }}{% endif %}">Clear all terms</a>
+                                        <button type="submit" class="govuk-button govuk-button__search-filters-form-apply-button" data-module="govuk-button">Apply terms</button>
+                                        <a class="govuk-link govuk-link--transferring-filter" href="{% if session['user_type'] == 'all_access_user' %}{{ url_for('main.browse', _anchor='browse-records') }}{% else %}{{ url_for('main.browse_transferring_body', _id = request.view_args['_id'], _anchor='browse-records') }}{% endif %}">Clear all terms</a>
                                     </div>
                                     <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
                                     <div class="ayr-filter-tags">
@@ -181,16 +316,10 @@
                                                 {% else %}
                                                     {% set search_term_url = url_for('main.search_transferring_body', _id = request.view_args['_id'], query=new_query) %}
                                                 {% endif %}
-                                                <button type="button"
-                                                        class="button-search-term"
-                                                        data-module="search-term-button">
+                                                <button type="button" class="button-search-term" data-module="search-term-button">
                                                     <a href="{{ search_term_url }}">
                                                         {{ search_terms[i] }}
-                                                        <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}"
-                                                             height="30px"
-                                                             width="30px"
-                                                             class="close-icon"
-                                                             alt="">
+                                                        <img src="{{ url_for('static', filename= 'image/cancel-filters.svg') }}" height="30px" width="30px" class="close-icon" alt="">
                                                     </a>
                                                 </button>
                                             </div>
@@ -200,9 +329,8 @@
                             </div>
                         </div>
                     </div>
-                </form>
+</form> -->
             </div>
         </div>
-        <!-- END TABLE -->
     </div>
 {% endblock %}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -106,11 +106,11 @@
                                                             {{ record['closure_type'] }}
                                                         </strong>
                                                     </td>
-                                                    <td class="govuk-table__cell govuk-table__cell--search-results right-align search__mobile-table__top-row">
+                                                    <td class="govuk-table__cell govuk-table__cell--search-results browse__table__right-align search__mobile-table__top-row">
                                                         {% if record['opening_date'] %}
                                                             {{ record['opening_date'] }}
                                                         {% else %}
-                                                            -
+                                                            ―
                                                         {% endif %}
                                                     </td>
                                                 </tr>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -191,17 +191,17 @@ class TestSearchResultsSummary:
         <label class="govuk-label search__heading" for="search-input">Search for digital records</label>
         <form method="get" action="/search">
             <div class="govuk-form-group govuk-form-group__search-form">
-                <input
-                    class="govuk-input govuk-!-width-three-quarters"
-                    id="search-input" name="query"
-                    type="text"
-                    value="tdr">
-                <button
-                    class="govuk-button govuk-button__search-button" data-module="govuk-button"
-                    type="submit">
-                        Search
-                </button>
-                <p class="govuk-body-s">Search by file name, transferring body, series or consignment reference.</p>
+                <input class="govuk-input govuk-!-width-three-quarters"
+                       id="search-input"
+                       name="query"
+                       type="text"
+                       value="">
+                <button class="govuk-button govuk-button__search-button"
+                        data-module="govuk-button"
+                        type="submit">Search</button>
+            <p class="govuk-body-s">
+                Search by file name, transferring body, series or consignment reference.
+            </p>
             </div>
         </form>
     </div>
@@ -578,100 +578,86 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         expected_html = f"""
-        <table class="govuk-table browse-grid__table" id="tbl_result" aria-label="Browse records">
+        <table class="govuk-table" id="tbl_result" aria-label="Record search results">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th
-                        scope="col"
-                        class="govuk-table__header browse-grid__key__transferring-body browse__all__desktop__header">
-                        Series reference
-                    </th>
-                    <th
-                        scope="col"
-                        class="govuk-table__header govuk-table__header--search-header search__mobile-heading">
+                    <th scope="col"
+                        class="govuk-table__header govuk-table__header--search-header
+                        search__desktop-heading">Series reference</th>
+                    <th class="govuk-table__header govuk-table__header--search-header
+                    search__mobile-heading" scope="col">
                         Series reference / File name / Consignment reference
                     </th>
-                    <th
-                        scope="col"
-                        class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
+                    <th class="govuk-table__header govuk-table__header--search-header
+                    search__desktop-heading" scope="col">
                         Consignment reference
                     </th>
-                    <th
-                        scope="col"
-                        class="govuk-table__header
-                        govuk-table__header--search-header
-                        govuk-table__header--search-header-title
-                        search__desktop-heading">
+                    <th class="govuk-table__header govuk-table__header--search-header
+                    govuk-table__header--search-header-title
+                    search__desktop-heading" scope="col">
                         File name
                     </th>
-                    <th
-                        scope="col"
-                        class="govuk-table__header
-                        govuk-table__header--search-header
-                        search__desktop-heading
-                        search__mobile-heading">
-                        Status
-                    </th>
-                    <th
-                        scope="col"
-                        class="govuk-table__header
-                        govuk-table__header--search-header
-                        search__desktop-heading
-                        search__mobile-heading">
-                        Record opening date
+                    <th scope="col"
+                        class="govuk-table__header govuk-table__header--search-header
+                        search__desktop-heading search__mobile-heading">Status</th>
+                    <th scope="col"
+                        class="govuk-table__header govuk-table__header--search-header search__desktop-heading
+                        search__mobile-heading">Record opening date
                     </th>
                 </tr>
             </thead>
             <tbody class="govuk-table__body">
-            <tr class="govuk-table__row top-row">
-                <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
-                    <a href="{browse_series_route_url}/{series_id}">first_series</a>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                govuk-table__cell--search-results-no-wrap search__mobile-table__top-row search__table__mobile--hidden">
-                    <a href="{browse_consignment_route_url}/{consignment_id}">TDR-2023-FI1</a>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                search__mobile-table__top-row search__table__mobile--hidden">
-                    <a class="word-break" href="{record_route_url}/{file_id}">first_file.docx</a>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                search__mobile-table__top-row">
-                    <strong class="govuk-tag govuk-tag--red">
-                        Closed
-                    </strong>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                browse__table__right-align search__mobile-table__top-row">
-                        25/02/2023
-                </td>
+            <div class="main-content" id="main-content" role="main">
+        <tr class="govuk-table__row top-row">
+            <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
+                <a href="{browse_series_route_url}/{series_id}">first_series</a>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            govuk-table__cell--search-results-no-wrap search__mobile-table__top-row search__table__mobile--hidden">
+                <a href="{browse_consignment_route_url}/{consignment_id}">TDR-2023-FI1</a>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            search__mobile-table__top-row search__table__mobile--hidden">
+                <a class="word-break" href="{record_route_url}/{file_id}">first_file.docx</a>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            search__mobile-table__top-row">
+                <strong class="govuk-tag govuk-tag--red">
+                    Closed
+                </strong>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            right-align search__mobile-table__top-row">
+                    25/02/2023
+            </td>
             </tr>
             <tr class="govuk-table__row search__mobile-row">
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                search__mobile-table__middle-row">
-                    <a class="word-break" href="{record_route_url}/{file_id}">
-                    first_file.docx
-                    </a>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                search__mobile-table__middle-row">
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                search__mobile-table__middle-row">
-                </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            search__mobile-table__middle-row">
+                <a class="word-break" href="{record_route_url}/{file_id}">
+                first_file.docx
+                </a>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            search__mobile-table__middle-row">
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            search__mobile-table__middle-row">
+            </td>
             </tr>
             <tr class="govuk-table__row search__mobile-row">
-                <td class="govuk-table__cell govuk-table__cell--search-results
-                govuk-table__cell--search-results-no-wrap">
-                    <a href="{browse_consignment_route_url}/{consignment_id}">
-                    TDR-2023-FI1
-                    </a>
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results">
-                </td>
-                <td class="govuk-table__cell govuk-table__cell--search-results">
-                </td>
-            </tr>
+            <td class="govuk-table__cell govuk-table__cell--search-results
+            govuk-table__cell--search-results-no-wrap">
+                <a href="{browse_consignment_route_url}/{consignment_id}">
+                TDR-2023-FI1
+                </a>
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results">
+            </td>
+            <td class="govuk-table__cell govuk-table__cell--search-results">
+            </td>
+        </tr>
+        </div>
             </tbody>
         </table>
         """
@@ -1401,69 +1387,60 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         search_filter_html = f"""
-        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
-            <div class="browse-all-filter-container">
-                <div class="browse-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--search">
-                        <label class="govuk-label govuk-heading-m govuk-heading-m--search"
-                        for="search_filter">Search within results</label>
-                    </h2>
-                </div>
-
-                <div class="govuk-form-group govuk-form-group--search-all-filter">
-                    <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
-                    id="search_filter" name="search_filter" type="text">
-                </div>
-
-                <div class="search-form__buttons">
-                    <button type="submit"
-                    class="govuk-button govuk-button__search-filters-form-apply-button"
-                    data-module="govuk-button">
-                        Apply terms
-                    </button>
-                    <a class="govuk-link govuk-link--transferring-filter"
-                      href="{self.browse_all_route_url}#browse-records">
-                      Clear all terms
-                    </a>
-                </div>
-
-                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
-
-                <div class="ayr-filter-tags">
-
-                    <div class="search-term">
-                        <button type="button"
-                        class="button-search-term"
-                        data-module="search-term-button">
-                            <a href="{self.route_url}/{transferring_body_id}?query={term2}">
-                                {term1}
-                                <img src="/assets/image/cancel-filters.svg"
-                                height="30px"
-                                width="30px"
-                                class="close-icon"
-                                alt="">
-                            </a>
-                        </button>
-                    </div>
-
-                    <div class="search-term">
-                        <button type="button"
-                        class="button-search-term"
-                        data-module="search-term-button">
-                            <a href="{self.route_url}/{transferring_body_id}?query={term1}">
-                                {term2}
-                                <img src="/assets/image/cancel-filters.svg"
-                                    height="30px"
-                                    width="30px"
-                                    class="close-icon"
-                                    alt="">
-                            </a>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        """
+        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters mobile-filters">
+                            <div class="search-all-filter-container">
+                                <div class="browse-filter__header">
+                                        <h2 class="govuk-heading-m govuk-heading-m--search">
+                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search"
+                                            for="search_filter">Search within results</label>
+                                        </h2>
+                                    </div>
+                                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                                    <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
+                                    id="search_filter"
+                                    name="search_filter"
+                                    type="text">
+                                </div>
+                                <div class="search-form__buttons">
+                                    <button type="submit"
+                                    class="govuk-button govuk-button__search-filters-form-apply-button"
+                                    data-module="govuk-button">Apply terms</button>
+                                    <a class="govuk-link govuk-link--transferring-filter"
+                                    href="{self.browse_all_route_url}#browse-records">Clear all terms</a>
+                                </div>
+                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+                                <div class="ayr-filter-tags">
+                                        <div class="search-term">
+                                            <button type="button"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                                <a href="{self.route_url}/{transferring_body_id}?query={term2}">
+                                                    {term1}
+                                                    <img src="/assets/image/cancel-filters.svg"
+                                                    height="30px"
+                                                    width="30px"
+                                                    class="close-icon"
+                                                    alt="">
+                                                </a>
+                                            </button>
+                                        </div>
+                                        <div class="search-term">
+                                            <button type="button"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                                <a href="{self.route_url}/{transferring_body_id}?query={term1}">
+                                                    {term2}
+                                                    <img src="/assets/image/cancel-filters.svg"
+                                                        height="30px"
+                                                        width="30px"
+                                                        class="close-icon"
+                                                        alt="">
+                                                </a>
+                                            </button>
+                                        </div>
+                                </div>
+                            </div>
+                        </div>"""
 
         assert_contains_html(
             search_filter_html,
@@ -1505,70 +1482,60 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         search_filter_html = f"""
-        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
-            <div class="browse-all-filter-container">
-                <div class="browse-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--search">
-                        <label class="govuk-label govuk-heading-m govuk-heading-m--search"
-                        for="search_filter">Search within results</label>
-                    </h2>
-                </div>
-
-                <div class="govuk-form-group govuk-form-group--search-all-filter">
-                    <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
-                    id="search_filter" name="search_filter" type="text">
-                </div>
-
-                <div class="search-form__buttons">
-                    <button
-                    type="submit"
-                    class="govuk-button govuk-button__search-filters-form-apply-button"
-                    data-module="govuk-button">
-                        Apply terms
-                    </button>
-                    <a class="govuk-link govuk-link--transferring-filter"
-                      href="{self.browse_transferring_body_route_url}/{transferring_body_id}#browse-records">
-                      Clear all terms
-                    </a>
-                </div>
-
-                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
-
-                <div class="ayr-filter-tags">
-
-                    <div class="search-term">
-                        <button type="button"
-                        class="button-search-term"
-                        data-module="search-term-button">
-                            <a href="{self.route_url}/{transferring_body_id}?query={term2}">
-                                {term1}
-                                <img src="/assets/image/cancel-filters.svg"
-                                height="30px"
-                                width="30px"
-                                class="close-icon"
-                                alt="">
-                            </a>
-                        </button>
-                    </div>
-
-                    <div class="search-term">
-                        <button type="button"
-                        class="button-search-term"
-                        data-module="search-term-button">
-                            <a href="{self.route_url}/{transferring_body_id}?query={term1}">
-                                {term2}
-                                <img src="/assets/image/cancel-filters.svg"
-                                    height="30px"
-                                    width="30px"
-                                    class="close-icon"
-                                    alt="">
-                            </a>
-                        </button>
-                    </div>
-                </div>
-            </div>
-        </div>
-        """
+        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters mobile-filters">
+                            <div class="search-all-filter-container">
+                                <div class="browse-filter__header">
+                                        <h2 class="govuk-heading-m govuk-heading-m--search">
+                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search"
+                                            for="search_filter">Search within results</label>
+                                        </h2>
+                                    </div>
+                                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                                    <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
+                                    id="search_filter"
+                                    name="search_filter"
+                                    type="text">
+                                </div>
+                                <div class="search-form__buttons">
+                                    <button type="submit"
+                                    class="govuk-button govuk-button__search-filters-form-apply-button"
+                                    data-module="govuk-button">Apply terms</button>
+                                    <a class="govuk-link govuk-link--transferring-filter"
+                                href="{self.browse_transferring_body_route_url}/{transferring_body_id}#browse-records">
+                                Clear all terms</a></div>
+                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+                                <div class="ayr-filter-tags">
+                                        <div class="search-term">
+                                            <button type="button"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                                <a href="{self.route_url}/{transferring_body_id}?query={term2}">
+                                                    {term1}
+                                                    <img src="/assets/image/cancel-filters.svg"
+                                                    height="30px"
+                                                    width="30px"
+                                                    class="close-icon"
+                                                    alt="">
+                                                </a>
+                                            </button>
+                                        </div>
+                                        <div class="search-term">
+                                            <button type="button"
+                                            class="button-search-term"
+                                            data-module="search-term-button">
+                                                <a href="{self.route_url}/{transferring_body_id}?query={term1}">
+                                                    {term2}
+                                                    <img src="/assets/image/cancel-filters.svg"
+                                                        height="30px"
+                                                        width="30px"
+                                                        class="close-icon"
+                                                        alt="">
+                                                </a>
+                                            </button>
+                                        </div>
+                                </div>
+                            </div>
+                        </div>"""
 
         assert_contains_html(
             search_filter_html,

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -191,17 +191,17 @@ class TestSearchResultsSummary:
         <label class="govuk-label search__heading" for="search-input">Search for digital records</label>
         <form method="get" action="/search">
             <div class="govuk-form-group govuk-form-group__search-form">
-                <input class="govuk-input govuk-!-width-three-quarters"
-                       id="search-input"
-                       name="query"
-                       type="text"
-                       value="">
-                <button class="govuk-button govuk-button__search-button"
-                        data-module="govuk-button"
-                        type="submit">Search</button>
-            <p class="govuk-body-s">
-                Search by file name, transferring body, series or consignment reference.
-            </p>
+                <input
+                    class="govuk-input govuk-!-width-three-quarters"
+                    id="search-input" name="query"
+                    type="text"
+                    value="tdr">
+                <button
+                    class="govuk-button govuk-button__search-button" data-module="govuk-button"
+                    type="submit">
+                        Search
+                </button>
+                <p class="govuk-body-s">Search by file name, transferring body, series or consignment reference.</p>
             </div>
         </form>
     </div>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -642,7 +642,7 @@ class TestSearchTransferringBody:
                     </strong>
                 </td>
                 <td class="govuk-table__cell govuk-table__cell--search-results
-                right-align search__mobile-table__top-row">
+                browse__table__right-align search__mobile-table__top-row">
                         25/02/2023
                 </td>
             </tr>
@@ -690,10 +690,10 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
                     ],
                 ],
@@ -702,7 +702,7 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1,th",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
                     ],
@@ -712,7 +712,7 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1,second",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―'"
                     ],
                 ],
             ),
@@ -729,10 +729,10 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1&sort=file_name-asc",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
                     ],
                 ],
@@ -742,10 +742,10 @@ class TestSearchTransferringBody:
                 [
                     [
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―'"
                     ],
                 ],
             ),
@@ -753,8 +753,8 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1&sort=opening_date-desc",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023'"
@@ -768,8 +768,8 @@ class TestSearchTransferringBody:
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―'"
                     ],
                 ],
             ),
@@ -780,8 +780,8 @@ class TestSearchTransferringBody:
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―'"
                     ]
                 ],
             ),
@@ -789,8 +789,8 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1&sort=closure_type-desc",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
@@ -812,7 +812,7 @@ class TestSearchTransferringBody:
                     [
                         "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―'"
                     ],
                 ],
             ),
@@ -886,10 +886,10 @@ class TestSearchTransferringBody:
 
         expected_rows = [
             [
-                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                 "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023', "
                 "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
-                "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-', "
+                "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―', "
                 "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
             ],
         ]
@@ -937,7 +937,7 @@ class TestSearchTransferringBody:
 
         expected_rows = [
             [
-                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                 "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023'"
             ],
         ]
@@ -997,7 +997,7 @@ class TestSearchTransferringBody:
 
         expected_rows = [
             [
-                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                 "'first_series', 'TDR-2023-FI1', 'first_file.docx', 'Closed', '25/02/2023'"
             ],
         ]
@@ -1050,7 +1050,7 @@ class TestSearchTransferringBody:
         expected_rows = [
             [
                 "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
-                "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-'"
+                "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―'"
             ],
         ]
 
@@ -1401,60 +1401,69 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         search_filter_html = f"""
-        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters mobile-filters">
-                            <div class="search-all-filter-container">
-                                <div class="browse-filter__header">
-                                        <h2 class="govuk-heading-m govuk-heading-m--search">
-                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search"
-                                            for="search_filter">Search within results</label>
-                                        </h2>
-                                    </div>
-                                <div class="govuk-form-group govuk-form-group--search-all-filter">
-                                    <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
-                                    id="search_filter"
-                                    name="search_filter"
-                                    type="text">
-                                </div>
-                                <div class="search-form__buttons">
-                                    <button type="submit"
-                                    class="govuk-button govuk-button__search-filters-form-apply-button"
-                                    data-module="govuk-button">Apply terms</button>
-                                    <a class="govuk-link govuk-link--transferring-filter"
-                                    href="{self.browse_all_route_url}#browse-records">Clear all terms</a>
-                                </div>
-                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
-                                <div class="ayr-filter-tags">
-                                        <div class="search-term">
-                                            <button type="button"
-                                            class="button-search-term"
-                                            data-module="search-term-button">
-                                                <a href="{self.route_url}/{transferring_body_id}?query={term2}">
-                                                    {term1}
-                                                    <img src="/assets/image/cancel-filters.svg"
-                                                    height="30px"
-                                                    width="30px"
-                                                    class="close-icon"
-                                                    alt="">
-                                                </a>
-                                            </button>
-                                        </div>
-                                        <div class="search-term">
-                                            <button type="button"
-                                            class="button-search-term"
-                                            data-module="search-term-button">
-                                                <a href="{self.route_url}/{transferring_body_id}?query={term1}">
-                                                    {term2}
-                                                    <img src="/assets/image/cancel-filters.svg"
-                                                        height="30px"
-                                                        width="30px"
-                                                        class="close-icon"
-                                                        alt="">
-                                                </a>
-                                            </button>
-                                        </div>
-                                </div>
-                            </div>
-                        </div>"""
+        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
+            <div class="browse-all-filter-container">
+                <div class="browse-filter__header">
+                    <h2 class="govuk-heading-m govuk-heading-m--search">
+                        <label class="govuk-label govuk-heading-m govuk-heading-m--search"
+                        for="search_filter">Search within results</label>
+                    </h2>
+                </div>
+
+                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                    <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
+                    id="search_filter" name="search_filter" type="text">
+                </div>
+
+                <div class="search-form__buttons">
+                    <button type="submit"
+                    class="govuk-button govuk-button__search-filters-form-apply-button"
+                    data-module="govuk-button">
+                        Apply terms
+                    </button>
+                    <a class="govuk-link govuk-link--transferring-filter"
+                      href="{self.browse_all_route_url}#browse-records">
+                      Clear all terms
+                    </a>
+                </div>
+
+                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+
+                <div class="ayr-filter-tags">
+
+                    <div class="search-term">
+                        <button type="button"
+                        class="button-search-term"
+                        data-module="search-term-button">
+                            <a href="{self.route_url}/{transferring_body_id}?query={term2}">
+                                {term1}
+                                <img src="/assets/image/cancel-filters.svg"
+                                height="30px"
+                                width="30px"
+                                class="close-icon"
+                                alt="">
+                            </a>
+                        </button>
+                    </div>
+
+                    <div class="search-term">
+                        <button type="button"
+                        class="button-search-term"
+                        data-module="search-term-button">
+                            <a href="{self.route_url}/{transferring_body_id}?query={term1}">
+                                {term2}
+                                <img src="/assets/image/cancel-filters.svg"
+                                    height="30px"
+                                    width="30px"
+                                    class="close-icon"
+                                    alt="">
+                            </a>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        """
 
         assert_contains_html(
             search_filter_html,
@@ -1496,60 +1505,70 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         search_filter_html = f"""
-        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--search-all-filters mobile-filters">
-                            <div class="search-all-filter-container">
-                                <div class="browse-filter__header">
-                                        <h2 class="govuk-heading-m govuk-heading-m--search">
-                                            <label class="govuk-label govuk-heading-m govuk-heading-m--search"
-                                            for="search_filter">Search within results</label>
-                                        </h2>
-                                    </div>
-                                <div class="govuk-form-group govuk-form-group--search-all-filter">
-                                    <input class="govuk-input govuk-!-width-full govuk-input--search-all-input"
-                                    id="search_filter"
-                                    name="search_filter"
-                                    type="text">
-                                </div>
-                                <div class="search-form__buttons">
-                                    <button type="submit"
-                                    class="govuk-button govuk-button__search-filters-form-apply-button"
-                                    data-module="govuk-button">Apply terms</button>
-                                    <a class="govuk-link govuk-link--transferring-filter"
-                                href="{self.browse_transferring_body_route_url}/{transferring_body_id}#browse-records">
-                                Clear all terms</a></div>
-                                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
-                                <div class="ayr-filter-tags">
-                                        <div class="search-term">
-                                            <button type="button"
-                                            class="button-search-term"
-                                            data-module="search-term-button">
-                                                <a href="{self.route_url}/{transferring_body_id}?query={term2}">
-                                                    {term1}
-                                                    <img src="/assets/image/cancel-filters.svg"
-                                                    height="30px"
-                                                    width="30px"
-                                                    class="close-icon"
-                                                    alt="">
-                                                </a>
-                                            </button>
-                                        </div>
-                                        <div class="search-term">
-                                            <button type="button"
-                                            class="button-search-term"
-                                            data-module="search-term-button">
-                                                <a href="{self.route_url}/{transferring_body_id}?query={term1}">
-                                                    {term2}
-                                                    <img src="/assets/image/cancel-filters.svg"
-                                                        height="30px"
-                                                        width="30px"
-                                                        class="close-icon"
-                                                        alt="">
-                                                </a>
-                                            </button>
-                                        </div>
-                                </div>
-                            </div>
-                        </div>"""
+        <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
+            <div class="browse-all-filter-container">
+                <div class="browse-filter__header">
+                    <h2 class="govuk-heading-m govuk-heading-m--search">
+                        <label class="govuk-label govuk-heading-m govuk-heading-m--search"
+                        for="search_filter">Search within results</label>
+                    </h2>
+                </div>
+
+                <div class="govuk-form-group govuk-form-group--search-all-filter">
+                    <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
+                    id="search_filter" name="search_filter" type="text">
+                </div>
+
+                <div class="search-form__buttons">
+                    <button
+                    type="submit"
+                    class="govuk-button govuk-button__search-filters-form-apply-button"
+                    data-module="govuk-button">
+                        Apply terms
+                    </button>
+                    <a class="govuk-link govuk-link--transferring-filter"
+                      href="{self.browse_transferring_body_route_url}/{transferring_body_id}#browse-records">
+                      Clear all terms
+                    </a>
+                </div>
+
+                <h3 class="govuk-heading-s govuk-heading-s--search-term">Search terms applied</h3>
+
+                <div class="ayr-filter-tags">
+
+                    <div class="search-term">
+                        <button type="button"
+                        class="button-search-term"
+                        data-module="search-term-button">
+                            <a href="{self.route_url}/{transferring_body_id}?query={term2}">
+                                {term1}
+                                <img src="/assets/image/cancel-filters.svg"
+                                height="30px"
+                                width="30px"
+                                class="close-icon"
+                                alt="">
+                            </a>
+                        </button>
+                    </div>
+
+                    <div class="search-term">
+                        <button type="button"
+                        class="button-search-term"
+                        data-module="search-term-button">
+                            <a href="{self.route_url}/{transferring_body_id}?query={term1}">
+                                {term2}
+                                <img src="/assets/image/cancel-filters.svg"
+                                    height="30px"
+                                    width="30px"
+                                    class="close-icon"
+                                    alt="">
+                            </a>
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+        """
 
         assert_contains_html(
             search_filter_html,
@@ -1649,7 +1668,7 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1&search_filter=th",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-', "
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090'"
                     ],
@@ -1659,7 +1678,7 @@ class TestSearchTransferringBody:
                 "query=TDR-2023-FI1&search_filter=second",
                 [
                     [
-                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'second_file.ppt', 'Open', '―'"
                     ],
                 ],
             ),
@@ -1687,7 +1706,7 @@ class TestSearchTransferringBody:
                     [
                         "'first_series', 'TDR-2023-FI1', 'third_file.docx', 'Closed', '10/03/2090', "
                         "'first_series', 'TDR-2023-FI1', 'fourth_file.xls', 'Closed', '25/03/2070', "
-                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '-'"
+                        "'first_series', 'TDR-2023-FI1', 'fifth_file.doc', 'Open', '―'"
                     ],
                 ],
             ),

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -578,86 +578,100 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         expected_html = f"""
-        <table class="govuk-table" id="tbl_result" aria-label="Record search results">
+        <table class="govuk-table browse-grid__table" id="tbl_result" aria-label="Browse records">
             <thead class="govuk-table__head">
                 <tr class="govuk-table__row">
-                    <th scope="col"
-                        class="govuk-table__header govuk-table__header--search-header
-                        search__desktop-heading">Series reference</th>
-                    <th class="govuk-table__header govuk-table__header--search-header
-                    search__mobile-heading" scope="col">
+                    <th
+                        scope="col"
+                        class="govuk-table__header browse-grid__key__transferring-body browse__all__desktop__header">
+                        Series reference
+                    </th>
+                    <th
+                        scope="col"
+                        class="govuk-table__header govuk-table__header--search-header search__mobile-heading">
                         Series reference / File name / Consignment reference
                     </th>
-                    <th class="govuk-table__header govuk-table__header--search-header
-                    search__desktop-heading" scope="col">
+                    <th
+                        scope="col"
+                        class="govuk-table__header govuk-table__header--search-header search__desktop-heading">
                         Consignment reference
                     </th>
-                    <th class="govuk-table__header govuk-table__header--search-header
-                    govuk-table__header--search-header-title
-                    search__desktop-heading" scope="col">
+                    <th
+                        scope="col"
+                        class="govuk-table__header
+                        govuk-table__header--search-header
+                        govuk-table__header--search-header-title
+                        search__desktop-heading">
                         File name
                     </th>
-                    <th scope="col"
-                        class="govuk-table__header govuk-table__header--search-header
-                        search__desktop-heading search__mobile-heading">Status</th>
-                    <th scope="col"
-                        class="govuk-table__header govuk-table__header--search-header search__desktop-heading
-                        search__mobile-heading">Record opening date
+                    <th
+                        scope="col"
+                        class="govuk-table__header
+                        govuk-table__header--search-header
+                        search__desktop-heading
+                        search__mobile-heading">
+                        Status
+                    </th>
+                    <th
+                        scope="col"
+                        class="govuk-table__header
+                        govuk-table__header--search-header
+                        search__desktop-heading
+                        search__mobile-heading">
+                        Record opening date
                     </th>
                 </tr>
             </thead>
             <tbody class="govuk-table__body">
-            <div class="main-content" id="main-content" role="main">
-        <tr class="govuk-table__row top-row">
-            <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
-                <a href="{browse_series_route_url}/{series_id}">first_series</a>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            govuk-table__cell--search-results-no-wrap search__mobile-table__top-row search__table__mobile--hidden">
-                <a href="{browse_consignment_route_url}/{consignment_id}">TDR-2023-FI1</a>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            search__mobile-table__top-row search__table__mobile--hidden">
-                <a class="word-break" href="{record_route_url}/{file_id}">first_file.docx</a>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            search__mobile-table__top-row">
-                <strong class="govuk-tag govuk-tag--red">
-                    Closed
-                </strong>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            right-align search__mobile-table__top-row">
-                    25/02/2023
-            </td>
+            <tr class="govuk-table__row top-row">
+                <td class="govuk-table__cell govuk-table__cell--search-results search__mobile-table__top-row">
+                    <a href="{browse_series_route_url}/{series_id}">first_series</a>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                govuk-table__cell--search-results-no-wrap search__mobile-table__top-row search__table__mobile--hidden">
+                    <a href="{browse_consignment_route_url}/{consignment_id}">TDR-2023-FI1</a>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                search__mobile-table__top-row search__table__mobile--hidden">
+                    <a class="word-break" href="{record_route_url}/{file_id}">first_file.docx</a>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                search__mobile-table__top-row">
+                    <strong class="govuk-tag govuk-tag--red">
+                        Closed
+                    </strong>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                right-align search__mobile-table__top-row">
+                        25/02/2023
+                </td>
             </tr>
             <tr class="govuk-table__row search__mobile-row">
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            search__mobile-table__middle-row">
-                <a class="word-break" href="{record_route_url}/{file_id}">
-                first_file.docx
-                </a>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            search__mobile-table__middle-row">
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            search__mobile-table__middle-row">
-            </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                search__mobile-table__middle-row">
+                    <a class="word-break" href="{record_route_url}/{file_id}">
+                    first_file.docx
+                    </a>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                search__mobile-table__middle-row">
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                search__mobile-table__middle-row">
+                </td>
             </tr>
             <tr class="govuk-table__row search__mobile-row">
-            <td class="govuk-table__cell govuk-table__cell--search-results
-            govuk-table__cell--search-results-no-wrap">
-                <a href="{browse_consignment_route_url}/{consignment_id}">
-                TDR-2023-FI1
-                </a>
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results">
-            </td>
-            <td class="govuk-table__cell govuk-table__cell--search-results">
-            </td>
-        </tr>
-        </div>
+                <td class="govuk-table__cell govuk-table__cell--search-results
+                govuk-table__cell--search-results-no-wrap">
+                    <a href="{browse_consignment_route_url}/{consignment_id}">
+                    TDR-2023-FI1
+                    </a>
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results">
+                </td>
+                <td class="govuk-table__cell govuk-table__cell--search-results">
+                </td>
+            </tr>
             </tbody>
         </table>
         """


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

Changed some html and css structure in order to make the search pages consistent with the rest of the pages.

Note: I've replaced the original search page classes with the ones the browse pages use, so the names are the same, there could be a separate ticket to transform these classes to have generic names to where they can be used across the app.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1004

## Screenshots of UI changes

### Before
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/9abcdd6c-1ed6-4afe-89b8-c06d48f0a36c">

<img width="1726" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/eb3deeb4-0b2c-49c2-a5ee-655fd0a63d69">

### After

<img width="1727" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/aac2e994-115a-413b-ac86-06a3f10f922f">
<img width="1725" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/7971e44d-719a-458e-adf1-ca1389560e0e">


- [ ] Requires env variable(s) to be updated
