### PR TITLE
AYR-1215 - Fix accessibility issues on the record view page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,9 +118,9 @@
         "filename": "app/templates/main/record-view.html",
         "hashed_secret": "b49139ad0afdb487229b83c6d3bda217b7e14977",
         "is_verified": false,
-        "line_number": 14
+        "line_number": 15
       }
     ]
   },
-  "generated_at": "2024-08-21T21:04:35Z"
+  "generated_at": "2024-09-02T20:02:22Z"
 }

--- a/app/static/src/scss/includes/_uv.scss
+++ b/app/static/src/scss/includes/_uv.scss
@@ -1,0 +1,13 @@
+#uv {
+  .sr-only {
+    display: none;
+  }
+
+  .rightOptions {
+    display: none;
+  }
+
+  .centerOptions {
+    width: fit-content;
+  }
+}

--- a/app/static/src/scss/main.scss
+++ b/app/static/src/scss/main.scss
@@ -21,6 +21,7 @@
 @import "includes/search-transferring-body";
 @import "includes/search-results-summary";
 @import "includes/static-content-template";
+@import "includes/uv";
 
 // components
 @import "includes/components/alert-banner";

--- a/app/templates/main/record-details.html
+++ b/app/templates/main/record-details.html
@@ -16,7 +16,8 @@
                 <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
                 <a href="{{ url_for('main.download_record', record_id=record['file_id']) }}"
                    class="govuk-button govuk-button__download--record"
-                   data-module="govuk-button">Download record</a>
+                   data-module="govuk-button"
+                   aria-label="Download record {{ record['file_name'] }}">Download record</a>
                 {% if download_filename %}
                     <p class="govuk-body govuk-body--download-filename">
                         The downloaded record will be named

--- a/app/templates/main/record-view.html
+++ b/app/templates/main/record-view.html
@@ -5,7 +5,8 @@
             {% if can_download_records %}
                 <a href="{{ url_for('main.download_record', record_id=record['file_id']) }}"
                    class="govuk-button govuk-button__download--record record-view-download-btn"
-                   data-module="govuk-button">Download record</a>
+                   data-module="govuk-button"
+                   aria-label="Download record {{ record['file_name'] }}">Download record</a>
             {% endif %}
         </div>
         <div class="universal-viewer" id="viewer">

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -27,16 +27,19 @@ def create_mock_s3_bucket_with_object(bucket_name, file):
     return bucket
 
 
-def expected_download_html_with_citeable_reference(file_id, file_name):
+def expected_download_html_with_citeable_reference(
+    file_id, file_name_download, file_name
+):
     return f"""
         <div class="rights-container">
             <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
             <a href="/download/{file_id}"
                 class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
+                data-module="govuk-button"
+                aria-label="Download record {file_name}">Download record</a>
             <p class="govuk-body govuk-body--download-filename">
                 The downloaded record will be named<br>
-                <strong>{file_name}</strong>
+                <strong>{file_name_download}</strong>
             </p>
             <p class="govuk-body govuk-body--terms-of-use">
                 Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
@@ -45,13 +48,14 @@ def expected_download_html_with_citeable_reference(file_id, file_name):
         """
 
 
-def expected_download_html_without_citeable_reference(file_id):
+def expected_download_html_without_citeable_reference(file_id, file_name):
     return f"""
         <div class="rights-container">
             <h3 class="govuk-heading-m govuk-heading-m__rights-header">Rights to access</h3>
             <a href="/download/{file_id}"
                 class="govuk-button govuk-button__download--record"
-                data-module="govuk-button">Download record</a>
+                data-module="govuk-button"
+                aria-label="Download record {file_name}">Download record</a>
             <p class="govuk-body govuk-body--terms-of-use">
                 Refer to <a href="/terms-of-use" class="govuk-link govuk-link--ayr">Terms of use.</a>
             </p>
@@ -338,7 +342,9 @@ class TestRecord:
 
         html = response.data.decode()
         expected_download_html = (
-            expected_download_html_without_citeable_reference(file.FileId)
+            expected_download_html_without_citeable_reference(
+                file.FileId, file.FileName
+            )
         )
 
         assert_contains_html(
@@ -369,7 +375,7 @@ class TestRecord:
         html = response.data.decode()
 
         expected_download_html = expected_download_html_with_citeable_reference(
-            file.FileId, download_filename
+            file.FileId, download_filename, file.FileName
         )
 
         assert_contains_html(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added aria-labels to be to the buttons (anchors) for specifying what record file is going to be downloaded
- Added display: none to elements that we don't accessible by keyboard by users (some download functionality related elements and the settings button)
- Made the the center options container take a width of fit-content, as opposed to a fixed width preventing the centering of the element
- Updated unit tests for the changes

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1215

## Screenshots of UI changes

N/A

- [ ] Requires env variable(s) to be updated
