### PR TITLE
Add err checking for get & read file

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -666,9 +666,11 @@ def download_record(record_id: uuid.UUID):
         current_app.logger.error(f"Error reading S3 file content: {e}")
         abort(500)
 
+    content_type = s3_file_object.get("ContentType", "application/octet-stream")
+
     response = send_file(
         io.BytesIO(file_content),
-        mimetype=s3_file_object["ContentType"],
+        mimetype=content_type,
         as_attachment=True,
         download_name=download_filename,
     )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,14 +1,15 @@
+import io
 import json
 import uuid
 
 import boto3
 from flask import (
-    Response,
     abort,
     current_app,
     redirect,
     render_template,
     request,
+    send_file,
     session,
     url_for,
 )
@@ -665,11 +666,11 @@ def download_record(record_id: uuid.UUID):
         current_app.logger.error(f"Error reading S3 file content: {e}")
         abort(500)
 
-    response = Response(
-        file_content,
-        headers={
-            "Content-Disposition": f"attachment;filename={download_filename}"
-        },
+    response = send_file(
+        io.BytesIO(file_content),
+        mimetype=s3_file_object["ContentType"],
+        as_attachment=True,
+        download_name=download_filename,
     )
     current_app.logger.info(
         json.dumps({"user_id": session["user_id"], "file": key})

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -213,11 +213,9 @@ class TestDownload:
 
         response = client.get(f"{self.route_url}/{file.FileId}")
 
-        assert response.status_code == 500
-        assert "Error reading S3 file content" in caplog.text
-
         msg = "Error reading S3 file content: Read error"
 
+        assert response.status_code == 500
         assert caplog.records[0].levelname == "ERROR"
         assert caplog.records[0].message == msg
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- change to use send_file (https://flask.palletsprojects.com/en/3.0.x/api/#flask.send_file) as this can try to detect the mimetype it from the file name.
- Default to octet-stream content type if there isn't a file type. See: https://www.rfc-editor.org/rfc/rfc9110.html#name-content-type. Our files stored in S3 don't have this set and could be causing an issue.
- Add 404 error on getting file from S3 in download_record
- Add 500 error on reading file from S3 in download_record
- Add tests

## JIRA ticket
- https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?selectedIssue=AYR-1031

## Screenshots of UI changes
N/A

### Before

### After

- [ ] Requires env variable(s) to be updated
