### PR TITLE
AYR-1238 - Fixes for OpenSearch sorting query

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -588,7 +588,7 @@ def search_transferring_body(_id: uuid.UUID):
 
     filters = {"query": query}
 
-    sort_query = build_sorting_orders_open_search(request.args)
+    sorting_query = build_sorting_orders_open_search(request.args)
     sorting_orders = build_sorting_orders(request.args)
 
     breadcrumb_values = {
@@ -649,7 +649,7 @@ def search_transferring_body(_id: uuid.UUID):
                     "filter": [{"term": {"transferring_body_id.keyword": _id}}],
                 }
             },
-            "sort": sort_query,
+            "sort": sorting_query,
         }
         size = per_page
         page_number = page

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -587,7 +587,9 @@ def search_transferring_body(_id: uuid.UUID):
     page = int(request.args.get("page", 1))
 
     filters = {"query": query}
-    sorting_orders = build_sorting_orders_open_search(request.args)
+
+    sort_query = build_sorting_orders_open_search(request.args)
+    sorting_orders = build_sorting_orders(request.args)
 
     breadcrumb_values = {
         0: {"query": ""},
@@ -647,7 +649,7 @@ def search_transferring_body(_id: uuid.UUID):
                     "filter": [{"term": {"transferring_body_id.keyword": _id}}],
                 }
             },
-            # "sort": sorting_orders,
+            "sort": sort_query,
         }
         size = per_page
         page_number = page

--- a/app/main/util/filter_sort_builder.py
+++ b/app/main/util/filter_sort_builder.py
@@ -39,18 +39,23 @@ def build_sorting_orders(args):
 
 
 def build_sorting_orders_open_search(args):
+    type_map = {
+        "series_id": "series_id.keyword",
+        "series_name": "series_name.keyword",
+        "consignment_reference": "consignment_reference.keyword",
+        "opening_date": "metadata.opening_date",
+        "file_name": "file_name.keyword",
+        "closure_type": "metadata.closure_type.keyword",
+    }
     sorting_orders = {}
     if args:
         if args.get("sort"):
             sort_details = args.get("sort").split("-")
-            sort_by = None
-            sort_order = None
-            if len(sort_details) > 1:
-                sort_by = sort_details[0].strip()
-                sort_order = sort_details[1].strip()
+            sort_by = sort_details[0].strip()
+            sort_order = sort_details[1].strip()
 
-            if sort_by and sort_order:
-                sorting_orders[f"{sort_by}"] = {"order": sort_order}
+            if sort_by in type_map and sort_by and sort_order:
+                sorting_orders[type_map[sort_by]] = {"order": sort_order}
 
     return sorting_orders
 

--- a/app/main/util/filter_sort_builder.py
+++ b/app/main/util/filter_sort_builder.py
@@ -39,7 +39,7 @@ def build_sorting_orders(args):
 
 
 def build_sorting_orders_open_search(args):
-    type_map = {
+    sorting_type_map = {
         "series_id": "series_id.keyword",
         "series_name": "series_name.keyword",
         "consignment_reference": "consignment_reference.keyword",
@@ -47,17 +47,23 @@ def build_sorting_orders_open_search(args):
         "file_name": "file_name.keyword",
         "closure_type": "metadata.closure_type.keyword",
     }
-    sorting_orders = {}
+    sorting_orders = ["asc", "desc"]
+    sorting_query = {}
     if args:
         if args.get("sort"):
             sort_details = args.get("sort").split("-")
             sort_by = sort_details[0].strip()
             sort_order = sort_details[1].strip()
 
-            if sort_by in type_map and sort_by and sort_order:
-                sorting_orders[type_map[sort_by]] = {"order": sort_order}
+            if (
+                sort_by
+                and sort_order
+                and sort_by in sorting_type_map
+                and sort_order in sorting_orders
+            ):
+                sorting_query[sorting_type_map[sort_by]] = {"order": sort_order}
 
-    return sorting_orders
+    return sorting_query
 
 
 def build_browse_consignment_filters(args, date_from, date_to):

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -15,12 +15,12 @@
     "Series reference (Z to A)": "series_name-desc",
     "Consignment reference (newest)": "consignment_reference-desc",
     "Consignment reference (oldest)": "consignment_reference-asc",
-    "Record opening date (sooner)": "metadata.opening_date-desc",
-    "Record opening date (later)": "metadata.opening_date-asc",
+    "Record opening date (sooner)": "opening_date-desc",
+    "Record opening date (later)": "opening_date-asc",
     "File name (A to Z)": "file_name-asc",
     "File name (Z to A)": "file_name-desc",
-    "Record status (closed)": "metadata.closure_type-asc",
-    "Record status (open)": "metadata.closure_type-desc"
+    "Record status (closed)": "closure_type-asc",
+    "Record status (open)": "closure_type-desc"
 } %}
 {% block beforeContent %}{{ super() }}{% endblock %}
 {% block content %}

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1389,6 +1389,13 @@ class TestSearchTransferringBody:
                 [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
                 "series_id-asc",
             ),
+            # edge case: random sort options as numbers
+            (
+                "sort=series_name-aaaaa&query=foobar",
+                os_mock_return_tb,
+                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
+                "series_id-asc",
+            ),
             (
                 "sort=series_name-desc&query=foobar",
                 os_mock_return_tb,

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1370,33 +1370,6 @@ class TestSearchTransferringBody:
         "query_params, mock_open_search_return, expected_results, expected_sort_select_value",
         [
             (
-                "query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
-                "series_id-asc",
-            ),
-            # edge case: random sort options as letters
-            (
-                "sort=foo-bar&query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
-                "series_id-asc",
-            ),
-            # edge case: random sort options as numbers
-            (
-                "sort=111-222&query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
-                "series_id-asc",
-            ),
-            # edge case: random sort order
-            (
-                "sort=series_name-aaaaa&query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
-                "series_id-asc",
-            ),
-            (
                 "sort=series_name-desc&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
@@ -1453,7 +1426,82 @@ class TestSearchTransferringBody:
         ],
     )
     @patch("app.main.routes.OpenSearch")
-    def test_search_transferring_body_with_search_filter_full_test(
+    def test_search_transferring_body_with_search_term_happy_path(
+        self,
+        mock_search_client,
+        client: FlaskClient,
+        mock_standard_user,
+        browse_consignment_files,
+        query_params,
+        mock_open_search_return,
+        expected_results,
+        expected_sort_select_value,
+    ):
+
+        mock_search_client.return_value = MockOpenSearch(
+            search_return_value=mock_open_search_return
+        )
+
+        mock_standard_user(
+            client, browse_consignment_files[0].consignment.series.body.Name
+        )
+
+        transferring_body_id = browse_consignment_files[
+            0
+        ].consignment.series.body.BodyId
+
+        response = client.get(
+            f"{self.route_url}/{transferring_body_id}?{query_params}"
+        )
+
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.data, "html.parser")
+        select = soup.find("select", {"id": "sort"})
+        option = select.find("option", selected=True)
+        option_text = None
+
+        if option:
+            option_text = option.get("value")
+
+        assert select
+        assert option_text == expected_sort_select_value
+        assert evaluate_table_body_rows(soup, expected_results)
+
+    @pytest.mark.parametrize(
+        "query_params, mock_open_search_return, expected_results, expected_sort_select_value",
+        [
+            # without any sort term the select value should be series_id-asc by default
+            (
+                "query=foobar",
+                os_mock_return_tb,
+                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
+                "series_id-asc",
+            ),
+            # edge case: random sort options as letters
+            (
+                "sort=foo-bar&query=foobar",
+                os_mock_return_tb,
+                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
+                "series_id-asc",
+            ),
+            # edge case: random sort options as numbers
+            (
+                "sort=111-222&query=foobar",
+                os_mock_return_tb,
+                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
+                "series_id-asc",
+            ),
+            # edge case: random sort order
+            (
+                "sort=series_name-aaaaa&query=foobar",
+                os_mock_return_tb,
+                [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
+                "series_id-asc",
+            ),
+        ],
+    )
+    @patch("app.main.routes.OpenSearch")
+    def test_search_transferring_body_with_search_term_edge_case_path(
         self,
         mock_search_client,
         client: FlaskClient,

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1458,13 +1458,10 @@ class TestSearchTransferringBody:
         soup = BeautifulSoup(response.data, "html.parser")
         select = soup.find("select", {"id": "sort"})
         option = select.find("option", selected=True)
-        option_text = None
-
-        if option:
-            option_text = option.get("value")
+        option_value = option.get("value")
 
         assert select
-        assert option_text == expected_sort_select_value
+        assert option_value == expected_sort_select_value
         assert evaluate_table_body_rows(soup, expected_results)
 
     @pytest.mark.parametrize(
@@ -1532,14 +1529,14 @@ class TestSearchTransferringBody:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         select = soup.find("select", {"id": "sort"})
-        option = select.find("option", selected=True)
-        option_text = "series_id-asc"
 
-        if option:
-            option_text = option.get("value")
+        option_selected = select.find("option", selected=True)
+        option_first = select.find("option")
+        option_first_value = option_first.get("value")
 
         assert select
-        assert option_text == expected_sort_select_value
+        assert option_selected is None
+        assert option_first_value == expected_sort_select_value
         assert evaluate_table_body_rows(soup, expected_results)
 
     @patch("app.main.routes.OpenSearch")

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1389,7 +1389,7 @@ class TestSearchTransferringBody:
                 [["first_series", "cbar", "fifth_file.doc", "Open", "fooDate"]],
                 "series_id-asc",
             ),
-            # edge case: random sort options as numbers
+            # edge case: random sort order
             (
                 "sort=series_name-aaaaa&query=foobar",
                 os_mock_return_tb,


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Modified existing function that built the OpenSearch sort query to map our search terms to value names (e.g. closure_type is mapped to metadata.closure_type.keyword) - this has a secondary function of allowing us to check that a sort term should be added to the query or not, random terms should not be added to it
- Fixed dropdown component not being passed a correct object with sort terms & subsequently not showing the currently selected term
- Added unit tests to handle some edge cases and check for dropdown values when a sort term is selected

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1238

## Screenshots of UI changes

N/A

- [ ] Requires env variable(s) to be updated
