### PR TITLE
AYR-1285 -  Change default font to Arial

### DIFF
--- a/app/static/src/scss/includes/_overrides.scss
+++ b/app/static/src/scss/includes/_overrides.scss
@@ -1,3 +1,8 @@
 legend {
   padding-inline: 0;
 }
+
+// use of !important is not ideal but fits this purpose
+* {
+  font-family: Arial, Helvetica, sans-serif !important;
+}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Added a CSS rule that applies the Arial font family to all elements in the page - it uses the !important directive which is not ideal, the reasoning behind this is that its impossible for us achieve the same thing by overriding SCSS variables (the proper way to do it) - we use a minified css file to import govuk styles and not the npm package and thus the styles are already built.

There are quite a lot of sideeffects that come along with changing the font, will catch up with @Terry-Price to review.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1285

- [ ] Requires env variable(s) to be updated
