### PR TITLE
AYR-1029 - Implement user creation for e2e tests

### DIFF
--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -60,9 +60,6 @@ class KeycloakClient:
         )
 
         self.token = self.keycloak_openid.token(grant_type="client_credentials")
-        self.token_info = self.keycloak_openid.decode_token(
-            self.token["access_token"]
-        )
         self.keycload_admin = keycloak.KeycloakAdmin(
             server_url=self.server_url,
             realm_name=self.realm_name,

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -135,32 +135,41 @@ def create_user_page(
 
 
 @pytest.fixture(scope="session")
-def create_user_aau():
+def create_users():
     client_aau = KeycloakClient("all_access_user")
-    client_aau.create_user()
-    yield client_aau.user_email, client_aau.user_pass
-    client_aau.delete_user()
-
-
-@pytest.fixture(scope="session")
-def create_user_standard():
     client_standard = KeycloakClient("standard_user")
+
+    client_aau.create_user()
     client_standard.create_user()
-    yield client_standard.user_email, client_standard.user_pass
+
+    yield {
+        "aau": {
+            "username": client_aau.user_email,
+            "password": client_aau.user_pass,
+        },
+        "standard": {
+            "username": client_standard.user_email,
+            "password": client_standard.user_pass,
+        },
+    }
+
+    client_aau.delete_user()
     client_standard.delete_user()
 
 
 @pytest.fixture
-def aau_user_page(create_user_page, create_user_aau) -> Page:
-    username, password = create_user_aau
+def aau_user_page(create_user_page, create_users) -> Page:
+    username = create_users["aau"]["username"]
+    password = create_users["aau"]["password"]
     page = create_user_page(username, password)
     yield page
     page.goto("/sign-out")
 
 
 @pytest.fixture
-def standard_user_page(create_user_page, create_user_standard) -> Page:
-    username, password = create_user_standard
+def standard_user_page(create_user_page, create_users) -> Page:
+    username = create_users["standard"]["username"]
+    password = create_users["standard"]["password"]
     page = create_user_page(username, password)
     yield page
     page.goto("/sign-out")

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -91,7 +91,7 @@ class KeycloakClient:
             }
         )
         self.user_id = user_id
-        return
+        return self.user_id
 
     def delete_user(self):
         if self.user_id is None:

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -87,7 +87,7 @@ def keycloak_admin():
     return keycload_admin
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def create_keycloak_user(keycloak_admin):
     def _create_keycloak_user(groups, user_type):
         user_email = f"{uuid.uuid4().hex}{user_type}@test.com"
@@ -111,7 +111,7 @@ def create_keycloak_user(keycloak_admin):
 
 
 @pytest.fixture(scope="session")
-def create_aau_keycloak_user(keycloak_admin):
+def create_aau_keycloak_user(keycloak_admin, create_keycloak_user):
     user_groups = ["/ayr_user_type/view_all"]
     user_type = "aau"
     user_id, user_email, user_pass = create_keycloak_user(
@@ -124,7 +124,7 @@ def create_aau_keycloak_user(keycloak_admin):
 
 
 @pytest.fixture(scope="session")
-def create_standard_keycloak_user(keycloak_admin):
+def create_standard_keycloak_user(keycloak_admin, create_keycloak_user):
     user_groups = [
         "/ayr_user_type/view_dept",
         "/transferring_body_user/Testing A",

--- a/e2e_tests/test_login.py
+++ b/e2e_tests/test_login.py
@@ -6,15 +6,16 @@ from itsdangerous import base64_decode
 from playwright.sync_api import Page, expect
 
 
-def test_sign_in_succeeds_when_valid_credentials(page: Page, create_users):
+def test_sign_in_succeeds_when_valid_credentials(
+    page: Page, create_aau_keycloak_user
+):
     """
     Given a user is on the sign-in page,
     When they provide valid credentials and click the "Sign in" button,
     Then they should see a success message indicating they are logged in with access to AYR.
     And they should be on the '/browse' page.
     """
-    username = create_users["aau"]["username"]
-    password = create_users["aau"]["password"]
+    username, password = create_aau_keycloak_user
     page.goto("/sign-in")
     page.get_by_label("Email address").fill(username)
     page.get_by_label("Password").fill(password)

--- a/e2e_tests/test_login.py
+++ b/e2e_tests/test_login.py
@@ -1,5 +1,4 @@
 import json
-import os
 import zlib
 
 import jwt
@@ -7,18 +6,17 @@ from itsdangerous import base64_decode
 from playwright.sync_api import Page, expect
 
 
-def test_sign_in_succeeds_when_valid_credentials(page: Page):
+def test_sign_in_succeeds_when_valid_credentials(page: Page, create_user_aau):
     """
     Given a user is on the sign-in page,
     When they provide valid credentials and click the "Sign in" button,
     Then they should see a success message indicating they are logged in with access to AYR.
     And they should be on the '/browse' page.
     """
+    username, password = create_user_aau
     page.goto("/sign-in")
-    page.get_by_label("Email address").fill(
-        os.environ.get("AYR_AAU_USER_USERNAME")
-    )
-    page.get_by_label("Password").fill(os.environ.get("AYR_AAU_USER_PASSWORD"))
+    page.get_by_label("Email address").fill(username)
+    page.get_by_label("Password").fill(password)
     page.get_by_role("button", name="Sign in").click()
     expect(page).to_have_url("/browse")
     cookies = page.context.cookies()
@@ -36,10 +34,13 @@ def test_sign_in_succeeds_when_valid_credentials(page: Page):
         access_token, options={"verify_signature": False}
     )
     assert set(decoded_token_dict.keys()) == {
+        "aud",
         "exp",
         "iat",
         "auth_time",
         "jti",
+        "realm_access",
+        "resource_access",
         "iss",
         "sub",
         "typ",

--- a/e2e_tests/test_login.py
+++ b/e2e_tests/test_login.py
@@ -6,14 +6,15 @@ from itsdangerous import base64_decode
 from playwright.sync_api import Page, expect
 
 
-def test_sign_in_succeeds_when_valid_credentials(page: Page, create_user_aau):
+def test_sign_in_succeeds_when_valid_credentials(page: Page, create_users):
     """
     Given a user is on the sign-in page,
     When they provide valid credentials and click the "Sign in" button,
     Then they should see a success message indicating they are logged in with access to AYR.
     And they should be on the '/browse' page.
     """
-    username, password = create_user_aau
+    username = create_users["aau"]["username"]
+    password = create_users["aau"]["password"]
     page.goto("/sign-in")
     page.get_by_label("Email address").fill(username)
     page.get_by_label("Password").fill(password)


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Moved classes to the top of the ```conftest.py``` file
- Added a ```KeycloakClient``` class that initializes with a number of properties (such as a random email, password, etc.) along with a ```KeycloakAdmin``` instance that uses ```KeycloakOpenID```
- The ```KeycloakClient``` class has functions used to create and delete a user using class instance properties
- Added a session scoped fixture function ```create_users``` that creates an all access and standard account which are returned as a dict, this function also deletes the users at the end of the session
- Modified ```aau_user_page``` and ```standard_user_page``` and a couple other e2e tests to use the fixture mentioned above instead of using environment variables as login credentials

Note: these changes make the .env.e2e_tests file in large part obsolete, however for now pa11y-ci still uses these environment variables

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1029

## Screenshots of UI changes

### Before
N/A
### After
N/A

- [ ] Requires env variable(s) to be updated
