### PR TITLE
AYR-1037 & AYR-1038 - Broken pagination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ instance/*
 # .env files
 .env
 .env.e2e_tests
+.env.development.local
 
 ### Flask.Python Stack ###
 # Byte-compiled / optimized / DLL files

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -172,6 +172,7 @@ def browse():
             query_string_parameters={
                 k: v for k, v in request.args.items() if k not in "page"
             },
+            id=None,
         )
 
 
@@ -488,6 +489,7 @@ def search_results_summary():
         query_string_parameters={
             k: v for k, v in request.args.items() if k not in "page"
         },
+        id=None,
     )
 
 

--- a/app/static/src/scss/includes/_pagination.scss
+++ b/app/static/src/scss/includes/_pagination.scss
@@ -1,9 +1,3 @@
 .govuk-pagination--centred {
   justify-content: center;
 }
-
-.govuk-pagination__link {
-  &:visited {
-    color: $colour-link-default;
-  }
-}

--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -4,7 +4,7 @@
          aria-label="Pagination">
         {% if results.has_prev == True %}
             <div class="govuk-pagination__prev">
-                <a class="govuk-link govuk-pagination__link"
+                <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None %} {{ url_for(view_name, _id=id, page=current_page-1, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=current_page-1, **query_string_parameters) }} {% endif %}"
                    rel="prev">
                     <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
@@ -26,13 +26,13 @@
                 {% if page %}
                     {% if page != current_page %}
                         <li class="govuk-pagination__item">
-                            <a class="govuk-link govuk-pagination__link"
+                            <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                                href="{% if id != None %} {{ url_for(view_name, _id=id , page=page, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=page, **query_string_parameters) }}{% endif %}"
                                aria-label="Page {{ page }}">{{ page }}</a>
                         </li>
                     {% else %}
                         <li class="govuk-pagination__item govuk-pagination__item--current">
-                            <a class="govuk-link govuk-pagination__link"
+                            <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                                href="{% if id != None %} {{ url_for(view_name, _id=id , page=page, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=page, **query_string_parameters) }} {% endif %}"
                                aria-label="Page {{ page }}">{{ page }}</a>
                         </li>
@@ -44,7 +44,7 @@
         </ul>
         {% if results.has_next == True %}
             <div class="govuk-pagination__next">
-                <a class="govuk-link govuk-pagination__link"
+                <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None %} {{ url_for(view_name, _id=id , page=current_page+1, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=current_page+1, **query_string_parameters) }}{% endif %}"
                    rel="next">
                     <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden">page</span></span>

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -58,11 +58,11 @@
                                 </div>
                             </tbody>
                         </table>
+                        <!-- PAGINATION -->
+                        {% with view_name='main.search_results_summary' %}
+                            {% include "pagination.html" %}
+                        {% endwith %}
                     </div>
-                    <!-- PAGINATION -->
-                    {% with view_name='main.search_results_summary' %}
-                        {% include "pagination.html" %}
-                    {% endwith %}
                 {% else %}
                     {% with view_type = "search" %}
                         {% include "no-results-found.html" %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Added 'id' as a None property to the functions that render the Browse and Search Results Summary templates -> the pagination template was checking if this property was None (ideally it would have been None by default if it doesn't exist but alas, Jinja) and because it didn't exist it was introducing a '_id' query into the next URL which in turn was breaking pagination.
- Deleted the govuk-pagination__link class in our SCSS (which had inconsistent performance across pages) and replaced it with the previously created .govuk-link **__no-visited-color** modifier, which should ensure links always have a blue color. Please note that the govuk-pagination__link class still exists inside the HTML itself, this is because a lot of unit tests still rely on it, which is not ideal but can be fixed in a separate ticket.
- Moved the pagination component inside the Search Results Summary template to be inside the same container as the table, ensuring that its always placed under it as opposed to next to it.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1037
https://national-archives.atlassian.net/browse/AYR-1038

## Screenshots of UI changes

### Before
- https://127.0.0.1:5000/browse?_id=&page=2
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/7c510c0e-3184-45a9-ac7e-2a59cbeb7aba">

- https://127.0.0.1:5000/search_results_summary?_id=&page=2&query=a
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/c2d79438-5880-4276-a8c3-316655db5502">

- https://127.0.0.1:5000/search_results_summary
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/65bfe3fa-f267-4192-9406-3e516aaaeb1e">



### After
- https://127.0.0.1:5000/browse?page=3
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/d17a9fcc-135e-4805-a784-c1252a556b41">

- https://127.0.0.1:5000/search_results_summary?page=3&query=a
<img width="1728" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/af3f833f-ecd5-4ae2-bd3d-1b04db622970">


- [ ] Requires env variable(s) to be updated
