### PR TITLE
Add new bad gateway 504 template and show it when search routes have opensearch requests timeout

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3,6 +3,7 @@ import json
 import uuid
 
 import boto3
+import opensearchpy
 from flask import (
     abort,
     current_app,
@@ -547,12 +548,15 @@ def search_results_summary():
 
         size = per_page
         from_ = size * (page - 1)
-        search_results = open_search.search(
-            dsl_query,
-            from_=from_,
-            size=size,
-            timeout=current_app.config["OPEN_SEARCH_TIMEOUT"],
-        )
+        try:
+            search_results = open_search.search(
+                dsl_query,
+                from_=from_,
+                size=size,
+                timeout=current_app.config["OPEN_SEARCH_TIMEOUT"],
+            )
+        except opensearchpy.exceptions.ConnectionTimeout:
+            abort(504)
 
         results = search_results["aggregations"][
             "aggregate_by_transferring_body"
@@ -676,12 +680,15 @@ def search_transferring_body(_id: uuid.UUID):
         size = per_page
         page_number = page
         from_ = size * (page_number - 1)
-        search_results = open_search.search(
-            dsl_query,
-            from_=from_,
-            size=size,
-            timeout=current_app.config["OPEN_SEARCH_TIMEOUT"],
-        )
+        try:
+            search_results = open_search.search(
+                dsl_query,
+                from_=from_,
+                size=size,
+                timeout=current_app.config["OPEN_SEARCH_TIMEOUT"],
+            )
+        except opensearchpy.exceptions.ConnectionTimeout:
+            abort(504)
 
         results = search_results["hits"]["hits"]
 

--- a/app/templates/main/504.html
+++ b/app/templates/main/504.html
@@ -1,0 +1,12 @@
+{% extends "base.html" %}
+{% block pageTitle %}Bad Gateway – {{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
+{% set mainClasses = "govuk-main-wrapper--l" %}
+{% block content %}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l">Bad Gateway</h1>
+            <p class="govuk-body">Sorry, the request could not be completed due to a bad gateway.</p>
+            <p class="govuk-body">Modify your request or try again later.</p>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
## Changes in this PR

- Add new bad gateway 504 template
- show it when search routes have opensearch requests timeout

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1258

## Screenshots of UI changes

Before and after of what a search timeout shows:

### Before
<img width="1008" alt="Screenshot 2024-10-15 at 12 17 21" src="https://github.com/user-attachments/assets/933fdf9f-6f4a-4dcb-a7f7-69dd2a64f2a4">


### After

<img width="1033" alt="Screenshot 2024-10-15 at 11 34 17" src="https://github.com/user-attachments/assets/100ba730-4a9c-48fa-8699-09c47a42bd4e">
