### PR TITLE
Removing pa11y CI from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,15 +57,6 @@ repos:
         language: system
         pass_filenames: false
 
--   repo: local
-    hooks:
-    -   id: pa11y-ci-precommit
-        name: Pa11y CI
-        entry: custom_hooks/pa11y_ci_precommit.sh
-        language: system
-        pass_filenames: false
-        verbose: true
-
 - repo: https://github.com/thibaudcolas/pre-commit-stylelint
   rev: v16.2.1
   hooks:


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Removed Pa11y CI configuration from pre-commit config so it doesn't run at each commit anymore
## JIRA ticket
N/A
## Screenshots of UI changes

### Before
N/A
### After
N/A
- [ ] Requires env variable(s) to be updated
