### PR TITLE
AYR-1055 - Remove 'govuk-pagination__link' from tests

### DIFF
--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -4,7 +4,8 @@
          aria-label="Pagination">
         {% if results.has_prev == True %}
             <div class="govuk-pagination__prev">
-                <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
+                <a data-testid="pagination-link"
+                   class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None %} {{ url_for(view_name, _id=id, page=current_page-1, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=current_page-1, **query_string_parameters) }} {% endif %}"
                    rel="prev">
                     <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
@@ -17,7 +18,8 @@
                         <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z">
                         </path>
                     </svg>
-                    <span class="govuk-pagination__link-title">Previous<span class="govuk-visually-hidden">page</span></span>
+                    <span data-testid="pagination-link-title"
+                          class="govuk-pagination__link-title">Previous<span class="govuk-visually-hidden">page</span></span>
                 </a>
             </div>
         {% endif %}
@@ -26,13 +28,15 @@
                 {% if page %}
                     {% if page != current_page %}
                         <li class="govuk-pagination__item">
-                            <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
+                            <a data-testid="pagination-link"
+                               class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                                href="{% if id != None %} {{ url_for(view_name, _id=id , page=page, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=page, **query_string_parameters) }}{% endif %}"
                                aria-label="Page {{ page }}">{{ page }}</a>
                         </li>
                     {% else %}
                         <li class="govuk-pagination__item govuk-pagination__item--current">
-                            <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
+                            <a data-testid="pagination-link"
+                               class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                                href="{% if id != None %} {{ url_for(view_name, _id=id , page=page, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=page, **query_string_parameters) }} {% endif %}"
                                aria-label="Page {{ page }}">{{ page }}</a>
                         </li>
@@ -44,10 +48,12 @@
         </ul>
         {% if results.has_next == True %}
             <div class="govuk-pagination__next">
-                <a class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
+                <a data-testid="pagination-link"
+                   class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None %} {{ url_for(view_name, _id=id , page=current_page+1, **query_string_parameters) }} {% else %} {{ url_for(view_name, page=current_page+1, **query_string_parameters) }}{% endif %}"
                    rel="next">
-                    <span class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden">page</span></span>
+                    <span data-testid="pagination-link-title"
+                          class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden">page</span></span>
                     <svg class="govuk-pagination__icon govuk-pagination__icon--next"
                          xmlns="http://www.w3.org/2000/svg"
                          height="13"

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -537,7 +537,7 @@ class TestBrowse:
         soup = BeautifulSoup(response.data, "html.parser")
 
         page_options = soup.find_all(
-            "span", class_="govuk-pagination__link-title"
+            "span", attrs={"data-testid": "pagination-link-title"}
         )
 
         expected_rows = [
@@ -618,7 +618,6 @@ class TestBrowse:
 
         soup = BeautifulSoup(response.data, "html.parser")
 
-        # page_options = soup.find_all("span", class_="govuk-pagination__link-title")
         previous_option = soup.find("div", {"class": "govuk-pagination__prev"})
         next_option = soup.find("div", {"class": "govuk-pagination__next"})
         expected_rows = [

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -925,7 +925,7 @@ class TestSearchTransferringBody:
         soup = BeautifulSoup(response.data, "html.parser")
 
         page_options = soup.find_all(
-            "span", class_="govuk-pagination__link-title"
+            "span", attrs={"data-testid": "pagination-link-title"}
         )
 
         expected_rows = [

--- a/e2e_tests/test_search.py
+++ b/e2e_tests/test_search.py
@@ -356,11 +356,11 @@ class TestSearchTransferringBody:
 
         assert (
             aau_user_page.locator(
-                ".govuk-pagination__link"
+                "data-testid=pagination-link"
             ).first.get_attribute("href")
             == url
         )
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
         assert links[0].text_content() == "Nextpage"
 
     def test_search_transferring_body_pagination_get_previous_page(
@@ -387,7 +387,7 @@ class TestSearchTransferringBody:
             )
             == "Pagination"
         )
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
 
         assert links[0].text_content() == "Previouspage"
 
@@ -417,12 +417,12 @@ class TestSearchTransferringBody:
         url = f" {self.route_url}/{self.transferring_body_id}?page=1&query=a "
         assert (
             aau_user_page.locator(
-                ".govuk-pagination__link"
+                "data-testid=pagination-link"
             ).first.get_attribute("href")
             == url
         )
         aau_user_page.get_by_label("Page 2").click()
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
         assert links[0].text_content() == "Previouspage"
         if len(links) > 1:
             assert links[1].text_content() == "Nextpage"
@@ -449,7 +449,7 @@ class TestSearchTransferringBody:
             )
             == "Pagination"
         )
-        page_links = aau_user_page.locator(".govuk-pagination__link").all()
+        page_links = aau_user_page.locator("data-testid=pagination-link").all()
         last_page = page_links[len(page_links) - 1].text_content()
 
         assert page_links[0].inner_text() == "1"
@@ -459,7 +459,7 @@ class TestSearchTransferringBody:
             ".govuk-pagination__item--ellipses"
         ).all()
         assert ellipsis_link[0].inner_text() == "…"
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
         assert links[0].text_content() == "Nextpage"
 
     def test_search_transferring_body_pagination_click_previous_page_link(
@@ -488,7 +488,7 @@ class TestSearchTransferringBody:
 
         aau_user_page.get_by_label("Page 2").click()
 
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
 
         assert links[0].text_content() == "Previouspage"
 
@@ -525,7 +525,7 @@ class TestSearchTransferringBody:
 
         aau_user_page.wait_for_selector(".govuk-pagination")
 
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
 
         assert links[1].text_content() == "Nextpage"
 
@@ -560,8 +560,8 @@ class TestSearchTransferringBody:
             )
             == "Pagination"
         )
-        page_links = aau_user_page.locator(".govuk-pagination__link").all()
+        page_links = aau_user_page.locator("data-testid=pagination-link").all()
         last_page = page_links[len(page_links) - 1].text_content()
         aau_user_page.get_by_role("link").get_by_text(last_page).click()
-        links = aau_user_page.locator(".govuk-pagination__link-title").all()
+        links = aau_user_page.locator("data-testid=pagination-link-title").all()
         assert links[0].text_content() == "Previouspage"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- replaced pagination tests to locate elements using testid instead of classes inside of unit tests and e2e tests

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1055

## Screenshots of UI changes

### Before
N/A

### After
N/A

- [ ] Requires env variable(s) to be updated
