### PR TITLE
AYR-1121 - Add support for download group permissions 

### DIFF
--- a/app/main/authorize/ayr_user.py
+++ b/app/main/authorize/ayr_user.py
@@ -17,6 +17,10 @@ class AYRUser:
         return self.is_all_access_user or self.is_standard_user
 
     @property
+    def can_download_records(self) -> bool:
+        return "/ayr_user_type/download" in self.groups
+
+    @property
     def is_all_access_user(self) -> bool:
         return "/ayr_user_type/view_all" in self.groups
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -593,6 +593,8 @@ def record(record_id: uuid.UUID):
     """
     form = SearchForm()
     file = db.session.get(File, record_id)
+    ayr_user = AYRUser(session.get("user_groups"))
+    can_download_records = ayr_user.can_download_records
 
     if file is None:
         abort(404)
@@ -628,6 +630,7 @@ def record(record_id: uuid.UUID):
         record=file_metadata,
         breadcrumb_values=breadcrumb_values,
         download_filename=download_filename,
+        can_download_records=can_download_records,
         filters={},
     )
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -643,7 +643,7 @@ def download_record(record_id: uuid.UUID):
     can_download_records = ayr_user.can_download_records
 
     if can_download_records is False:
-        abort(401)
+        abort(403)
 
     if file is None:
         abort(404)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -639,6 +639,11 @@ def record(record_id: uuid.UUID):
 @access_token_sign_in_required
 def download_record(record_id: uuid.UUID):
     file = db.session.get(File, record_id)
+    ayr_user = AYRUser(session.get("user_groups"))
+    can_download_records = ayr_user.can_download_records
+
+    if can_download_records is False:
+        abort(401)
 
     if file is None:
         abort(404)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -642,7 +642,7 @@ def download_record(record_id: uuid.UUID):
     ayr_user = AYRUser(session.get("user_groups"))
     can_download_records = ayr_user.can_download_records
 
-    if can_download_records is False:
+    if can_download_records is not True:
         abort(403)
 
     if file is None:

--- a/app/templates/main/401.html
+++ b/app/templates/main/401.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block pageTitle %}Server Error – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Unauthorised</h1>
+            <p class="govuk-body">If you typed the web address, check it is correct.</p>
+            <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
+        </div>
+    </div>
+{% endblock %}

--- a/app/templates/main/401.html
+++ b/app/templates/main/401.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% block pageTitle %}Server Error – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block pageTitle %}Unauthorised – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
 {% block content %}
     <div class="govuk-grid-row">

--- a/app/templates/main/403.html
+++ b/app/templates/main/403.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
-{% block pageTitle %}Unauthorised – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% block pageTitle %}Forbidden – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% set mainClasses = "govuk-main-wrapper--l" %}
 {% block content %}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l">Unauthorised</h1>
+            <h1 class="govuk-heading-l">Forbidden</h1>
             <p class="govuk-body">If you typed the web address, check it is correct.</p>
             <p class="govuk-body">If you pasted the web address, check you copied the entire address.</p>
         </div>

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -77,22 +77,24 @@
                     </div>
                 </div>
                 <div class="govuk-grid-column-one-third govuk-grid-column-one-third--record mobile-record-layout-rights">
-                    <div class="rights-container">
-                        <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-                        <a href="{{ url_for('main.download_record', record_id=record['file_id']) }}"
-                           class="govuk-button govuk-button__download--record"
-                           data-module="govuk-button">Download record</a>
-                        {% if download_filename %}
-                            <p class="govuk-body govuk-body--download-filename">
-                                The downloaded record will be named
-                                <br>
-                                <strong>{{ download_filename }}</strong>
+                    {% if can_download_records %}
+                        <div class="rights-container">
+                            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
+                            <a href="{{ url_for('main.download_record', record_id=record['file_id']) }}"
+                               class="govuk-button govuk-button__download--record"
+                               data-module="govuk-button">Download record</a>
+                            {% if download_filename %}
+                                <p class="govuk-body govuk-body--download-filename">
+                                    The downloaded record will be named
+                                    <br>
+                                    <strong>{{ download_filename }}</strong>
+                                </p>
+                            {% endif %}
+                            <p class="govuk-body govuk-body--terms-of-use">
+                                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
                             </p>
-                        {% endif %}
-                        <p class="govuk-body govuk-body--terms-of-use">
-                            Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
-                        </p>
-                    </div>
+                        </div>
+                    {% endif %}
                 </div>
                 <div class="govuk-grid-column-one-third govuk-grid-column-one-third--record mobile-record-layout-record-arrangement">
                     <div class="record-container">

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -24,8 +24,13 @@ def mock_standard_user():
         "app.main.authorize.access_token_sign_in_required.get_keycloak_instance_from_flask_config"
     )
 
-    def _mock_standard_user(client: FlaskClient, body: str = "test_body"):
+    def _mock_standard_user(
+        client: FlaskClient, body: str = "test_body", can_download: bool = False
+    ):
         groups = ["/ayr_user_type/view_dept", f"/transferring_body_user/{body}"]
+        if can_download:
+            groups = groups + ["/ayr_user_type/download"]
+
         with client.session_transaction() as session:
             session["access_token"] = "valid_access_token"
             session["refresh_token"] = "valid_refresh_token"
@@ -58,8 +63,11 @@ def mock_all_access_user():
         "app.main.authorize.access_token_sign_in_required.get_keycloak_instance_from_flask_config"
     )
 
-    def _mock_all_access_user(client: FlaskClient):
+    def _mock_all_access_user(client: FlaskClient, can_download: bool = False):
         groups = ["/ayr_user_type/view_all"]
+
+        if can_download:
+            groups = groups + ["/ayr_user_type/download"]
 
         with client.session_transaction() as session:
             session["access_token"] = "valid_access_token"

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -274,7 +274,7 @@ class TestDownload:
         assert response.status_code == 200
 
     @mock_aws
-    def test_download_record_for_all_access_user_unauthorized_response(
+    def test_download_record_for_all_access_user_forbidden_response(
         self, app, client, mock_all_access_user
     ):
         """
@@ -293,10 +293,10 @@ class TestDownload:
         mock_all_access_user(client)
         response = client.get(f"{self.route_url}/{file.FileId}")
 
-        assert response.status_code == 401
+        assert response.status_code == 403
 
     @mock_aws
-    def test_download_record_for_standard_user_unauthorized_response(
+    def test_download_record_for_standard_user_forbidden_response(
         self, app, client, mock_standard_user
     ):
         """
@@ -315,4 +315,4 @@ class TestDownload:
         mock_standard_user(client, file.consignment.series.body.Name)
         response = client.get(f"{self.route_url}/{file.FileId}")
 
-        assert response.status_code == 401
+        assert response.status_code == 403

--- a/app/tests/test_download.py
+++ b/app/tests/test_download.py
@@ -56,7 +56,9 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_standard_user(client, file.consignment.series.body.Name)
+        mock_standard_user(
+            client, file.consignment.series.body.Name, can_download=True
+        )
         response = client.get(f"{self.route_url}/{file.FileId}")
 
         assert response.status_code == 200
@@ -97,7 +99,9 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_standard_user(client, file.consignment.series.body.Name)
+        mock_standard_user(
+            client, file.consignment.series.body.Name, can_download=True
+        )
         response = client.get(f"{self.route_url}/{file.FileId}")
 
         assert response.status_code == 200
@@ -138,7 +142,9 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_standard_user(client, file.consignment.series.body.Name)
+        mock_standard_user(
+            client, file.consignment.series.body.Name, can_download=True
+        )
         response = client.get(f"{self.route_url}/{file.FileId}")
 
         assert response.status_code == 200
@@ -176,7 +182,9 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_standard_user(client, file.consignment.series.body.Name)
+        mock_standard_user(
+            client, file.consignment.series.body.Name, can_download=True
+        )
         response = client.get(f"{self.route_url}/invalid_file")
 
         assert response.status_code == 404
@@ -209,7 +217,9 @@ class TestDownload:
         }
         mock_boto3_client.return_value = mock_s3_client
 
-        mock_standard_user(client, file.consignment.series.body.Name)
+        mock_standard_user(
+            client, file.consignment.series.body.Name, can_download=True
+        )
 
         response = client.get(f"{self.route_url}/{file.FileId}")
 
@@ -236,7 +246,7 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_standard_user(client, "different_body")
+        mock_standard_user(client, "different_body", can_download=True)
         response = client.get(f"{self.route_url}/{file.FileId}")
 
         assert response.status_code == 404
@@ -258,7 +268,51 @@ class TestDownload:
         create_mock_s3_bucket_with_object(bucket_name, file)
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 
-        mock_all_access_user(client)
+        mock_all_access_user(client, can_download=True)
         response = client.get(f"{self.route_url}/{file.FileId}")
 
         assert response.status_code == 200
+
+    @mock_aws
+    def test_download_record_for_all_access_user_unauthorized_response(
+        self, app, client, mock_all_access_user
+    ):
+        """
+        Given a File in the database
+        And an all_access_user
+        When the all_access_user with no download permissions makes a request to download record
+        Then the response status code should be 401
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file",
+        )
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+
+        mock_all_access_user(client)
+        response = client.get(f"{self.route_url}/{file.FileId}")
+
+        assert response.status_code == 401
+
+    @mock_aws
+    def test_download_record_for_standard_user_unauthorized_response(
+        self, app, client, mock_standard_user
+    ):
+        """
+        Given a File in the database
+        And an all_access_user
+        When the standard_user with no download permissions makes a request to download record
+        Then the response status code should be 401
+        """
+        bucket_name = "test_bucket"
+        file = FileFactory(
+            FileType="file",
+        )
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+
+        mock_standard_user(client, file.consignment.series.body.Name)
+        response = client.get(f"{self.route_url}/{file.FileId}")
+
+        assert response.status_code == 401

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -300,61 +300,6 @@ class TestRecord:
 
         assert button is None
 
-    def test_record_aau_user_with_perms_can_download_record_without_citeable_reference(
-        self, client: FlaskClient, mock_all_access_user, record_files
-    ):
-        """
-        Given a File in the database
-        When an all permitted access user with request to view the record page
-        Then the response status code should be 200
-        And the HTML content should see record download component
-        on the page
-        """
-        file = record_files[4]["file_object"]
-        mock_all_access_user(client, can_download=True)
-
-        response = client.get(f"{self.route_url}/{file.FileId}")
-
-        assert response.status_code == 200
-
-        html = response.data.decode()
-
-        expected_download_html = (
-            expected_download_html_without_citeable_reference(file.FileId)
-        )
-
-        assert_contains_html(
-            expected_download_html, html, "div", {"class": "rights-container"}
-        )
-
-    def test_record_aau_user_with_perms_can_download_record_with_citeable_reference(
-        self, client: FlaskClient, mock_all_access_user, record_files
-    ):
-        """
-        Given a File in the database
-        When an all permitted access user with request to view the record page
-        Then the response status code should be 200
-        And the HTML content should see record download component
-        on the page
-        """
-        file = record_files[0]["file_object"]
-        download_filename = f"{file.CiteableReference}.docx"
-        mock_all_access_user(client, can_download=True)
-
-        response = client.get(f"{self.route_url}/{file.FileId}")
-
-        assert response.status_code == 200
-
-        html = response.data.decode()
-
-        expected_download_html = expected_download_html_with_citeable_reference(
-            file.FileId, download_filename
-        )
-
-        assert_contains_html(
-            expected_download_html, html, "div", {"class": "rights-container"}
-        )
-
     def test_record_aau_user_without_perms_cant_see_download_button(
         self, client: FlaskClient, mock_all_access_user, record_files
     ):

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -9,6 +9,38 @@ db_date_format = "%Y-%m-%d"
 python_date_format = "%d/%m/%Y"
 
 
+def expected_download_html_with_citeable_reference(file_id, file_name):
+    return f"""
+        <div class="rights-container">
+            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
+            <a href="/download/{file_id}"
+                class="govuk-button govuk-button__download--record"
+                data-module="govuk-button">Download record</a>
+            <p class="govuk-body govuk-body--download-filename">
+                The downloaded record will be named<br>
+                <strong>{file_name}</strong>
+            </p>
+            <p class="govuk-body govuk-body--terms-of-use">
+                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
+            </p>
+        </div>
+        """
+
+
+def expected_download_html_without_citeable_reference(file_id):
+    return f"""
+        <div class="rights-container">
+            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
+            <a href="/download/{file_id}"
+                class="govuk-button govuk-button__download--record"
+                data-module="govuk-button">Download record</a>
+            <p class="govuk-body govuk-body--terms-of-use">
+                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
+            </p>
+        </div>
+        """
+
+
 class TestRecord:
     @property
     def route_url(self):
@@ -206,18 +238,9 @@ class TestRecord:
         assert response.status_code == 200
 
         html = response.data.decode()
-
-        expected_download_html = f"""
-        <div class="rights-container">
-            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-            <a href="/download/{file.FileId}"
-                class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
-            <p class="govuk-body govuk-body--terms-of-use">
-                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
-            </p>
-        </div>
-        """
+        expected_download_html = (
+            expected_download_html_without_citeable_reference(file.FileId)
+        )
 
         assert_contains_html(
             expected_download_html, html, "div", {"class": "rights-container"}
@@ -245,21 +268,9 @@ class TestRecord:
 
         html = response.data.decode()
 
-        expected_download_html = f"""
-        <div class="rights-container">
-            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-            <a href="/download/{file.FileId}"
-                class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
-            <p class="govuk-body govuk-body--download-filename">
-                The downloaded record will be named<br>
-                <strong>{download_filename}</strong>
-            </p>
-            <p class="govuk-body govuk-body--terms-of-use">
-                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
-            </p>
-        </div>
-        """
+        expected_download_html = expected_download_html_with_citeable_reference(
+            file.FileId, download_filename
+        )
 
         assert_contains_html(
             expected_download_html, html, "div", {"class": "rights-container"}
@@ -308,17 +319,9 @@ class TestRecord:
 
         html = response.data.decode()
 
-        expected_download_html = f"""
-        <div class="rights-container">
-            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-            <a href="/download/{file.FileId}"
-                class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
-            <p class="govuk-body govuk-body--terms-of-use">
-                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
-            </p>
-        </div>
-        """
+        expected_download_html = (
+            expected_download_html_without_citeable_reference(file.FileId)
+        )
 
         assert_contains_html(
             expected_download_html, html, "div", {"class": "rights-container"}
@@ -344,21 +347,9 @@ class TestRecord:
 
         html = response.data.decode()
 
-        expected_download_html = f"""
-        <div class="rights-container">
-            <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
-            <a href="/download/{file.FileId}"
-                class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
-            <p class="govuk-body govuk-body--download-filename">
-                The downloaded record will be named<br>
-                <strong>{download_filename}</strong>
-            </p>
-            <p class="govuk-body govuk-body--terms-of-use">
-                Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
-            </p>
-        </div>
-        """
+        expected_download_html = expected_download_html_with_citeable_reference(
+            file.FileId, download_filename
+        )
 
         assert_contains_html(
             expected_download_html, html, "div", {"class": "rights-container"}

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -112,7 +112,7 @@ def create_keycloak_user(keycloak_admin):
 
 @pytest.fixture(scope="session")
 def create_aau_keycloak_user(keycloak_admin, create_keycloak_user):
-    user_groups = ["/ayr_user_type/view_all"]
+    user_groups = ["/ayr_user_type/view_all", "/ayr_user_type/download"]
     user_type = "aau"
     user_id, user_email, user_pass = create_keycloak_user(
         user_groups, user_type
@@ -127,6 +127,7 @@ def create_aau_keycloak_user(keycloak_admin, create_keycloak_user):
 def create_standard_keycloak_user(keycloak_admin, create_keycloak_user):
     user_groups = [
         "/ayr_user_type/view_dept",
+        "/ayr_user_type/download",
         "/transferring_body_user/Testing A",
     ]
     user_type = "standard"

--- a/e2e_tests/conftest.py
+++ b/e2e_tests/conftest.py
@@ -112,7 +112,7 @@ def create_keycloak_user(keycloak_admin):
 
 @pytest.fixture(scope="session")
 def create_aau_keycloak_user(keycloak_admin, create_keycloak_user):
-    user_groups = ["/ayr_user_type/view_all", "/ayr_user_type/download"]
+    user_groups = ["/ayr_user_type/view_all"]
     user_type = "aau"
     user_id, user_email, user_pass = create_keycloak_user(
         user_groups, user_type
@@ -125,6 +125,39 @@ def create_aau_keycloak_user(keycloak_admin, create_keycloak_user):
 
 @pytest.fixture(scope="session")
 def create_standard_keycloak_user(keycloak_admin, create_keycloak_user):
+    user_groups = [
+        "/ayr_user_type/view_dept",
+        "/transferring_body_user/Testing A",
+    ]
+    user_type = "standard"
+    user_id, user_email, user_pass = create_keycloak_user(
+        user_groups, user_type
+    )
+
+    yield user_email, user_pass
+
+    keycloak_admin.delete_user(user_id=user_id)
+
+
+@pytest.fixture(scope="session")
+def create_aau_keycloak_user_with_download(
+    keycloak_admin, create_keycloak_user
+):
+    user_groups = ["/ayr_user_type/view_all", "/ayr_user_type/download"]
+    user_type = "aau"
+    user_id, user_email, user_pass = create_keycloak_user(
+        user_groups, user_type
+    )
+
+    yield user_email, user_pass
+
+    keycloak_admin.delete_user(user_id=user_id)
+
+
+@pytest.fixture(scope="session")
+def create_standard_keycloak_user_with_download(
+    keycloak_admin, create_keycloak_user
+):
     user_groups = [
         "/ayr_user_type/view_dept",
         "/ayr_user_type/download",
@@ -151,6 +184,26 @@ def aau_user_page(create_user_page, create_aau_keycloak_user) -> Page:
 @pytest.fixture
 def standard_user_page(create_user_page, create_standard_keycloak_user) -> Page:
     username, password = create_standard_keycloak_user
+    page = create_user_page(username, password)
+    yield page
+    page.goto("/sign-out")
+
+
+@pytest.fixture
+def aau_user_page_with_download(
+    create_user_page, create_aau_keycloak_user_with_download
+) -> Page:
+    username, password = create_aau_keycloak_user_with_download
+    page = create_user_page(username, password)
+    yield page
+    page.goto("/sign-out")
+
+
+@pytest.fixture
+def standard_user_page_with_download(
+    create_user_page, create_standard_keycloak_user_with_download
+) -> Page:
+    username, password = create_standard_keycloak_user_with_download
     page = create_user_page(username, password)
     yield page
     page.goto("/sign-out")

--- a/e2e_tests/test_record.py
+++ b/e2e_tests/test_record.py
@@ -2,7 +2,7 @@
 Feature: Record page functionality
 """
 
-from playwright.sync_api import Page
+from playwright.sync_api import Page, expect
 
 
 class TestRecord:
@@ -97,7 +97,81 @@ class TestRecord:
                 field, exact=True
             ).is_visible()
 
-    def test_record_download_record(self, standard_user_page: Page):
+    def test_record_aau_users_with_perms_can_see_download_button(
+        self, aau_user_page_with_download: Page
+    ):
+        """
+        Scenario: Seeing download button on record page
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the aau user has the correct group to be able to download
+        Then the download button is visible
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        aau_user_page_with_download.goto(f"{self.route_url}/{record_id}")
+
+        button = aau_user_page_with_download.get_by_role(
+            "link", name="Download record"
+        )
+
+        expect(button).to_be_visible()
+
+    def test_record_standard_users_with_perms_can_see_download_button(
+        self, standard_user_page_with_download: Page
+    ):
+        """
+        Scenario: Seeing download button on record page
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the standard user has the correct group to be able to download
+        Then the download button is visible
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        standard_user_page_with_download.goto(f"{self.route_url}/{record_id}")
+
+        button = standard_user_page_with_download.get_by_role(
+            "link", name="Download record"
+        )
+
+        expect(button).to_be_visible()
+
+    def test_record_aau_users_without_perms_cant_see_download_button(
+        self, aau_user_page: Page
+    ):
+        """
+        Scenario: Seeing download button on record page
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the aau user does not have the group to be able to download
+        Then the download button is NOT visible
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        aau_user_page.goto(f"{self.route_url}/{record_id}")
+
+        button = aau_user_page.get_by_role("link", name="Download record")
+
+        expect(button).to_be_hidden()
+
+    def test_record_standard_users_without_perms_cant_see_download_button(
+        self, standard_user_page: Page
+    ):
+        """
+        Scenario: Seeing download button on record page
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the standard user does not have the group to be able to download
+        Then the download button is NOT visible
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        standard_user_page.goto(f"{self.route_url}/{record_id}")
+
+        button = standard_user_page.get_by_role("link", name="Download record")
+
+        expect(button).to_be_hidden()
+
+    def test_record_download_record(
+        self, standard_user_page_with_download: Page
+    ):
         """
         Scenario: Downloading a record
 
@@ -106,9 +180,11 @@ class TestRecord:
         Then the file "TSTA 1_ZD5B3S.doc" should be downloaded
         """
         record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
-        standard_user_page.goto(f"{self.route_url}/{record_id}")
+        standard_user_page_with_download.goto(f"{self.route_url}/{record_id}")
 
-        with standard_user_page.expect_download() as download_record:
-            standard_user_page.get_by_text("Download record").click()
+        with standard_user_page_with_download.expect_download() as download_record:
+            standard_user_page_with_download.get_by_text(
+                "Download record"
+            ).click()
         download = download_record.value
         assert "TSTA 1_ZD5B3S.doc" == download.suggested_filename

--- a/e2e_tests/test_record.py
+++ b/e2e_tests/test_record.py
@@ -188,3 +188,33 @@ class TestRecord:
             ).click()
         download = download_record.value
         assert "TSTA 1_ZD5B3S.doc" == download.suggested_filename
+
+    def test_record_download_record_standard_user_without_download_perms(
+        self, standard_user_page: Page
+    ):
+        """
+        Scenario: Downloading a record
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the standard user with no download perms attempts to access the download record endpoint
+        They get a status 403 response
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        response = standard_user_page.goto(f"download/{record_id}")
+
+        assert response.status == 403
+
+    def test_record_download_record_aau_user_without_download_perms(
+        self, aau_user_page: Page
+    ):
+        """
+        Scenario: Downloading a record
+
+        Given the user navigates to the record page with ID "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        When the all access user with no download perms attempts to access the download record endpoint
+        They get a status 403 response
+        """
+        record_id = "100251bb-5b93-48a9-953f-ad5bd9abfbdc"
+        response = aau_user_page.goto(f"download/{record_id}")
+
+        assert response.status == 403


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added a new property inside ayr_user.py that checks if a user is in the appropriate group to download records
- Inside the record template we only render the download button section when the user has passes the condition outlined above
- Made some small changes to existing unit tests for the record endpoint in order to reduce repetition of code & strings
- Along side the tests for checking a standard user can see the download record button there are now tests for all access users as well
- Added tests to check that standard and all access users without the download group are not able to view the download record button
- Inside of the download record endpoint, users that are not in the download group now get a 403 response (forbidden)
- Added tests for the change above to the download tests
- Added 403 page template (Flask throws a fit when this doesnt exist and we do abort(403))
- Changed e2e tests slightly so users get created with the download group by default in order to not break any existing tests

## JIRA ticket

## Screenshots of UI changes

### Before
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/60956e51-edf2-4319-aa30-9c10b846f789">

### After
<img width="1122" alt="image" src="https://github.com/user-attachments/assets/c267cf8a-8da3-41bb-8285-99dd42080538">

- [ ] Requires env variable(s) to be updated
