### PR TITLE
AYR-915 - Adding autocomplete functionality to browse AAU page

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -108,9 +108,8 @@
                     <input class="govuk-input"
                            id="transferring_body_filter"
                            name="transferring_body_filter"
-                           type="search"
+                           type="text"
                            list="transferring_bodies"
-                           value="{{ filters['transferring_body'] }}"
                            autocomplete="off">
                     <datalist id="transferring_bodies">
                         {% for body in transferring_bodies %}<option value="{{ body }}" />{% endfor %}

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -108,21 +108,13 @@
                     <input class="govuk-input"
                            id="transferring_body_filter"
                            name="transferring_body_filter"
-                           type="text">
-                    <!-- For future reference, we can use a datalist for autocomplete where the input above is type of "search" and takes the attribute list as "transferring_bodies", defined below -->
-                    <!-- <datalist id="transferring_bodies">
-                        {% for body in transferring_bodies %}
-                            {% if filters['transferring_body'] %}
-                                {% if ((filters['transferring_body'] | lower) == body | lower) %}
-                                    <option value="{{ body }}" />
-                                {% else %}
-                                    <option value="{{ body }}" />
-                                {% endif %}
-                            {% else %}
-                                <option value="{{ body }}" />
-                            {% endif %}
-                        {% endfor %}
-                    </datalist> -->
+                           type="search"
+                           list="transferring_bodies"
+                           value="{{ filters['transferring_body'] }}"
+                           autocomplete="off">
+                    <datalist id="transferring_bodies">
+                        {% for body in transferring_bodies %}<option value="{{ body }}" />{% endfor %}
+                    </datalist>
                 </div>
             </div>
             <div class="browse-all-filter-container browse-all-filter-container--file-type">

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -148,7 +148,14 @@ class TestBrowse:
         html = response.data.decode()
 
         expected_html = """
-            <input class="govuk-input" id="transferring_body_filter" name="transferring_body_filter" type="text">
+            <input
+                class="govuk-input"
+                id="transferring_body_filter"
+                name="transferring_body_filter"
+                type="search"
+                list="transferring_bodies"
+                autocomplete="off"
+            >
         """
 
         assert_contains_html(

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -152,7 +152,7 @@ class TestBrowse:
                 class="govuk-input"
                 id="transferring_body_filter"
                 name="transferring_body_filter"
-                type="search"
+                type="text"
                 list="transferring_bodies"
                 autocomplete="off"
             >


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added a datalist element that contains all of our transferring bodies (much alike the list for a combobox)
- Added a list attribute to the transferring bodies filter input that takes the ID of the datalist above in order to show results whenever a user tries to search for transferring bodies - this should work with or without JavaScript enabled
- Set the autocomplete attribute of the same input mentioned above to off, this actually refers to recently used terms and not the datalist we want to use data from

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-915

## Screenshots of UI changes

### Before
<img width="326" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/03dd4349-fc08-4350-8ae9-341e33ae3ba9">


### After
<img width="338" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/bd0763c8-e390-4c5b-b18c-beebea5bbaab">

<img width="350" alt="image" src="https://github.com/nationalarchives/da-ayr-beta-webapp/assets/105435961/eb2ccb36-4ecc-4988-a015-493ba6a53797">

- [ ] Requires env variable(s) to be updated
