### PR TITLE
Make dependabot update docker versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,11 @@
 
 version: 2
 updates:
-  - package-ecosystem: "pip" # See documentation for possible values
+  - package-ecosystem: "pip"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "docker"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
## Changes in this PR

Make dependabot update docker versions

So that we can keep our docker images up to date with bug fixes