### PR TITLE
AYR-1232 - Adjust permissions for search TB & summary pages

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -471,6 +471,11 @@ def search():
 @bp.route("/search_results_summary", methods=["GET"])
 @access_token_sign_in_required
 def search_results_summary():
+
+    ayr_user = AYRUser(session.get("user_groups"))
+    if ayr_user.is_standard_user:
+        abort(403)
+
     form = SearchForm()
     per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])
     page = int(request.args.get("page", 1))
@@ -562,6 +567,10 @@ def search_results_summary():
 @bp.route("/search/transferring_body/<uuid:_id>", methods=["GET"])
 @access_token_sign_in_required
 def search_transferring_body(_id: uuid.UUID):
+
+    body = db.session.get(Body, _id)
+    validate_body_user_groups_or_404(body.Name)
+
     form = SearchForm()
     search_results = None
     per_page = int(current_app.config["DEFAULT_PAGE_SIZE"])

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1453,7 +1453,7 @@ class TestSearchTransferringBody:
         mock_search_client.return_value = MockOpenSearch(
             search_return_value=os_mock_return_tb
         )
-        mock_standard_user(client)
+        mock_standard_user(client, "first_body")
 
         transferring_body_id = browse_consignment_files[
             0
@@ -1464,4 +1464,4 @@ class TestSearchTransferringBody:
             f"{self.route_url}/{transferring_body_id}", data=form_data
         )
 
-        assert response.status_code == 404
+        assert response.status_code == 200


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added check inside the transferring body search endpoint to only allow standard users with permissions (else, we return 404)
- Added check inside the summary_search_page to return 403 to non all-access users
- Adjusted tests

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1232

## Screenshots of UI changes
N/A

- [ ] Requires env variable(s) to be updated
