### PR TITLE
Use presigned url in manifest generation

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -51,11 +51,17 @@ def create_app(config_class, database_uri=None):
     SELF = "'self'"
 
     csp = {
-        "default-src": f"'self' {app.config['FLASKS3_CDN_DOMAIN']} ",
+        "default-src": f" {SELF} {app.config['FLASKS3_CDN_DOMAIN']} ",
+        "connect-src": [
+            SELF,
+            app.config["FLASKS3_CDN_DOMAIN"],
+            f"https://{app.config['RECORD_BUCKET_NAME']}.s3.amazonaws.com",
+        ],
         "script-src": (
             [
                 SELF,
                 f"{app.config['FLASKS3_CDN_DOMAIN']}",
+                f"https://{app.config['RECORD_BUCKET_NAME']}.s3.amazonaws.com",
                 "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/dist/umd/5315.4c3c820c7f8b3cc26be6.js",
                 "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/dist/umd/998.9c1bd6b181b8236d95c2.js",
                 "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/dist/umd/7484.468f27df41f99efd4b79.js",

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -84,6 +84,16 @@ def generate_pdf_manifest(record_id):
         "main.download_record", record_id=record_id, _external=True, render=True
     )
 
+    presigned_url = None
+    try:
+        presigned_url = create_presigned_url(file)
+    except Exception as e:
+        current_app.logger.info(
+            f"Failed to create presigned url for document render non-javascript fallback {e}"
+        )
+
+    file_url = presigned_url
+
     manifest = {
         "@context": [
             "http://iiif.io/api/presentation/3/context.json",
@@ -152,9 +162,15 @@ def generate_image_manifest(s3_file_object, record_id):
     image = Image.open(io.BytesIO(file_content))
     width, height = image.size
 
-    file_url = url_for(
-        "main.download_record", record_id=record_id, _external=True, render=True
-    )
+    presigned_url = None
+    try:
+        presigned_url = create_presigned_url(file)
+    except Exception as e:
+        current_app.logger.info(
+            f"Failed to create presigned url for document render non-javascript fallback {e}"
+        )
+
+    file_url = presigned_url
 
     manifest = {
         "@context": "http://iiif.io/api/presentation/2/context.json",

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -1,0 +1,91 @@
+from unittest.mock import Mock, patch
+
+from flask import Flask
+
+from app.main.util.render_utils import (
+    create_presigned_url,
+    generate_breadcrumb_values,
+    get_download_filename,
+    get_file_details,
+    get_file_mimetype,
+)
+
+
+def test_get_file_mimetype():
+    assert get_file_mimetype("pdf") == "application/pdf"
+    assert get_file_mimetype("png") == "image/png"
+    assert get_file_mimetype("jpg") == "image/jpg"
+    assert get_file_mimetype("jpeg") == "image/jpeg"
+
+
+@patch("app.main.util.render_utils.get_file_metadata")
+def test_get_file_details(mock_get_file_metadata):
+    mock_file = Mock()
+    mock_file.FileId = "test_id"
+    mock_file.FileName = "test_file.pdf"
+    mock_get_file_metadata.return_value = {"metadata_key": "metadata_value"}
+
+    metadata, file_type, extension = get_file_details(mock_file)
+
+    assert metadata == {"metadata_key": "metadata_value"}
+    assert file_type == "iiif"
+    assert extension == "pdf"
+
+
+def test_generate_breadcrumb_values():
+    mock_file = Mock()
+    mock_file.consignment.consignment_id = "consignment_id"
+    mock_file.consignment.series.series_id = "series_id"
+    mock_file.consignment.series.body.BodyId = "body_id"
+    mock_file.consignment.series.Name = "Series Name"
+    mock_file.consignment.ConsignmentId = "consignment_id"
+    mock_file.consignment.ConsignmentReference = "consignment_reference"
+    mock_file.FileName = "file_name.pdf"
+
+    result = generate_breadcrumb_values(mock_file)
+
+    assert result[0]["transferring_body_id"] == "body_id"
+    assert result[3]["series"] == "Series Name"
+    assert result[4]["consignment_id"] == "consignment_id"
+    assert result[5]["consignment_reference"] == "consignment_reference"
+    assert result[6]["file_name"] == "file_name.pdf"
+
+
+def test_get_download_filename():
+    mock_file = Mock()
+    mock_file.CiteableReference = "CITEREF-123"
+    mock_file.FileName = "example.txt"
+    assert get_download_filename(mock_file) == "CITEREF-123.txt"
+
+    mock_file.FileName = "no_extension"
+    assert get_download_filename(mock_file) is None
+
+
+@patch("boto3.client")
+@patch("app.main.util.render_utils.create_presigned_url")
+def test_create_presigned_url(mock_current_app, mock_boto_client):
+    app = Flask(__name__)
+
+    app.config["SUPPORTED_RENDER_EXTENSIONS"] = ["pdf", "jpg", "jpeg", "png"]
+    app.config["RECORD_BUCKET_NAME"] = "test_record_download_bucket"
+
+    mock_file = Mock()
+    mock_file.FileName = "test.pdf"
+    mock_file.FileId = "file_id"
+    mock_file.consignment.ConsignmentReference = "consignment_reference"
+
+    mock_s3_client = mock_boto_client.return_value
+    mock_s3_client.generate_presigned_url.return_value = "http://presigned.url"
+
+    with app.app_context():
+        url = create_presigned_url(mock_file)
+
+    mock_s3_client.generate_presigned_url.assert_called_once_with(
+        "get_object",
+        Params={
+            "Bucket": "test_record_download_bucket",
+            "Key": "consignment_reference/file_id",
+        },
+        ExpiresIn=10,
+    )
+    assert url == "http://presigned.url"

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -1,5 +1,6 @@
 import json
 from io import BytesIO
+from unittest.mock import patch
 
 import boto3
 from bs4 import BeautifulSoup
@@ -106,13 +107,18 @@ class TestRoutes:
         assert response.status_code == 200
 
     @mock_aws
+    @patch("app.main.util.render_utils.create_presigned_url")
     def test_route_generate_pdf_manifest(
         self,
+        mock_create_presigned_url,
         app,
         client: FlaskClient,
         mock_all_access_user,
         record_files,
     ):
+        mock_create_presigned_url.return_value = (
+            "https://presigned-url.com/download.pdf"
+        )
 
         mock_all_access_user(client)
 
@@ -134,18 +140,18 @@ class TestRoutes:
                     "id": f"http://localhost/record/{file.FileId}/manifest?render=True",
                     "items": [
                         {
-                            "id": f"http://localhost/download/{file.FileId}?render=True",
+                            "id": "https://presigned-url.com/download.pdf",
                             "items": [
                                 {
                                     "body": {
                                         "format": "application/pdf",
-                                        "id": f"http://localhost/download/{file.FileId}?render=True",
+                                        "id": "https://presigned-url.com/download.pdf",
                                         "type": "Text",
                                     },
-                                    "id": f"http://localhost/download/{file.FileId}?render=True",
+                                    "id": "https://presigned-url.com/download.pdf",
                                     "label": {"en": ["test"]},
                                     "motivation": "painting",
-                                    "target": f"http://localhost/download/{file.FileId}?render=True",
+                                    "target": "https://presigned-url.com/download.pdf",
                                     "type": "Annotation",
                                 }
                             ],
@@ -165,14 +171,17 @@ class TestRoutes:
             "type": "Manifest",
             "viewingDirection": "left-to-right",
         }
+
         actual_manifest = json.loads(response.text)
 
         assert response.status_code == 200
         assert actual_manifest == expected_pdf_manifest
 
     @mock_aws
+    @patch("app.main.util.render_utils.create_presigned_url")
     def test_route_generate_image_manifest(
         self,
+        mock_create_presigned_url,
         app,
         client: FlaskClient,
         mock_all_access_user,
@@ -186,6 +195,10 @@ class TestRoutes:
         app.config["RECORD_BUCKET_NAME"] = bucket_name
         create_mock_s3_bucket_with_imaage_object(bucket_name, file)
 
+        mock_create_presigned_url.return_value = (
+            "https://presigned-url.com/download.png"
+        )
+
         response = client.get(f"{self.record_route_url}/{file.FileId}/manifest")
         assert response.status_code == 200
 
@@ -197,22 +210,22 @@ class TestRoutes:
             "label": file.FileName,
             "sequences": [
                 {
-                    "@id": f"http://localhost/download/{file.FileId}?render=True",
+                    "@id": "https://presigned-url.com/download.png",
                     "@type": "sc:Sequence",
                     "canvases": [
                         {
-                            "@id": f"http://localhost/download/{file.FileId}?render=True",
+                            "@id": "https://presigned-url.com/download.png",
                             "@type": "sc:Canvas",
                             "height": 600,
                             "width": 800,
                             "images": [
                                 {
-                                    "@id": f"http://localhost/download/{file.FileId}?render=True",
+                                    "@id": "https://presigned-url.com/download.png",
                                     "@type": "oa:Annotation",
                                     "motivation": "sc:painting",
-                                    "on": f"http://localhost/download/{file.FileId}?render=True",
+                                    "on": "https://presigned-url.com/download.png",
                                     "resource": {
-                                        "@id": f"http://localhost/download/{file.FileId}?render=True",
+                                        "@id": "https://presigned-url.com/download.png",
                                         "format": "image/png",
                                         "height": 600,
                                         "type": "dctypes:Image",


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Uses presigned url to generate file paths in iiif manifest
- Requires CORS headers to be sent from S3


## JIRA ticket

https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?selectedIssue=AYR-1212

## Screenshots of UI changes
N/A

### Before

### After

- [ ] Requires env variable(s) to be updated
