### PR TITLE
AYR-1006 - Fix for hover states

### DIFF
--- a/app/static/src/scss/includes/_accessibility.scss
+++ b/app/static/src/scss/includes/_accessibility.scss
@@ -26,23 +26,27 @@
   }
 
   &--accessibility {
-    color: $colour-link-visited;
+    color: $colour-link-default;
     font-size: 1rem;
   }
 
   &:visited {
-    color: $colour-link-visited;
+    color: $colour-link-default;
+  }
+
+  &:hover {
+    color: $colour-link-hover;
   }
 
   &:active {
-    color: $colour-link-visited;
+    color: $colour-link-default;
   }
 
-  color: $colour-link-visited;
+  color: $colour-link-default;
 }
 
 .govuk-tna-link {
-  color: $colour-link-visited;
+  color: $colour-link-default;
 }
 
 .li::marker {

--- a/app/static/src/scss/includes/_accessibility.scss
+++ b/app/static/src/scss/includes/_accessibility.scss
@@ -20,9 +20,21 @@
 }
 
 .govuk-link {
+
   &__ayr {
     margin-bottom: 1rem;
     font-size: 1rem;
+  }
+
+  &__1-rem-mb-font {
+    margin-bottom: 1rem;
+    font-size: 1rem;
+  }
+
+  &__no-visited-color {
+    &:visited {
+      color: $colour-link-default;
+    }
   }
 
   &--accessibility {

--- a/app/static/src/scss/includes/_accessibility.scss
+++ b/app/static/src/scss/includes/_accessibility.scss
@@ -30,10 +30,6 @@
     font-size: 1rem;
   }
 
-  &:visited {
-    color: $colour-link-default;
-  }
-
   &:hover {
     color: $colour-link-hover;
   }

--- a/app/static/src/scss/includes/_accessibility.scss
+++ b/app/static/src/scss/includes/_accessibility.scss
@@ -20,7 +20,6 @@
 }
 
 .govuk-link {
-
   &__ayr {
     margin-bottom: 1rem;
     font-size: 1rem;

--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -63,38 +63,38 @@
   }
 
   &__link--record {
-    color: $colour-link-visited;
+    color: $colour-link-default;
     font-size: 1rem;
     font-weight: 400;
     margin-top: 0;
 
     &--series {
       white-space: nowrap;
-      color: $colour-link-visited;
+      color: $colour-link-default;
 
       &:visited {
-        color: $colour-link-visited;
-        -webkit-text-fill-color: $colour-link-visited;
+        color: $colour-link-default;
+        -webkit-text-fill-color: $colour-link-default;
       }
     }
 
     &--transferring-body {
       flex-wrap: wrap;
-      color: $colour-link-visited;
+      color: $colour-link-default;
 
       &:visited {
-        color: $colour-link-visited;
-        -webkit-text-fill-color: $colour-link-visited;
+        color: $colour-link-default;
+        -webkit-text-fill-color: $colour-link-default;
       }
     }
 
     &--consignment {
       white-space: nowrap;
-      color: $colour-link-visited;
+      color: $colour-link-default;
 
       &:visited {
-        color: $colour-link-visited;
-        -webkit-text-fill-color: $colour-link-visited;
+        color: $colour-link-default;
+        -webkit-text-fill-color: $colour-link-default;
       }
     }
   }

--- a/app/static/src/scss/includes/_browse-all.scss
+++ b/app/static/src/scss/includes/_browse-all.scss
@@ -225,8 +225,8 @@
 
   &-table__cell {
     &--ayr a {
-      color: $colour-link-visited;
-      -webkit-text-fill-color: $colour-link-visited;
+      color: $colour-link-default;
+      -webkit-text-fill-color: $colour-link-default;
     }
   }
 }

--- a/app/static/src/scss/includes/_search-results-summary.scss
+++ b/app/static/src/scss/includes/_search-results-summary.scss
@@ -23,10 +23,10 @@
   }
 
   a {
-    color: $colour-link-visited;
+    color: $colour-link-default;
 
     &:visited {
-      color: $colour-link-visited;
+      color: $colour-link-default;
     }
   }
 

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -102,11 +102,11 @@
     }
 
     a {
-      color: $colour-link-visited;
+      color: $colour-link-default;
       margin-bottom: -1rem;
 
       &:visited {
-        color: $colour-link-visited;
+        color: $colour-link-default;
       }
 
       // this is a temp fix, the overall problem is that .govuk-table__cell is overwritten in multiple places, should be fixed with css refactoring
@@ -172,7 +172,7 @@ a.govuk-link {
     font-size: 0.9rem;
 
     &:visited {
-      color: $colour-link-visited;
+      color: $colour-link-default;
     }
   }
 }

--- a/app/static/src/scss/includes/_static-content-template.scss
+++ b/app/static/src/scss/includes/_static-content-template.scss
@@ -31,12 +31,6 @@
 }
 
 .govuk-link {
-  &__ayr-content {
-    margin-bottom: 1rem;
-    font-size: 1rem;
-    color: $colour-link-default;
-  }
-
   &__back-to-top a {
     color: $colour-link-default;
     font-size: 1rem;

--- a/app/static/src/scss/includes/_static-content-template.scss
+++ b/app/static/src/scss/includes/_static-content-template.scss
@@ -34,11 +34,11 @@
   &__ayr-content {
     margin-bottom: 1rem;
     font-size: 1rem;
-    color: $colour-link-visited;
+    color: $colour-link-default;
   }
 
   &__back-to-top a {
-    color: $colour-link-visited;
+    color: $colour-link-default;
     font-size: 1rem;
   }
 }

--- a/app/static/src/scss/includes/_variables.scss
+++ b/app/static/src/scss/includes/_variables.scss
@@ -5,7 +5,9 @@ $breakpoint-large: 1200px;
 
 // colour__component__type
 $colour-link-normal: #0b0c0c;
-$colour-link-visited: #1d70b8;
+$colour-link-default: #1d70b8;
+$colour-link-hover:	#003078;
+$colour-link-visited: #4c2c92;
 $colour-border-normal: #b1b4b6;
 $colour-container-normal: #f3f2f1;
 $colour-timeline-normal: #005ea5;

--- a/app/static/src/scss/includes/_variables.scss
+++ b/app/static/src/scss/includes/_variables.scss
@@ -6,7 +6,7 @@ $breakpoint-large: 1200px;
 // colour__component__type
 $colour-link-normal: #0b0c0c;
 $colour-link-default: #1d70b8;
-$colour-link-hover:	#003078;
+$colour-link-hover: #003078;
 $colour-link-visited: #4c2c92;
 $colour-border-normal: #b1b4b6;
 $colour-container-normal: #f3f2f1;

--- a/app/templates/main/accessibility.html
+++ b/app/templates/main/accessibility.html
@@ -2,22 +2,22 @@
 {% block pageTitle %}Accessibility – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#accessibility-statement">Accessibility statement for Access Your Records</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#feedback-contact">Feedback and contact information</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#feedback-contact">Feedback and contact information</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#technical-information">Technical information about this website’s accessibility</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#improve-accessibility">What we’re doing to improve accessibility</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#preparation-of-accessibility-statement">Preparation of this accessibility statement</a>
     </li>
 {% endblock %}
@@ -129,6 +129,6 @@
     class="govuk-link">DAC accessibility report for Access Your Records</a>.
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-body">Back to top</a>
+        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/accessibility.html
+++ b/app/templates/main/accessibility.html
@@ -6,7 +6,8 @@
            href="#accessibility-statement">Accessibility statement for Access Your Records</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#feedback-contact">Feedback and contact information</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#feedback-contact">Feedback and contact information</a>
     </li>
     <li class="govuk-list__ayr-content">
         <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
@@ -129,6 +130,7 @@
     class="govuk-link">DAC accessibility report for Access Your Records</a>.
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
+        <a href="#top"
+           class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -153,7 +153,7 @@
                     <button type="submit"
                             class="govuk-button govuk-button__browse-all-filters-form-apply-button"
                             data-module="govuk-button">Apply filters</button>
-                    <a class="govuk-link govuk-link--browse-all-filter"
+                    <a class="govuk-link govuk-link__no-visited-color govuk-link--browse-all-filter"
                        href="{{ url_for('main.browse', sort=request.args.get('sort'), _anchor='browse-records') }}">Clear filters</a>
                 </div>
             </div>

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -115,7 +115,7 @@
                     <button type="submit"
                             class="govuk-button govuk-button__browse-all-filters-form-apply-button"
                             data-module="govuk-button">Apply filters</button>
-                    <a class="govuk-link govuk-link--browse-all-filter"
+                    <a class="govuk-link govuk-link__no-visited-color govuk-link--browse-all-filter"
                        href="{{ url_for('main.browse_series',_id = request.view_args['_id'], sort=request.args.get('sort'), _anchor='browse-records') }}">Clear filters</a>
                 </div>
             </div>

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -129,7 +129,7 @@
                     <button type="submit"
                             class="govuk-button govuk-button__browse-all-filters-form-apply-button"
                             data-module="govuk-button">Apply filters</button>
-                    <a class="govuk-link govuk-link--browse-all-filter"
+                    <a class="govuk-link govuk-link__no-visited-color govuk-link--browse-all-filter"
                        href="{{ url_for('main.browse_transferring_body', _id=request.view_args['_id'], sort=request.args.get('sort'), _anchor='browse-records') }}">Clear filters</a>
                 </div>
             </div>

--- a/app/templates/main/how-to-use-this-service.html
+++ b/app/templates/main/how-to-use-this-service.html
@@ -2,17 +2,17 @@
 {% block pageTitle %}How to use this service – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#getting-started">Getting started</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#getting-started">Getting started</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#accessing-my-account">Accessing my AYR account</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#finding-records">Finding records using search and browse</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#finding-records">Finding records using search and browse</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#contact-us">How to contact us about this service</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#contact-us">How to contact us about this service</a>
     </li>
 {% endblock %}
 {% block static_content %}
@@ -148,6 +148,6 @@
         </p>
     </address>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-body">Back to top</a>
+        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/how-to-use-this-service.html
+++ b/app/templates/main/how-to-use-this-service.html
@@ -2,17 +2,20 @@
 {% block pageTitle %}How to use this service – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#getting-started">Getting started</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#getting-started">Getting started</a>
     </li>
     <li class="govuk-list__ayr-content">
         <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#accessing-my-account">Accessing my AYR account</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#finding-records">Finding records using search and browse</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#finding-records">Finding records using search and browse</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#contact-us">How to contact us about this service</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#contact-us">How to contact us about this service</a>
     </li>
 {% endblock %}
 {% block static_content %}
@@ -148,6 +151,7 @@
         </p>
     </address>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
+        <a href="#top"
+           class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/privacy.html
+++ b/app/templates/main/privacy.html
@@ -2,28 +2,36 @@
 {% block pageTitle %}Privacy – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-collected">What data we collect from you</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-collected">What data we collect from you</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-needed">Why we need your data</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-needed">Why we need your data</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-usage">What we do with your data</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-usage">What we do with your data</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-retention">How long we keep your data for</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-retention">How long we keep your data for</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-processing">Where your data is processed and stored</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-processing">Where your data is processed and stored</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-protection">How we protect your data and keep it secure</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#data-protection">How we protect your data and keep it secure</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#rights">Your rights</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#rights">Your rights</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#notice-changes">Changes to this notice</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#notice-changes">Changes to this notice</a>
     </li>
     <li class="govuk-list__ayr-content">
         <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
@@ -165,6 +173,7 @@
         Textphone <a href="tel:01625 545 860" class="govuk-link">01625 545 860</a>
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
+        <a href="#top"
+           class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/privacy.html
+++ b/app/templates/main/privacy.html
@@ -2,31 +2,31 @@
 {% block pageTitle %}Privacy – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-collected">What data we collect from you</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-collected">What data we collect from you</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-needed">Why we need your data</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-needed">Why we need your data</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-usage">What we do with your data</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-usage">What we do with your data</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-retention">How long we keep your data for</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-retention">How long we keep your data for</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-processing">Where your data is processed and stored</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-processing">Where your data is processed and stored</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#data-protection">How we protect your data and keep it secure</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#data-protection">How we protect your data and keep it secure</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#rights">Your rights</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#rights">Your rights</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#notice-changes">Changes to this notice</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#notice-changes">Changes to this notice</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content"
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
            href="#questions-complaints">Questions and complaints</a>
     </li>
 {% endblock %}
@@ -165,6 +165,6 @@
         Textphone <a href="tel:01625 545 860" class="govuk-link">01625 545 860</a>
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-body">Back to top</a>
+        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/terms-of-use.html
+++ b/app/templates/main/terms-of-use.html
@@ -2,16 +2,20 @@
 {% block pageTitle %}Terms of use – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link one</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#">Anchor link one</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link two this is a really long link test</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#">Anchor link two this is a really long link test</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link three</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#">Anchor link three</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link four</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color"
+           href="#">Anchor link four</a>
     </li>
 {% endblock %}
 {% block static_content %}
@@ -54,6 +58,7 @@
         Odio aenean sed adipiscing diam donec adipiscing tristique risus nec. Donec massa sapien faucibus et molestie ac. Faucibus ornare suspendisse sed nisi lacus sed viverra tellus in. A lacus vestibulum sed arcu non odio. Pharetra convallis posuere morbi leo urna molestie at elementum eu. Malesuada nunc vel risus commodo viverra maecenas. Sollicitudin nibh sit amet commodo nulla facilisi nullam. In egestas erat imperdiet sed euismod nisi porta lorem. Nisi porta lorem mollis aliquam ut porttitor leo a diam. Etiam non quam lacus suspendisse faucibus. Morbi tristique senectus et netus. Bibendum arcu vitae elementum curabitur vitae. Scelerisque eu ultrices vitae auctor eu augue ut lectus arcu. Lacus luctus accumsan tortor posuere ac ut consequat.
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
+        <a href="#top"
+           class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}

--- a/app/templates/main/terms-of-use.html
+++ b/app/templates/main/terms-of-use.html
@@ -2,16 +2,16 @@
 {% block pageTitle %}Terms of use – {{ config['SERVICE_NAME'] }} –  GOV.UK{% endblock %}
 {% block content_list %}
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#">Anchor link one</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link one</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#">Anchor link two this is a really long link test</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link two this is a really long link test</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#">Anchor link three</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link three</a>
     </li>
     <li class="govuk-list__ayr-content">
-        <a class="govuk-link govuk-link__ayr-content" href="#">Anchor link four</a>
+        <a class="govuk-link govuk-link__1-rem-mb-font govuk-link__no-visited-color" href="#">Anchor link four</a>
     </li>
 {% endblock %}
 {% block static_content %}
@@ -54,6 +54,6 @@
         Odio aenean sed adipiscing diam donec adipiscing tristique risus nec. Donec massa sapien faucibus et molestie ac. Faucibus ornare suspendisse sed nisi lacus sed viverra tellus in. A lacus vestibulum sed arcu non odio. Pharetra convallis posuere morbi leo urna molestie at elementum eu. Malesuada nunc vel risus commodo viverra maecenas. Sollicitudin nibh sit amet commodo nulla facilisi nullam. In egestas erat imperdiet sed euismod nisi porta lorem. Nisi porta lorem mollis aliquam ut porttitor leo a diam. Etiam non quam lacus suspendisse faucibus. Morbi tristique senectus et netus. Bibendum arcu vitae elementum curabitur vitae. Scelerisque eu ultrices vitae auctor eu augue ut lectus arcu. Lacus luctus accumsan tortor posuere ac ut consequat.
     </p>
     <div class="govuk-!-margin-top-9">
-        <a href="#top" class="govuk-link govuk-body">Back to top</a>
+        <a href="#top" class="govuk-link govuk-link__no-visited-color govuk-body">Back to top</a>
     </div>
 {% endblock %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Changed the colour variable "$colour-link-visited", which represented the normal blue color of a link, to "$colour-link-default", and added some more link color states (hover, visited)
- Changed some classes to be more BEM-like and descriptive, e.g. changed "__ayr-content" to "__1-rem-mb-font" (because it is used to change margin bottom and font to be 1 rem)
- Modified some classes where elements could be overwritten by multiple different files at the same time, and changed behaviour to be more along the lines of the modifier classes pattern (this was most likely causing elements to sometimes be inconsistent in their hover state) - e.g. instead of overwriting &:hover inside .govuk-link, which carries the risk of affecting links in other pages across the app, there is now a modifier of "__no-visited-color" that makes sure links don't have a visited colour.
- Links on the left should now not have any visited link colour but links on the right do (as requested by Terry)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1006

## Screenshots of UI changes

### Before
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/3547991d-fb97-48c9-ae0e-0b0093f654ba)
<img width="1725" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/ba230885-6192-428e-a95d-73e851a5170a">

### After
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/13d1c21c-7612-4a80-8cd0-1c90333d92de)
<img width="1724" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/6efcb81b-0c7a-4da5-b093-8c87acd32def">


- [ ] Requires env variable(s) to be updated
