### PR TITLE
ensure opensearch dates retrieved are in required format

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -35,6 +35,7 @@ from app.main.flask_config_helpers import (
     get_keycloak_instance_from_flask_config,
 )
 from app.main.util.date_filters_validator import validate_date_filters
+from app.main.util.date_validator import format_opensearch_date
 from app.main.util.filter_sort_builder import (
     build_browse_consignment_filters,
     build_filters,
@@ -669,6 +670,14 @@ def search_transferring_body(_id: uuid.UUID):
         search_results = open_search.search(dsl_query, from_=from_, size=size)
 
         results = search_results["hits"]["hits"]
+
+        for result in results:
+            for key, value in result["_source"]["metadata"].items():
+                if "date" in key:
+                    result["_source"]["metadata"][key] = format_opensearch_date(
+                        value
+                    )
+
         total_records = search_results["hits"]["total"]["value"]
 
         page_count = calculate_total_pages(total_records, per_page)

--- a/app/main/util/date_validator.py
+++ b/app/main/util/date_validator.py
@@ -1,8 +1,9 @@
 import calendar
-from datetime import date
+from datetime import date, datetime
 
 PYTHON_DATE_FORMAT = "%d/%m/%Y"
 DB_DATE_FORMAT = "%Y-%m-%d"
+OPENSEARCH_DATE_FORMAT = "%Y-%m-%dT%H:%M:%S"
 
 
 def validate_dates(args):
@@ -244,3 +245,11 @@ def _get_last_day_of_month(month, year):
         last_day = 30
 
     return last_day
+
+
+def format_opensearch_date(date_string, current_format=OPENSEARCH_DATE_FORMAT):
+    try:
+        date_obj = datetime.strptime(date_string, current_format)
+        return date_obj.strftime(PYTHON_DATE_FORMAT)
+    except ValueError:
+        return date_string

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -55,6 +55,32 @@ os_mock_return_tb = {
     }
 }
 
+os_mock_return_tb_closed_record = {
+    "hits": {
+        "total": {
+            "value": 1000,
+        },
+        "hits": [
+            {
+                "_source": {
+                    "file_name": "fifth_file.doc",
+                    "file_id": "1e2a9d26-b330-4f99-92ff-b1a5b2c1d610",
+                    "series_name": "first_series",
+                    "series_id": "sbar",
+                    "status": "Closed",
+                    "closure_date": "2001-01-01T00:00:00",
+                    "consignment_reference": "cbar",
+                    "consignment_id": "ibar",
+                    "metadata": {
+                        "closure_type": "Closed",
+                        "opening_date": "2025-01-01T00:00:00",
+                    },
+                },
+            },
+        ],
+    }
+}
+
 
 class MockOpenSearch:
     def __init__(self, search_return_value=None, index_return_value=None):
@@ -1594,5 +1620,37 @@ class TestSearchTransferringBody:
         response = client.get(
             f"{self.route_url}/{transferring_body_id}", data=form_data
         )
+
+        assert response.status_code == 200
+
+    @patch("app.main.routes.OpenSearch")
+    def test_search_transferring_body_returns_correct_date_format(
+        self,
+        mock_search_client,
+        client,
+        mock_standard_user,
+        browse_consignment_files,
+    ):
+        """
+        Given a standard user accessing the search transferring body page
+        When they make a GET request with any amount of search terms
+        Then they should see search transferring body page with dates
+        displayed in a DD/MM/YYYY format
+        """
+        mock_search_client.return_value = MockOpenSearch(
+            search_return_value=os_mock_return_tb_closed_record
+        )
+        mock_standard_user(client, "first_body")
+
+        transferring_body_id = browse_consignment_files[
+            0
+        ].consignment.series.body.BodyId
+
+        form_data = {"query": "test", "sort": "closure_type-asc"}
+        response = client.get(
+            f"{self.route_url}/{transferring_body_id}", data=form_data
+        )
+
+        assert "01/01/2025" in response.text
 
         assert response.status_code == 200


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Format dates in results retrieved from OpenSearch to be in required AYR DD/MM/YYY format

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1233

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
