### PR TITLE
AYR-998 - Reading Keycloak client secret from different specified SM store

### DIFF
--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -26,6 +26,7 @@ def test_local_env_vars_config_initialized(monkeypatch):
     monkeypatch.setenv(
         "DB_SSL_ROOT_CERTIFICATE", "test_db_ssl_root_certificate"
     )
+    monkeypatch.setenv("AWS_SM_KEYCLOAK_CLIENT_SECRET_ID", "")
     monkeypatch.setenv("KEYCLOAK_BASE_URI", "test_keycloak_base_uri")
     monkeypatch.setenv("KEYCLOAK_CLIENT_ID", "test_keycloak_client_id")
     monkeypatch.setenv("KEYCLOAK_REALM_NAME", "test_keycloak_realm_name")

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -118,7 +118,6 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
             "KEYCLOAK_BASE_URI": "test_keycloak_base_uri",
             "KEYCLOAK_CLIENT_ID": "test_keycloak_client_id",
             "KEYCLOAK_REALM_NAME": "test_keycloack_realm_name",
-            "KEYCLOAK_CLIENT_SECRET": "test_keycloak_client_secret",  # pragma: allowlist secret
             "RECORD_BUCKET_NAME": "test_record_bucket_name",
             "FLASKS3_ACTIVE": "False",
             "FLASKS3_CDN_DOMAIN": "test_flasks3_cdn_domain",
@@ -135,6 +134,8 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
         }
     )
 
+    secret_kc_value = json.dumps({"SECRET": "test_keycloak_client_secret"})
+
     ssm_client = boto3.client("secretsmanager")
 
     ssm_client.create_secret(
@@ -142,8 +143,17 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
         SecretString=secret_value,
     )
 
+    ssm_client.create_secret(
+        Name="test_kc_secret_id",
+        SecretString=secret_kc_value,
+    )
+
     monkeypatch.setenv(
         "AWS_SM_CONFIG_SECRET_ID", "test_secret_id"
+    )  # pragma: allowlist secret
+
+    monkeypatch.setenv(
+        "AWS_SM_KEYCLOAK_CLIENT_SECRET_ID", "test_kc_secret_id"
     )  # pragma: allowlist secret
 
     config = AWSSecretsManagerConfig()

--- a/configs/aws_secrets_manager_config.py
+++ b/configs/aws_secrets_manager_config.py
@@ -15,9 +15,11 @@ if os.environ.get("DEFAULT_AWS_PROFILE"):
 class AWSSecretsManagerConfig(BaseConfig):
     def __init__(self) -> None:
         super().__init__()
-        self.secrets_dict = self._get_secrets_manager_config_dict()
+        self.secrets_dict = self._get_secrets_manager_config_dict(
+            os.getenv("AWS_SM_CONFIG_SECRET_ID")
+        )
 
-    def _get_secrets_manager_config_dict(self):
+    def _get_secrets_manager_config_dict(self, secret_id):
         """
         Get string value of `secret_name` in Secrets Manager.
         :param key: Name of key whose value will be returned.
@@ -27,12 +29,18 @@ class AWSSecretsManagerConfig(BaseConfig):
             service_name="secretsmanager",
         )
 
-        secret_value_json_string = client.get_secret_value(
-            SecretId=os.getenv("AWS_SM_CONFIG_SECRET_ID")
-        )["SecretString"]
+        secret_value_json_string = client.get_secret_value(SecretId=secret_id)[
+            "SecretString"
+        ]
         secrets_dict = json.loads(secret_value_json_string)
 
         return secrets_dict
 
     def _get_config_value(self, variable_name):
         return self.secrets_dict[variable_name]
+
+    @property
+    def KEYCLOAK_CLIENT_SECRET(self):
+        return self._get_secrets_manager_config_dict(
+            os.getenv("AWS_SM_KEYCLOAK_CLIENT_SECRET_ID")
+        )["SECRET"]

--- a/configs/aws_secrets_manager_config.py
+++ b/configs/aws_secrets_manager_config.py
@@ -21,9 +21,9 @@ class AWSSecretsManagerConfig(BaseConfig):
 
     def _get_secrets_manager_config_dict(self, secret_id):
         """
-        Get string value of `secret_name` in Secrets Manager.
-        :param key: Name of key whose value will be returned.
-        :return: String value of requested Parameter Store key.
+        Get dict of secret values using `secret_id` in Secrets Manager.
+        :param secret_id: The ID of the Secrets Manager store to retrieve data from.
+        :return: Dict representing the values inside the store
         """
         client = boto3.client(
             service_name="secretsmanager",
@@ -37,6 +37,11 @@ class AWSSecretsManagerConfig(BaseConfig):
         return secrets_dict
 
     def _get_config_value(self, variable_name):
+        """
+        Get a specific value from inside the Secrets Manager dict using `variable_name`.
+        :param variable_name: Key of the value that should be retrieved.
+        :return: Value of the retrieved secret
+        """
         return self.secrets_dict[variable_name]
 
     @property


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Inside ```AWSSecretsManagerConfig``` the function ```_get_secrets_manager_config_dict``` now takes a ```secret_id``` as an argument, allowing us to use it in multiple locations as a generic function and with multiple ids
- The ```KEYCLOAK_CLIENT_SECRET``` property inside the same class is now being overwritten in order to use the above mentioned function to retrieve the SM store for specifically the Keycloak client secret, in this case the ```secret_id``` is stored as an environment variable as ```AWS_SM_KEYCLOAK_CLIENT_SECRET_ID```
- Made changes to fix broken unit tests after the changes above
## JIRA ticket

## Screenshots of UI changes

### Before
N/A
### After
N/A
- [ ] Requires env variable(s) to be updated
