### PR TITLE
AYR-794 - Change breadcrumbs links hover state

### DIFF
--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -62,6 +62,12 @@
     }
   }
 
+  [class*="__link"] {
+    &:hover {
+      text-decoration-thickness: 3px;
+    }
+  }
+
   &__link--record {
     color: $colour-link-default;
     font-size: 1rem;

--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -63,6 +63,8 @@
   }
 
   [class*="__link"] {
+    text-underline-offset: 3px;
+
     &:hover {
       text-decoration-thickness: 3px;
     }

--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -18,7 +18,7 @@
                             No results found
                         {% endif %}
                     </h1>
-                    <p class="govuk-body browse__body">You are viewing</p>
+                    <h2 class="govuk-body browse__body">You are viewing</h2>
                     {% if browse_type == "browse" %}
                         {% include "browse-all.html" %}
                     {% elif browse_type == "transferring_body" %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -59,7 +59,7 @@
             <div class="govuk-grid-row govuk-grid-row--record-view mobile-record-layout">
                 <div class="govuk-grid-row govuk-grid-row-record">
                     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-                        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+                        <h2 class="govuk-body-m govuk-body-m__record-view">You are viewing</h2>
                         {% with dict = breadcrumbs %}
                             {% set record_breadcrumbs = True %}
                             {% include "breadcrumb.html" %}

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -18,7 +18,7 @@
                         No results found
                     {% endif %}
                 </h1>
-                <p class="govuk-body browse__body">You are viewing</p>
+                <h2 class="govuk-body browse__body">You are viewing</h2>
                 {% set breadcrumbs = {"everything": "All available records", "body": "Results summary"} %}
                 <!-- BREAD CRUMB -->
                 {% with dict = breadcrumbs %}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -39,7 +39,7 @@
                         No results found
                     {% endif %}
                 </h1>
-                <p class="govuk-body browse__body">You are viewing</p>
+                <h2 class="govuk-body browse__body">You are viewing</h2>
                 <!-- BREAD CRUMB -->
                 {% with dict = breadcrumbs %}
                     {% include "breadcrumb.html" %}

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -101,7 +101,7 @@ class TestRecord:
 
         expected_breadcrumbs_html = f"""
         <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+        <h2 class="govuk-body-m govuk-body-m__record-view">You are viewing</h2>
 
         <div class="govuk-breadcrumbs govuk-breadcrumbs--file">
             <ol class="govuk-breadcrumbs__list">


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Changed links inside breadcrumbs to have a state on hover
- Changed "You are viewing" text from a p tag to a h2 following feedback from Terry

## JIRA ticket

## Screenshots of UI changes

### Before
<img width="439" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/ceaf2c1f-6ced-458e-877e-8dc92e5a969c">


### After
<img width="453" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/614406db-c074-4358-adce-9d4a5751eef1">

- [ ] Requires env variable(s) to be updated
