### PR TITLE
Update search query to handle multiple query type searching within opensearch

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -588,22 +588,15 @@ def search_transferring_body(_id: uuid.UUID):
     if query:
         quoted_phrases, single_terms = extract_search_terms(query)
 
+        if search_filter:
+            if search_filter.startswith('"') and search_filter.endswith('"'):
+                quoted_phrases.append(search_filter[1:-1])
+            else:
+                single_terms.append(search_filter.strip())
         search_terms = quoted_phrases + single_terms
 
-        if query:
-            quoted_phrases, single_terms = extract_search_terms(query)
-
-            if search_filter:
-                if search_filter.startswith('"') and search_filter.endswith(
-                    '"'
-                ):
-                    quoted_phrases.append(search_filter[1:-1])
-                else:
-                    single_terms.append(search_filter.strip())
-            search_terms = quoted_phrases + single_terms
-
-            query = f"{query},{search_filter}" if search_filter else query
-            filters["query"] = query
+        query = f"{query},{search_filter}" if search_filter else query
+        filters["query"] = query
 
         breadcrumb_values[0] = {"query": query}
         display_terms = " + ".join(

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,6 @@
 import io
 import json
+import re
 import uuid
 
 import boto3
@@ -584,7 +585,18 @@ def search_transferring_body(_id: uuid.UUID):
     )
 
     if query:
-        search_terms = [term.strip() for term in query.split(",") if term]
+        # Extract quoted phrases and terms not in quotes separately
+        quoted_phrases = re.findall(
+            r'"([^"]*)"', query
+        )  # Finds phrases within quotes
+        remaining_terms = re.sub(r'"[^"]*"', "", query).replace(",", " ")
+        single_terms = [
+            term.strip() for term in remaining_terms.split() if term.strip()
+        ]
+
+        # Combine quoted phrases and single terms into final search_terms list
+        search_terms = quoted_phrases + single_terms
+
         if search_filter:
             search_terms.append(search_filter)
             query += f",{search_filter}" if search_terms else search_filter

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -588,12 +588,21 @@ def search_transferring_body(_id: uuid.UUID):
     if query:
         quoted_phrases, single_terms = extract_search_terms(query)
 
-        # Combine quoted phrases and single terms into final search_terms list
         search_terms = quoted_phrases + single_terms
 
-        if search_filter:
-            search_terms.append(search_filter)
-            query += f",{search_filter}" if search_terms else search_filter
+        if query:
+            quoted_phrases, single_terms = extract_search_terms(query)
+
+            if search_filter:
+                if search_filter.startswith('"') and search_filter.endswith(
+                    '"'
+                ):
+                    quoted_phrases.append(search_filter[1:-1])
+                else:
+                    single_terms.append(search_filter.strip())
+            search_terms = quoted_phrases + single_terms
+
+            query = f"{query},{search_filter}" if search_filter else query
             filters["query"] = query
 
         breadcrumb_values[0] = {"query": query}

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -8,6 +8,7 @@ from app.main.util.search_utils import (
     build_search_results_summary_query,
     build_search_transferring_body_query,
     execute_search,
+    extract_search_terms,
     filter_opensearch_highlight_results,
     format_opensearch_results,
     get_all_fields_excluding,
@@ -327,11 +328,14 @@ def test_get_all_fields_excluding(mock_open_search):
 
 
 def test_build_dsl_search_query():
+    query = "test_query"
+    quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_dsl_search_query(
-        "test_query",
         ["field_1"],
         {"sort_1": "test_1"},
         [{"clause_1": "test_2"}],
+        quoted_phrases,
+        single_terms,
     )
     assert dsl_query == expected_base_dsl_search_query
 
@@ -341,6 +345,7 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
     search_fields = ["field_1"]
     sorting_orders = {"sort_1": "test_1"}
     filter_clauses = [{"clause_1": "test_2"}]
+    quoted_phrases, single_terms = extract_search_terms(query)
 
     expected_dsl_query = {
         "query": {
@@ -379,14 +384,20 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
     }
 
     dsl_query = build_dsl_search_query(
-        query, search_fields, sorting_orders, filter_clauses
+        search_fields,
+        sorting_orders,
+        filter_clauses,
+        quoted_phrases,
+        single_terms,
     )
     assert dsl_query == expected_dsl_query
 
 
 def test_build_search_results_summary_query():
+    query = "test_query"
+    quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_search_results_summary_query(
-        "test_query", ["field_1"], {"sort_1": "test_1"}
+        ["field_1"], {"sort_1": "test_1"}, quoted_phrases, single_terms
     )
     assert dsl_query == {
         **expected_base_dsl_search_query,
@@ -423,12 +434,15 @@ def test_build_search_results_summary_query():
 
 def test_build_search_transferring_body_query():
     transferring_body_id = "test_transferring_body_id"
+    query = "test_query"
+    quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_search_transferring_body_query(
-        "test_query",
         ["field_1"],
         {"sort_1": "test_1"},
         transferring_body_id,
         "test_highlight_key",
+        quoted_phrases,
+        single_terms,
     )
     assert dsl_query == {
         **expected_base_dsl_search_query,

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -374,7 +374,7 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
                 "filter": filter_clauses,
             }
         },
-        "sort": sorting_orders,
+        "sort": {},
         "_source": {"exclude": ["*.keyword"]},
     }
 

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -369,7 +369,7 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
                             "fuzziness": "AUTO",
                             "lenient": True,
                         }
-                    }
+                    },
                 ],
                 "filter": filter_clauses,
             }
@@ -378,7 +378,9 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
         "_source": {"exclude": ["*.keyword"]},
     }
 
-    dsl_query = build_dsl_search_query(query, search_fields, sorting_orders, filter_clauses)
+    dsl_query = build_dsl_search_query(
+        query, search_fields, sorting_orders, filter_clauses
+    )
     assert dsl_query == expected_dsl_query
 
 

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -336,6 +336,52 @@ def test_build_dsl_search_query():
     assert dsl_query == expected_base_dsl_search_query
 
 
+def test_build_dsl_search_query_and_exact_fuzzy_search():
+    query = '"exact match", fuzzy, search'
+    search_fields = ["field_1"]
+    sorting_orders = {"sort_1": "test_1"}
+    filter_clauses = [{"clause_1": "test_2"}]
+
+    expected_dsl_query = {
+        "query": {
+            "bool": {
+                "must": [
+                    {
+                        "multi_match": {
+                            "query": "exact match",
+                            "fields": search_fields,
+                            "type": "phrase",
+                            "lenient": True,
+                        }
+                    },
+                    {
+                        "multi_match": {
+                            "query": "fuzzy",
+                            "fields": search_fields,
+                            "fuzziness": "AUTO",
+                            "lenient": True,
+                        }
+                    },
+                    {
+                        "multi_match": {
+                            "query": "search",
+                            "fields": search_fields,
+                            "fuzziness": "AUTO",
+                            "lenient": True,
+                        }
+                    }
+                ],
+                "filter": filter_clauses,
+            }
+        },
+        "sort": sorting_orders,
+        "_source": {"exclude": ["*.keyword"]},
+    }
+
+    dsl_query = build_dsl_search_query(query, search_fields, sorting_orders, filter_clauses)
+    assert dsl_query == expected_dsl_query
+
+
 def test_build_search_results_summary_query():
     dsl_query = build_search_results_summary_query(
         "test_query", ["field_1"], {"sort_1": "test_1"}

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -375,7 +375,7 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
             }
         },
         "sort": {},
-        "_source": {"exclude": ["*.keyword"]},
+        "_source": True,
     }
 
     dsl_query = build_dsl_search_query(


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- AND behaviour for search terms: Each term in the search query now acts as a filter, requiring that all terms be present in the results.
- Phrase Matching with Quotes:
Terms in quotes (e.g., "everybody book") are treated as exact phrases. Records must contain the exact phrase with words in the specified order
- Individual words not in quotes (e.g., best or during) are treated as single terms with fuzzy matching, which allows minor variations (e.g. "best" could match "test")

Examples:
- Quoted Phrase ("everybody book") - Matches documents containing the exact phrase "everybody book".
- Multiple Words without Quotes (best, during) - Matches documents containing both terms with flexibility for minor spelling errors.
- Mixed Query ("everybody book", best, during) - Combines exact phrase matching for "everybody book" with flexible term matching for best and during.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1278


## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
