### PR TITLE
AYR-1277 - Query term bug

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -508,7 +508,7 @@ def search_results_summary():
             hosts=current_app.config.get("OPEN_SEARCH_HOST"),
             http_auth=current_app.config.get("OPEN_SEARCH_HTTP_AUTH"),
             use_ssl=True,
-            verify_certs=False,
+            verify_certs=True,
             connection_class=RequestsHttpConnection,
         )
 
@@ -643,7 +643,7 @@ def search_transferring_body(_id: uuid.UUID):
             hosts=current_app.config.get("OPEN_SEARCH_HOST"),
             http_auth=current_app.config.get("OPEN_SEARCH_HTTP_AUTH"),
             use_ssl=True,
-            verify_certs=False,
+            verify_certs=True,
             connection_class=RequestsHttpConnection,
         )
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -508,7 +508,7 @@ def search_results_summary():
             hosts=current_app.config.get("OPEN_SEARCH_HOST"),
             http_auth=current_app.config.get("OPEN_SEARCH_HTTP_AUTH"),
             use_ssl=True,
-            verify_certs=True,
+            verify_certs=False,
             connection_class=RequestsHttpConnection,
         )
 
@@ -607,6 +607,7 @@ def search_transferring_body(_id: uuid.UUID):
         0: {"query": ""},
         1: {"transferring_body_id": _id},
         2: {"transferring_body": db.session.get(Body, _id).Name},
+        3: {"search_terms": "‘’"},
     }
     search_terms = []
     results = {"hits": {"total": {"value": 0}, "hits": []}}
@@ -642,7 +643,7 @@ def search_transferring_body(_id: uuid.UUID):
             hosts=current_app.config.get("OPEN_SEARCH_HOST"),
             http_auth=current_app.config.get("OPEN_SEARCH_HTTP_AUTH"),
             use_ssl=True,
-            verify_certs=True,
+            verify_certs=False,
             connection_class=RequestsHttpConnection,
         )
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Fixed a bug where if the query param in the URL was edited to be empty the breadcrumbs would break

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1277

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/4e1b142f-8368-45b1-9e8b-08235409fce9)

### After
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/0a6f2672-b60f-4016-827e-db00e78a52c1">


- [ ] Requires env variable(s) to be updated
