### PR TITLE
Deploy to test-one and not to stg on merge to main

### DIFF
--- a/.github/workflows/trigger_staging_cd.yml
+++ b/.github/workflows/trigger_staging_cd.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        environment: [int, stg]
+        environment: [int, test-one]
 
 
     steps:


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

Deploy to test-one and not to stg on merge to main since we want to run e2e tests continuously on code from main and to keep in line with tdr stg should be more stable. This may be revisited in the future. Currently stg has no data anyway so doesnt matter too much