### PR TITLE
AYR-1036 - Long TB name causing bad styling on Series Browse view

### DIFF
--- a/app/static/src/scss/includes/_browse-series.scss
+++ b/app/static/src/scss/includes/_browse-series.scss
@@ -20,6 +20,10 @@
   &--consignment-reference {
     white-space: nowrap;
   }
+
+  &.word-break {
+    word-break: break-word;
+  }
 }
 
 @media screen and (width <= $breakpoint-medium) {

--- a/app/static/src/scss/includes/_browse-series.scss
+++ b/app/static/src/scss/includes/_browse-series.scss
@@ -22,6 +22,7 @@
   }
 
   &.word-break {
+    word-wrap: break-word;
     word-break: break-word;
   }
 }

--- a/app/static/src/scss/includes/_pagination.scss
+++ b/app/static/src/scss/includes/_pagination.scss
@@ -1,3 +1,9 @@
 .govuk-pagination--centred {
   justify-content: center;
 }
+
+.govuk-pagination__link {
+  &:visited {
+    color: $colour-link-default;
+  }
+}

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -109,7 +109,6 @@
         color: $colour-link-default;
       }
 
-      // this is a temp fix, the overall problem is that .govuk-table__cell is overwritten in multiple places, should be fixed with css refactoring
       &.word-break {
         word-break: break-word;
       }

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -62,7 +62,7 @@
                         <div class="main-content" id="main-content" role="main">
                             {% for record in results %}
                                 <tr class="govuk-table__row browse__mobile-table__top-row">
-                                    <td class="govuk-table__cell browse__table__mobile--hidden browse__table__series--nowrap">
+                                    <td class="govuk-table__cell browse__table__mobile--hidden govuk-!-width-one-quarter word-break ">
                                         {{ record["transferring_body"] }}
                                     </td>
                                     <td class="govuk-table__cell browse__table__mobile--hidden browse__table__series--nowrap">{{ record["series"] }}</td>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- removed the no-break class from the transferring_body and added a class for word-break
- fixed a small bug where the pagination buttons had a visited link color
- modified the width of transferring_body to be one quarter using the GDS override styles

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1036

## Screenshots of UI changes

### Before
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/7707bc17-9fb8-4037-973b-974c64d376c1">

### After
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/2829fd7f-4502-4936-bba4-b4b01698f15c">


- [ ] Requires env variable(s) to be updated
