### PR TITLE
AYR-1079 - Fix e2e tests after changes to tables

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -26,7 +26,7 @@
                        aria-label="Browse records">
                     <thead class="govuk-table__head">
                         <!-- Column headings -->
-                        <tr class="govuk-table__row govuk-table__row__heading">
+                        <tr class="govuk-table__row">
                             <th scope="col"
                                 class="govuk-table__header govuk-table--invisible-on-desktop">
                                 Transferring body /

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -26,7 +26,7 @@
                        aria-label="Browse records">
                     <thead class="govuk-table__head">
                         <!-- Column headings -->
-                        <tr class="govuk-table__row">
+                        <tr class="govuk-table__row govuk-table__row__heading">
                             <th scope="col"
                                 class="govuk-table__header govuk-table--invisible-on-desktop">
                                 Transferring body /

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -77,3 +77,28 @@ def browser_context_args(browser_context_args):
         "ignore_https_errors": True,
         "java_script_enabled": False,
     }
+
+
+class Utils:
+    @staticmethod
+    def get_page_table_headers(page: Page):
+        return page.locator(
+            "th:not(.govuk-table--invisible-on-desktop)"
+        ).evaluate_all("""els => els.map(e => e.innerText.trim())""")
+
+    @staticmethod
+    def get_page_table_rows(page: Page):
+        return page.get_by_role("row").evaluate_all(
+            """els => {
+                    document.querySelectorAll('.govuk-table--invisible-on-desktop')
+                        .forEach(el => el.remove())
+                    return els.map(el =>
+                        [...el.querySelectorAll('td')].map(e => e.innerText.trim())
+                    ).filter(e => e.length > 0)
+                }"""
+        )
+
+
+@pytest.fixture
+def utils():
+    return Utils

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -81,13 +81,13 @@ def browser_context_args(browser_context_args):
 
 class Utils:
     @staticmethod
-    def get_page_table_headers(page: Page):
+    def get_desktop_page_table_headers(page: Page):
         return page.locator(
             "th:not(.govuk-table--invisible-on-desktop)"
         ).evaluate_all("""els => els.map(e => e.innerText.trim())""")
 
     @staticmethod
-    def get_page_table_rows(page: Page):
+    def get_desktop_page_table_rows(page: Page):
         return page.get_by_role("row").evaluate_all(
             """els => {
                     document.querySelectorAll('.govuk-table--invisible-on-desktop')

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -37,24 +37,15 @@ class TestBrowse:
         assert aau_user_page.inner_html("text='All available records'")
 
     def test_browse_filter_functionality_with_query_string_parameters(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         aau_user_page.goto(
             f"{self.route_url}?transferring_body_filter=all&series_filter=&date_from_day"
             "01=&date_from_month=07&date_from_year=2023&date_to_day=31&date_to_month=02&date_to_year=2024"
         )
 
-        header_rows = aau_user_page.locator(
-            "thead.govuk-table__head th[class*=browse__all__desktop__header]"
-        ).evaluate_all("""els => els.map(e => e.textContent.trim())""")
-
-        rows = aau_user_page.locator(
-            ".govuk-table__row.browse__table__all_desktop__row"
-        ).evaluate_all(
-            """els => els.map(el =>
-              [...el.querySelectorAll('td.browse__table__all_desktop')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],
@@ -65,24 +56,15 @@ class TestBrowse:
         assert rows == expected_rows
 
     def test_browse_sort_functionality_by_transferring_body_descending(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         aau_user_page.get_by_label("Sort by").select_option(
             "transferring_body-desc"
         )
         aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
-        header_rows = aau_user_page.locator(
-            "thead.govuk-table__head th[class*=browse__all__desktop__header]"
-        ).evaluate_all("""els => els.map(e => e.textContent.trim())""")
-
-        rows = aau_user_page.locator(
-            ".govuk-table__row.browse__table__all_desktop__row"
-        ).evaluate_all(
-            """els => els.map(el =>
-              [...el.querySelectorAll('td.browse__table__all_desktop')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "63", "5"],
@@ -93,7 +75,7 @@ class TestBrowse:
         assert rows == expected_rows
 
     def test_browse_filter_functionality_with_transferring_body_filter(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         aau_user_page.locator("#transferring_body_filter").select_option(
             "Mock 1 Department"
@@ -101,17 +83,8 @@ class TestBrowse:
         aau_user_page.get_by_role("button", name="Apply filters").click()
         aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
-        header_rows = aau_user_page.locator(
-            "thead.govuk-table__head th[class*=browse__all__desktop__header]"
-        ).evaluate_all("""els => els.map(e => e.textContent.trim())""")
-
-        rows = aau_user_page.locator(
-            ".govuk-table__row.browse__table__all_desktop__row"
-        ).evaluate_all(
-            """els => els.map(el =>
-              [...el.querySelectorAll('td.browse__table__all_desktop')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"]
@@ -121,23 +94,14 @@ class TestBrowse:
         assert rows == expected_rows
 
     def test_browse_filter_functionality_with_series_filter_wildcard_character(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         aau_user_page.goto(f"{self.route_url}")
         aau_user_page.locator("#series_filter").fill("1")
         aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        header_rows = aau_user_page.locator(
-            "thead.govuk-table__head th[class*=browse__all__desktop__header]"
-        ).evaluate_all("""els => els.map(e => e.textContent.trim())""")
-
-        rows = aau_user_page.locator(
-            ".govuk-table__row.browse__table__all_desktop__row"
-        ).evaluate_all(
-            """els => els.map(el =>
-              [...el.querySelectorAll('td.browse__table__all_desktop')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],
@@ -148,7 +112,7 @@ class TestBrowse:
         assert rows == expected_rows
 
     def test_browse_filter_functionality_with_date_filter(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         aau_user_page.goto(f"{self.route_url}")
         aau_user_page.locator("#date_from_day").fill("1")
@@ -156,17 +120,8 @@ class TestBrowse:
         aau_user_page.locator("#date_from_year").fill("2024")
         aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        header_rows = aau_user_page.locator(
-            "thead.govuk-table__head th[class*=browse__all__desktop__header]"
-        ).evaluate_all("""els => els.map(e => e.textContent.trim())""")
-
-        rows = aau_user_page.locator(
-            ".govuk-table__row.browse__table__all_desktop__row"
-        ).evaluate_all(
-            """els => els.map(el =>
-              [...el.querySelectorAll('td.browse__table__all_desktop')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -44,8 +44,8 @@ class TestBrowse:
             "01=&date_from_month=07&date_from_year=2023&date_to_day=31&date_to_month=02&date_to_year=2024"
         )
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],
@@ -63,8 +63,8 @@ class TestBrowse:
         )
         aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "63", "5"],
@@ -83,8 +83,8 @@ class TestBrowse:
         aau_user_page.get_by_role("button", name="Apply filters").click()
         aau_user_page.get_by_role("button", name="Apply", exact=True).click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"]
@@ -100,8 +100,8 @@ class TestBrowse:
         aau_user_page.locator("#series_filter").fill("1")
         aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],
@@ -120,8 +120,8 @@ class TestBrowse:
         aau_user_page.locator("#date_from_year").fill("2024")
         aau_user_page.get_by_role("button", name="Apply filters").click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             ["Mock 1 Department", "MOCK1 123", "05/03/2024", "83", "11"],

--- a/e2e_tests/test_browse_consignment.py
+++ b/e2e_tests/test_browse_consignment.py
@@ -122,8 +122,8 @@ class TestBrowseConsignment:
             f"date_to_day=&date_to_month=&date_to_year="
         )
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["03/08/2022", "delivery-form-digital.doc", "Open", "–"],
@@ -158,8 +158,8 @@ class TestBrowseConsignment:
             "button", name="Apply", exact=True
         ).click()
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["03/08/2022", "Presentation.pptx", "Closed", "04/08/2122"],
@@ -196,8 +196,8 @@ class TestBrowseConsignment:
             "button", name="Apply", exact=True
         ).click()
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             [

--- a/e2e_tests/test_browse_consignment.py
+++ b/e2e_tests/test_browse_consignment.py
@@ -2,7 +2,7 @@ from playwright.sync_api import Page
 
 
 def verify_header_row(header_rows):
-    assert header_rows[0] == [
+    assert header_rows == [
         "Date of record",
         "File name",
         "Status",
@@ -114,7 +114,7 @@ class TestBrowseConsignment:
         assert standard_user_page.get_by_label("Page 3").is_visible()
 
     def test_browse_consignment_filter_functionality_with_query_string_parameters(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(
             f"{self.route_url}/{self.consignment_id}?sort=date_last_modified-desc&record_status=all&"
@@ -122,36 +122,27 @@ class TestBrowseConsignment:
             f"date_to_day=&date_to_month=&date_to_year="
         )
 
-        header_rows = standard_user_page.locator("#tbl_result").evaluate_all(
-            """els => els.slice(0).map(el => [...el.querySelectorAll('th')].map(e => e.textContent.trim()))"""
-        )
-
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
-            ["03/08/2022", "delivery-form-digital.doc", "Open", "-"],
-            ["03/08/2022", "Digital Transfer training email .msg", "Open", "-"],
-            ["03/08/2022", "Draft DDRO 05.docx", "Open", "-"],
+            ["03/08/2022", "delivery-form-digital.doc", "Open", "–"],
+            ["03/08/2022", "Digital Transfer training email .msg", "Open", "–"],
+            ["03/08/2022", "Draft DDRO 05.docx", "Open", "–"],
             [
                 "03/08/2022",
                 "DTP_ Digital Transfer process diagram UG.docx",
                 "Open",
-                "-",
+                "–",
             ],
-            ["03/08/2022", "base_de_donnees.png", "Open", "-"],
+            ["03/08/2022", "base_de_donnees.png", "Open", "–"],
         ]
 
         verify_header_row(header_rows)
         assert rows == expected_rows
 
     def test_browse_consignment_sort_functionality_by_record_status_descending(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.consignment_id}")
         standard_user_page.get_by_label("Sort by").select_option(
@@ -167,17 +158,8 @@ class TestBrowseConsignment:
             "button", name="Apply", exact=True
         ).click()
 
-        header_rows = standard_user_page.locator("#tbl_result").evaluate_all(
-            """els => els.slice(0).map(el => [...el.querySelectorAll('th')].map(e => e.textContent.trim()))"""
-        )
-
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["03/08/2022", "Presentation.pptx", "Closed", "04/08/2122"],
@@ -187,21 +169,21 @@ class TestBrowseConsignment:
                 "Closed",
                 "26/12/2121",
             ],
-            ["03/08/2022", "Digital Transfer training email .msg", "Open", "-"],
+            ["03/08/2022", "Digital Transfer training email .msg", "Open", "–"],
             [
                 "03/08/2022",
                 "DTP_ Digital Transfer process diagram UG.docx",
                 "Open",
-                "-",
+                "–",
             ],
-            ["03/08/2022", "Draft DDRO 05.docx", "Open", "-"],
+            ["03/08/2022", "Draft DDRO 05.docx", "Open", "–"],
         ]
 
         verify_header_row(header_rows)
         assert rows == expected_rows
 
     def test_browse_consignment_filter_functionality_with_record_opening_date_filter(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.consignment_id}")
         standard_user_page.locator("label").filter(
@@ -214,17 +196,8 @@ class TestBrowseConsignment:
             "button", name="Apply", exact=True
         ).click()
 
-        header_rows = standard_user_page.locator("#tbl_result").evaluate_all(
-            """els => els.slice(0).map(el => [...el.querySelectorAll('th')].map(e => e.textContent.trim()))"""
-        )
-
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
             [

--- a/e2e_tests/test_browse_series.py
+++ b/e2e_tests/test_browse_series.py
@@ -67,8 +67,8 @@ class TestBrowseSeries:
             "=01&date_from_month=01&date_from_year=2023&date_to_day=31&date_to_month=12&date_to_year=2023"
         )
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "30/11/2023", "9", "TDR-2023-GXFH"],
@@ -93,8 +93,8 @@ class TestBrowseSeries:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],
@@ -118,8 +118,8 @@ class TestBrowseSeries:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],

--- a/e2e_tests/test_browse_series.py
+++ b/e2e_tests/test_browse_series.py
@@ -2,7 +2,7 @@ from playwright.sync_api import Page
 
 
 def verify_header_row(header_rows):
-    assert header_rows[0] == [
+    assert header_rows == [
         "Transferring body",
         "Series reference",
         "Last transfer date",
@@ -60,27 +60,15 @@ class TestBrowseSeries:
         assert standard_user_page.inner_html("text='TSTA 1'")
 
     def test_browse_series_filter_functionality_with_query_string_parameters(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(
             f"{self.route_url}/{self.series_id}?sort=last_record_transferred-desc&date_from_day"
             "=01&date_from_month=01&date_from_year=2023&date_to_day=31&date_to_month=12&date_to_year=2023"
         )
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th.browse__series__desktop__header')].map(e => e.textContent.trim())
-            )"""
-        )
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "30/11/2023", "9", "TDR-2023-GXFH"],
@@ -93,7 +81,7 @@ class TestBrowseSeries:
         assert rows == expected_rows
 
     def test_browse_series_sort_functionality_by_records_held_in_consignment_descending(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.series_id}")
         standard_user_page.get_by_label("Sort by").select_option(
@@ -105,20 +93,8 @@ class TestBrowseSeries:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th.browse__series__desktop__header')].map(e => e.textContent.trim())
-            )"""
-        )
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],
@@ -132,7 +108,7 @@ class TestBrowseSeries:
         assert rows == expected_rows
 
     def test_browse_series_filter_functionality_with_date_filter(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.series_id}")
         standard_user_page.locator("#date_from_day").fill("1")
@@ -142,20 +118,8 @@ class TestBrowseSeries:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th.browse__series__desktop__header')].map(e => e.textContent.trim())
-            )"""
-        )
-        rows = standard_user_page.locator(
-            "#tbl_result tr.govuk-table__row-ref"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [
             ["Testing A", "TSTA 1", "25/01/2024", "17", "TDR-2024-H5DN"],

--- a/e2e_tests/test_browse_transferring_body.py
+++ b/e2e_tests/test_browse_transferring_body.py
@@ -2,7 +2,7 @@ from playwright.sync_api import Page
 
 
 def verify_header_row(header_rows):
-    assert header_rows[0] == [
+    assert header_rows == [
         "Transferring body",
         "Series reference",
         "Last transfer date",
@@ -78,40 +78,15 @@ class TestBrowseTransferringBody:
         assert not next_button.is_visible()
 
     def test_browse_transferring_body_filter_functionality_with_query_string_parameters(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(
             f"{self.route_url}/{self.transferring_body_id}?series_filter=&date_from_day01=&"
             f"date_from_month=01&date_from_year=2024&date_to_day=&date_to_month=&date_to_year="
         )
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
-            )"""
-        )
-
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.map(el => {
-                var headerCells = [...el.querySelectorAll('th')];
-                if (headerCells.length >= 3) {
-                    headerCells.splice(2, 1);
-                }
-                return headerCells.map(e => e.textContent.trim());
-            })"""
-        )
-
-        rows = standard_user_page.locator(
-            ".govuk-table__body .browse__table__desktop"
-        ).evaluate_all(
-            """els => els.map(el =>
-                [...el.querySelectorAll('.govuk-table__cell')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -119,7 +94,7 @@ class TestBrowseTransferringBody:
         assert rows == expected_rows
 
     def test_browse_transferring_body_sort_functionality_by_series_descending(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
         standard_user_page.get_by_label("Sort by").select_option("series-desc")
@@ -129,25 +104,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.map(el => {
-                var headerCells = [...el.querySelectorAll('th')];
-                if (headerCells.length >= 3) {
-                    headerCells.splice(2, 1);
-                }
-                return headerCells.map(e => e.textContent.trim());
-            })"""
-        )
-
-        rows = standard_user_page.locator(
-            ".govuk-table__body .browse__table__desktop"
-        ).evaluate_all(
-            """els => els.map(el =>
-                [...el.querySelectorAll('.govuk-table__cell')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -155,7 +113,7 @@ class TestBrowseTransferringBody:
         assert rows == expected_rows
 
     def test_browse_transferring_body_filter_functionality_with_series_filter(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
         standard_user_page.locator("#series_filter").fill("TSTA 1")
@@ -166,25 +124,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.map(el => {
-                var headerCells = [...el.querySelectorAll('th')];
-                if (headerCells.length >= 3) {
-                    headerCells.splice(2, 1);
-                }
-                return headerCells.map(e => e.textContent.trim());
-            })"""
-        )
-
-        rows = standard_user_page.locator(
-            ".govuk-table__body .browse__table__desktop"
-        ).evaluate_all(
-            """els => els.map(el =>
-                [...el.querySelectorAll('.govuk-table__cell')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -192,7 +133,7 @@ class TestBrowseTransferringBody:
         assert rows == expected_rows
 
     def test_browse_transferring_body_filter_functionality_with_series_filter_wildcard_character(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
         standard_user_page.locator("#series_filter").fill("1")
@@ -200,25 +141,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.map(el => {
-                var headerCells = [...el.querySelectorAll('th')];
-                if (headerCells.length >= 3) {
-                    headerCells.splice(2, 1);
-                }
-                return headerCells.map(e => e.textContent.trim());
-            })"""
-        )
-
-        rows = standard_user_page.locator(
-            ".govuk-table__body .browse__table__desktop"
-        ).evaluate_all(
-            """els => els.map(el =>
-                [...el.querySelectorAll('.govuk-table__cell')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -226,7 +150,7 @@ class TestBrowseTransferringBody:
         assert rows == expected_rows
 
     def test_browse_transferring_body_filter_functionality_with_date_filter(
-        self, standard_user_page: Page
+        self, standard_user_page: Page, utils
     ):
         standard_user_page.goto(f"{self.route_url}/{self.transferring_body_id}")
         standard_user_page.locator("#date_from_day").fill("1")
@@ -236,25 +160,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = standard_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.map(el => {
-                var headerCells = [...el.querySelectorAll('th')];
-                if (headerCells.length >= 3) {
-                    headerCells.splice(2, 1);
-                }
-                return headerCells.map(e => e.textContent.trim());
-            })"""
-        )
-
-        rows = standard_user_page.locator(
-            ".govuk-table__body .browse__table__desktop"
-        ).evaluate_all(
-            """els => els.map(el =>
-                [...el.querySelectorAll('.govuk-table__cell')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(standard_user_page)
+        rows = utils.get_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 

--- a/e2e_tests/test_browse_transferring_body.py
+++ b/e2e_tests/test_browse_transferring_body.py
@@ -85,8 +85,8 @@ class TestBrowseTransferringBody:
             f"date_from_month=01&date_from_year=2024&date_to_day=&date_to_month=&date_to_year="
         )
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -104,8 +104,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -124,8 +124,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -141,8 +141,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 
@@ -160,8 +160,8 @@ class TestBrowseTransferringBody:
 
         standard_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(standard_user_page)
-        rows = utils.get_page_table_rows(standard_user_page)
+        header_rows = utils.get_desktop_page_table_headers(standard_user_page)
+        rows = utils.get_desktop_page_table_rows(standard_user_page)
 
         expected_rows = [["Testing A", "TSTA 1", "25/01/2024", "63", "5"]]
 

--- a/e2e_tests/test_search.py
+++ b/e2e_tests/test_search.py
@@ -2,14 +2,14 @@ from playwright.sync_api import Page, expect
 
 
 def verify_search_results_summary_header_row(header_rows):
-    assert header_rows[0] == [
+    assert header_rows == [
         "Results found within each Transferring body",
         "Records found",
     ]
 
 
 def verify_search_transferring_body_header_row(header_rows):
-    assert header_rows[0] == [
+    assert header_rows == [
         "Series reference",
         "Consignment reference",
         "File name",
@@ -24,7 +24,7 @@ class TestSearchResultsSummary:
         return "/browse"
 
     def test_search_results_summary_search_single_term(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         """
         Given a standard user on the search page
@@ -40,19 +40,8 @@ class TestSearchResultsSummary:
 
         aau_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = aau_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
-            )"""
-        )
-
-        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
-            """els => els.slice(1).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [["Mock 1 Department", "16"], ["Testing A", "12"]]
 
@@ -60,7 +49,7 @@ class TestSearchResultsSummary:
         assert rows == expected_rows
 
     def test_search_results_summary_search_multiple_terms(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         """
         Given a standard user on the search page
@@ -75,19 +64,8 @@ class TestSearchResultsSummary:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = aau_user_page.locator(
-            "#tbl_result tr:visible"
-        ).evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('th')].map(e => e.textContent.trim())
-            )"""
-        )
-
-        rows = aau_user_page.locator("#tbl_result tr:visible").evaluate_all(
-            """els => els.slice(1).map(el =>
-              [...el.querySelectorAll('td')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [["Testing A", "4"]]
 
@@ -113,7 +91,7 @@ class TestSearchTransferringBody:
         return "c3e3fd83-4d52-4638-a085-1f4e4e4dfa50"
 
     def test_search_transferring_body_search_single_term(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         """
         Given a standard user on the search transferring body page
@@ -128,17 +106,8 @@ class TestSearchTransferringBody:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.get_by_role("link", name="Testing A").click()
 
-        header_rows = aau_user_page.locator("#tbl_result").evaluate_all(
-            """els => els.slice(0).map(el =>
-            [...el.querySelectorAll('th.search__desktop-heading')].map(e => e.textContent.trim())
-            )"""
-        )
-
-        rows = aau_user_page.locator("#tbl_result tr.top-row").evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td.search__mobile-table__top-row')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             [
@@ -177,7 +146,7 @@ class TestSearchTransferringBody:
         assert rows == expected_rows
 
     def test_search_transferring_body_search_multiple_terms(
-        self, aau_user_page: Page
+        self, aau_user_page: Page, utils
     ):
         """
         Given a user on the search transferring body page
@@ -190,17 +159,8 @@ class TestSearchTransferringBody:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.get_by_role("link", name="Testing A").click()
 
-        header_rows = aau_user_page.locator("#tbl_result").evaluate_all(
-            """els => els.slice(0).map(el =>
-            [...el.querySelectorAll('th.search__desktop-heading')].map(e => e.textContent.trim())
-            )"""
-        )
-
-        rows = aau_user_page.locator("#tbl_result tr.top-row").evaluate_all(
-            """els => els.slice(0).map(el =>
-              [...el.querySelectorAll('td.search__mobile-table__top-row')].map(e => e.textContent.trim())
-            )"""
-        )
+        header_rows = utils.get_page_table_headers(aau_user_page)
+        rows = utils.get_page_table_rows(aau_user_page)
 
         expected_rows = [
             [

--- a/e2e_tests/test_search.py
+++ b/e2e_tests/test_search.py
@@ -40,8 +40,8 @@ class TestSearchResultsSummary:
 
         aau_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [["Mock 1 Department", "16"], ["Testing A", "12"]]
 
@@ -64,8 +64,8 @@ class TestSearchResultsSummary:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.wait_for_selector("#tbl_result")
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [["Testing A", "4"]]
 
@@ -106,8 +106,8 @@ class TestSearchTransferringBody:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.get_by_role("link", name="Testing A").click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             [
@@ -159,8 +159,8 @@ class TestSearchTransferringBody:
         aau_user_page.get_by_role("button", name="Search").click()
         aau_user_page.get_by_role("link", name="Testing A").click()
 
-        header_rows = utils.get_page_table_headers(aau_user_page)
-        rows = utils.get_page_table_rows(aau_user_page)
+        header_rows = utils.get_desktop_page_table_headers(aau_user_page)
+        rows = utils.get_desktop_page_table_rows(aau_user_page)
 
         expected_rows = [
             [


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added a fixture for utilities that includes standardised functions for getting table headers and rows as array of strings or, in the case of the rows, array of arrays of strings - these replace all of the manually written queries made inside each one of the e2e tests affected by the table refactor changes for better readability & maintainability.
- Made other minor changes to all of the e2e tests affected by the table refactor changes, such as modifying assertions for headers at the top of the files in order to be compatible with the output of the functions described above.
- The utils fixture is now passed to functions that require it - in the future we could use this to add other functions to replace logic that is overly repeated.

Ignoring the visual regression tests (because they are still flaky) all e2e tests now pass
<img width="945" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/249d58aa-96f8-4914-a972-c6298300360f">

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1079

## Screenshots of UI changes

### Before
N/A

### After
N/A

- [ ] Requires env variable(s) to be updated
