### PR TITLE
Add textract linux dependencies

### DIFF
--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -1,6 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.11
 # use python 3.11, not 3.12 due to issues with textract on 3.12 at the moment
 
+RUN yum install -y python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils pstotext tesseract-ocr \
+flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig
+
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 
 RUN pip install -r requirements.txt


### PR DESCRIPTION
## Changes in this PR
Add textract linux dependencies to fix text extraction process for certain doc types like pdf which were failing otherwise.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1363