### PR TITLE
AYR-791 - Replace select with textbox on /browse for AAU users

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -102,7 +102,7 @@
                          alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="transferring_body_filter">Search transferring body</label>
+                    <label class="govuk-label" for="transferring_body_filter">Transferring body</label>
                 </h3>
                 <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
                     <input class="govuk-input"

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -102,25 +102,27 @@
                          alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="transferring_body_filter">Select transferring body</label>
+                    <label class="govuk-label" for="transferring_body_filter">Search transferring body</label>
                 </h3>
                 <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
-                    <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-                            id="transferring_body_filter"
-                            name="transferring_body_filter">
-                        <option value="all" selected>Choose one...</option>
+                    <input class="govuk-input"
+                           id="transferring_body_filter"
+                           name="transferring_body_filter"
+                           type="text">
+                    <!-- For future reference, we can use a datalist for autocomplete where the input above is type of "search" and takes the attribute list as "transferring_bodies", defined below -->
+                    <!-- <datalist id="transferring_bodies">
                         {% for body in transferring_bodies %}
                             {% if filters['transferring_body'] %}
                                 {% if ((filters['transferring_body'] | lower) == body | lower) %}
-                                    <option value="{{ body }}" selected="selected">{{ body }}</option>
+                                    <option value="{{ body }}" />
                                 {% else %}
-                                    <option value="{{ body }}">{{ body }}</option>
+                                    <option value="{{ body }}" />
                                 {% endif %}
                             {% else %}
-                                <option value="{{ body }}">{{ body }}</option>
+                                <option value="{{ body }}" />
                             {% endif %}
                         {% endfor %}
-                    </select>
+                    </datalist> -->
                 </div>
             </div>
             <div class="browse-all-filter-container browse-all-filter-container--file-type">

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -147,26 +147,15 @@ class TestBrowse:
 
         html = response.data.decode()
 
-        expected_html = f"""
-            <select class="govuk-select govuk-select__filters-form-transferring-body-select"
-            id="transferring_body_filter" name="transferring_body_filter">
-                <option value="all" selected>Choose one...</option>
-                <option value="first_body">{browse_files[0].consignment.series.body.Name}</option>
-                <option value="second_body">{browse_files[3].consignment.series.body.Name}</option>
-                <option value="third_body">{browse_files[10].consignment.series.body.Name}</option>
-                <option value="fourth_body">{browse_files[13].consignment.series.body.Name}</option>
-                <option value="fifth_body">{browse_files[19].consignment.series.body.Name}</option>
-                <option value="sixth_body">{browse_files[25].consignment.series.body.Name}</option>
-            </select>
+        expected_html = """
+            <input class="govuk-input" id="transferring_body_filter" name="transferring_body_filter" type="text">
         """
 
         assert_contains_html(
             expected_html,
             html,
-            "select",
-            {
-                "class": "govuk-select govuk-select__filters-form-transferring-body-select"
-            },
+            "input",
+            {"class": "govuk-input"},
         )
 
     def test_browse_submit_search_query(

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -155,7 +155,7 @@ class TestBrowse:
             expected_html,
             html,
             "input",
-            {"class": "govuk-input"},
+            {"name": "transferring_body_filter"},
         )
 
     def test_browse_submit_search_query(

--- a/e2e_tests/test_browse.py
+++ b/e2e_tests/test_browse.py
@@ -77,7 +77,7 @@ class TestBrowse:
     def test_browse_filter_functionality_with_transferring_body_filter(
         self, aau_user_page: Page, utils
     ):
-        aau_user_page.locator("#transferring_body_filter").select_option(
+        aau_user_page.locator("#transferring_body_filter").fill(
             "Mock 1 Department"
         )
         aau_user_page.get_by_role("button", name="Apply filters").click()


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- On browse page, replaced the tranferring bodies select element with a textbox
- Removed "Search" from the label of the textbox following feedback from Terry

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-791
## Screenshots of UI changes

### Before
<img width="304" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/bc2d025c-5fc6-49c5-9046-235346ac752d">

### After
<img width="326" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/4b015400-f01f-432e-94db-0bb93202fd47">


- [ ] Requires env variable(s) to be updated
