### PR TITLE
AYR-793 - Reduce space between heading and the breadcrumbs

### DIFF
--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -39,6 +39,8 @@
 }
 
 .govuk-breadcrumbs {
+  margin-top: 6px;
+
   &__list-item {
     &:last-child span {
       @include signposting-text;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Changed margin-top for breadcrumbs in order to reduce the space between "You are viewing" heading and breadcrumbs

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-793

## Screenshots of UI changes

### Before
![image](https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/7212b227-f64a-4728-9a9a-316113c45707)

### After
<img width="381" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/11d3d1ec-652d-4b18-adc0-808af9586d39">

- [ ] Requires env variable(s) to be updated
