### PR TITLE
AYR-1327 - Format metadata fields

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,7 +10,7 @@ from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from app.logger_config import setup_logging
 from app.main.db.models import db
-from app.main.util.search_utils import opensearch_field_name_map
+from app.main.util.search_utils import OPENSEARCH_FIELD_NAME_MAP
 
 compress = Compress()
 talisman = Talisman()
@@ -35,9 +35,7 @@ def clean_tags_and_replace_highlight_tag(text, highlight_tag):
 
 def format_opensearch_field_name(field):
     """Format the name of an OpenSearch field using a map or dynamically"""
-    return opensearch_field_name_map.get(
-        field, field.replace("_", " ").capitalize()
-    )
+    return OPENSEARCH_FIELD_NAME_MAP.get(field)
 
 
 def create_app(config_class, database_uri=None):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -10,23 +10,11 @@ from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
 
 from app.logger_config import setup_logging
 from app.main.db.models import db
+from app.main.util.search_utils import opensearch_field_name_map
 
 compress = Compress()
 talisman = Talisman()
 s3 = FlaskS3()
-
-
-opensearch_field_name_map = {
-    "file_name": "File name",
-    "description": "Description",
-    "Source-Organisation": "Transferring body",
-    "foi_exemption_code": "FOI code",
-    "content": "Content",
-    "closure_start_date": "Closure start date",
-    "end_date": "Record date",
-    "date_last_modified": "Record date",
-    "closure_start_date": "Closure start date",
-}
 
 
 def null_to_dash(value):
@@ -47,10 +35,9 @@ def clean_tags_and_replace_highlight_tag(text, highlight_tag):
 
 def format_opensearch_field_name(field):
     """Format the name of an OpenSearch field using a map or dynamically"""
-    if field in opensearch_field_name_map:
-        return opensearch_field_name_map[field]
-    else:
-        return field.replace("_", " ").capitalize()
+    return opensearch_field_name_map.get(
+        field, field.replace("_", " ").capitalize()
+    )
 
 
 def create_app(config_class, database_uri=None):

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -16,6 +16,19 @@ talisman = Talisman()
 s3 = FlaskS3()
 
 
+opensearch_field_name_map = {
+    "file_name": "File name",
+    "description": "Description",
+    "Source-Organisation": "Transferring body",
+    "foi_exemption_code": "FOI code",
+    "content": "Content",
+    "closure_start_date": "Closure start date",
+    "end_date": "Record date",
+    "date_last_modified": "Record date",
+    "closure_start_date": "Closure start date",
+}
+
+
 def null_to_dash(value):
     """Filter that converts string values that are "null" or Nones to dash"""
     if value == "null":
@@ -32,6 +45,14 @@ def clean_tags_and_replace_highlight_tag(text, highlight_tag):
     return clean_text.replace(highlight_tag, "mark")
 
 
+def format_opensearch_field_name(field):
+    """Format the name of an OpenSearch field using a map or dynamically"""
+    if field in opensearch_field_name_map:
+        return opensearch_field_name_map[field]
+    else:
+        return field.replace("_", " ").capitalize()
+
+
 def create_app(config_class, database_uri=None):
     app = Flask(__name__, static_url_path="/assets")
     config = config_class()
@@ -45,6 +66,9 @@ def create_app(config_class, database_uri=None):
     app.jinja_env.filters["null_to_dash"] = null_to_dash
     app.jinja_env.filters["clean_tags_and_replace_highlight_tag"] = (
         clean_tags_and_replace_highlight_tag
+    )
+    app.jinja_env.filters["format_opensearch_field_name"] = (
+        format_opensearch_field_name
     )
     app.jinja_loader = ChoiceLoader(
         [

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -34,7 +34,7 @@ def clean_tags_and_replace_highlight_tag(text, highlight_tag):
 
 
 def format_opensearch_field_name(field):
-    """Format the name of an OpenSearch field using a map or dynamically"""
+    """Format the name of an OpenSearch field using a map"""
     return OPENSEARCH_FIELD_NAME_MAP.get(field)
 
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -35,7 +35,7 @@ def clean_tags_and_replace_highlight_tag(text, highlight_tag):
 
 def format_opensearch_field_name(field):
     """Format the name of an OpenSearch field using a map"""
-    return OPENSEARCH_FIELD_NAME_MAP.get(field)
+    return OPENSEARCH_FIELD_NAME_MAP[field]
 
 
 def create_app(config_class, database_uri=None):

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -509,9 +509,7 @@ def search_results_summary():
 
     if query:
         open_search = setup_opensearch()
-        search_fields = get_open_search_fields_to_search_on(
-            open_search, search_area
-        )
+        search_fields = get_open_search_fields_to_search_on(search_area)
         sorting_orders = build_sorting_orders(request.args)
         dsl_query = build_search_results_summary_query(
             query, search_fields, sorting_orders
@@ -597,9 +595,7 @@ def search_transferring_body(_id: uuid.UUID):
         breadcrumb_values[3]["search_terms"] = display_terms or query
 
         open_search = setup_opensearch()
-        search_fields = get_open_search_fields_to_search_on(
-            open_search, search_area
-        )
+        search_fields = get_open_search_fields_to_search_on(search_area)
         sorting_orders = build_sorting_orders(request.args)
         dsl_query = build_search_transferring_body_query(
             query, search_fields, sorting_orders, _id, highlight_tag

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -5,6 +5,25 @@ from opensearchpy import OpenSearch, RequestsHttpConnection
 from app.main.util.date_validator import format_opensearch_date
 from app.main.util.pagination import calculate_total_pages, get_pagination
 
+opensearch_field_name_map = {
+    "file_name": "File name",
+    "description": "Description",
+    "transferring_body": "Transferring body",
+    "foi_exemption_code": "FOI code",
+    "content": "Content",
+    "closure_start_date": "Closure start date",
+    "end_date": "Record date",
+    "date_last_modified": "Record date",
+    "closure_start_date": "Closure start date",
+    # might be useful to show in the future
+    # "file_reference": "File reference",
+    # "file_path": "File path",
+    "citeable_reference": "Citeable reference",
+    "series_name": "Series name",
+    "transferring_body_description": "Transferring body description",
+    "consignment_reference": "Consignment ref",
+}
+
 
 def format_opensearch_results(results):
     """Format date fields of the _source object inside results"""
@@ -35,14 +54,15 @@ def post_process_opensearch_results(results):
     return results
 
 
-def get_open_search_fields_to_search_on(open_search, search_area):
+def get_open_search_fields_to_search_on(search_area):
     """Retrieve a list of fields depending on the search area (all fields, metadata, record, etc.)"""
     fields_record = ["content"]
+    fields_all = list(opensearch_field_name_map.keys())
     if search_area == "metadata":
-        return get_all_fields_excluding(open_search, "documents", fields_record)
+        return get_filtered_list(fields_all, fields_record)
     elif search_area == "record":
         return fields_record
-    return ["*"]
+    return fields_all
 
 
 def get_param(param, request):

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -5,7 +5,7 @@ from opensearchpy import OpenSearch, RequestsHttpConnection
 from app.main.util.date_validator import format_opensearch_date
 from app.main.util.pagination import calculate_total_pages, get_pagination
 
-opensearch_field_name_map = {
+OPENSEARCH_FIELD_NAME_MAP = {
     "file_name": "File name",
     "description": "Description",
     "transferring_body": "Transferring body",
@@ -57,7 +57,7 @@ def post_process_opensearch_results(results):
 def get_open_search_fields_to_search_on(search_area):
     """Retrieve a list of fields depending on the search area (all fields, metadata, record, etc.)"""
     fields_record = ["content"]
-    fields_all = list(opensearch_field_name_map.keys())
+    fields_all = list(OPENSEARCH_FIELD_NAME_MAP.keys())
     if search_area == "metadata":
         return get_filtered_list(fields_all, fields_record)
     elif search_area == "record":

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -251,6 +251,9 @@ a.govuk-link {
     ~ tr.hidden-row-#{$i} {
     display: table-row;
   }
+  tr:has(> td > div > details.details-toggle-#{$i}[open]) .field-count-#{$i} {
+    display: none;
+  }
 }
 
 .govuk-table {

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -90,7 +90,8 @@
                                                 {% for record in results %}
                                                     {% set main_loop_index = loop.index %}
                                                     <tr class="govuk-table__row govuk-table__row--primary">
-                                                        {% set first_field = record['highlight'].keys() | list | first | format_opensearch_field_name %}
+                                                        {% set first_field = record['highlight'].keys() | list | first %}
+                                                        {% set first_field_formatted = first_field | format_opensearch_field_name %}
                                                         {% set first_result_value = record['highlight'].values() | list | first | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe %}
                                                         {% set total_fields = record['highlight'].keys() | length %}
                                                         <td class="govuk-table__cell">
@@ -101,9 +102,9 @@
                                                                 </details>
                                                                 {% if record['highlight'] %}
                                                                     {% if total_fields > 1 %}
-                                                                        <span>{{ first_field }} <span class="field-count-{{ main_loop_index }}">+{{ total_fields - 1 }}</span></span>
+                                                                        <span>{{ first_field_formatted }} <span class="field-count-{{ main_loop_index }}">+{{ total_fields - 1 }}</span></span>
                                                                     {% else %}
-                                                                        {{ first_field }}
+                                                                        {{ first_field_formatted }}
                                                                     {% endif %}
                                                                 {% else %}
                                                                     None
@@ -112,7 +113,7 @@
                                                         </td>
                                                         <td class="govuk-table__cell">
                                                             {% if record['highlight'] %}
-                                                                {% if first_field == "field_name" %}
+                                                                {% if first_field == "file_name" %}
                                                                     <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">{{ first_result_value }}</a>
                                                                 {% else %}
                                                                     {{ first_result_value }}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -90,7 +90,7 @@
                                                 {% for record in results %}
                                                     {% set main_loop_index = loop.index %}
                                                     <tr class="govuk-table__row govuk-table__row--primary">
-                                                        {% set first_field = record['highlight'].keys() | list | first | replace('_', ' ') | capitalize %}
+                                                        {% set first_field = record['highlight'].keys() | list | first | format_opensearch_field_name %}
                                                         {% set first_result_value = record['highlight'].values() | list | first | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe %}
                                                         {% set total_fields = record['highlight'].keys() | length %}
                                                         <td class="govuk-table__cell">
@@ -101,7 +101,7 @@
                                                                 </details>
                                                                 {% if record['highlight'] %}
                                                                     {% if total_fields > 1 %}
-                                                                        {{ first_field }} +{{ total_fields - 1 }}
+                                                                        <span>{{ first_field }} <span class="field-count-{{ main_loop_index }}">+{{ total_fields - 1 }}</span></span>
                                                                     {% else %}
                                                                         {{ first_field }}
                                                                     {% endif %}
@@ -141,7 +141,7 @@
                                                         {% if key != 'file_name' %}
                                                             <tr class="govuk-table__row top-row hidden-row-{{ main_loop_index }}">
                                                                 <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">
-                                                                    {{ key | replace('_', ' ') | capitalize }}
+                                                                    {{ key | format_opensearch_field_name }}
                                                                 </td>
                                                                 <td class="govuk-table__cell govuk-table__cell--no-pt">
                                                                     {{ value | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe }}

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -125,10 +125,7 @@ def test_clean_tags(input_text, expected_output):
         ("series_name", "Series name"),
         ("transferring_body_description", "Transferring body description"),
         ("consignment_reference", "Consignment ref"),
-        # edge cases
-        # empty string should return empty string
         ("", None),
-        # single word, no underscore
         ("singleword", None),
         ("unknown_field", None),
     ],

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -115,7 +115,7 @@ def test_clean_tags(input_text, expected_output):
         # fields directly mapped
         ("file_name", "File name"),
         ("description", "Description"),
-        ("Source-Organisation", "Transferring body"),
+        ("transferring_body", "Transferring body"),
         ("foi_exemption_code", "FOI code"),
         ("content", "Content"),
         ("closure_start_date", "Closure start date"),
@@ -124,6 +124,10 @@ def test_clean_tags(input_text, expected_output):
         ("unknown_field", "Unknown field"),
         ("another_field", "Another field"),
         ("custom_field_name", "Custom field name"),
+        ("citeable_reference", "Citeable reference"),
+        ("series_name", "Series name"),
+        ("transferring_body_description", "Transferring body description"),
+        ("consignment_reference", "Consignment ref"),
         # edge cases
         # empty string should return empty string
         ("", ""),

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -121,18 +121,16 @@ def test_clean_tags(input_text, expected_output):
         ("closure_start_date", "Closure start date"),
         ("end_date", "Record date"),
         ("date_last_modified", "Record date"),
-        ("unknown_field", "Unknown field"),
-        ("another_field", "Another field"),
-        ("custom_field_name", "Custom field name"),
         ("citeable_reference", "Citeable reference"),
         ("series_name", "Series name"),
         ("transferring_body_description", "Transferring body description"),
         ("consignment_reference", "Consignment ref"),
         # edge cases
         # empty string should return empty string
-        ("", ""),
+        ("", None),
         # single word, no underscore
-        ("singleword", "Singleword"),
+        ("singleword", None),
+        ("unknown_field", None),
     ],
 )
 def test_format_opensearch_field_name(field, expected):

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -1,6 +1,10 @@
 import pytest
 
-from app import clean_tags_and_replace_highlight_tag, null_to_dash
+from app import (
+    clean_tags_and_replace_highlight_tag,
+    format_opensearch_field_name,
+    null_to_dash,
+)
 
 
 @pytest.mark.parametrize(
@@ -103,3 +107,29 @@ def test_clean_tags(input_text, expected_output):
         clean_tags_and_replace_highlight_tag(input_text, "test_highlight_key")
         == expected_output
     )
+
+
+@pytest.mark.parametrize(
+    "field, expected",
+    [
+        # fields directly mapped
+        ("file_name", "File name"),
+        ("description", "Description"),
+        ("Source-Organisation", "Transferring body"),
+        ("foi_exemption_code", "FOI code"),
+        ("content", "Content"),
+        ("closure_start_date", "Closure start date"),
+        ("end_date", "Record date"),
+        ("date_last_modified", "Record date"),
+        ("unknown_field", "Unknown field"),
+        ("another_field", "Another field"),
+        ("custom_field_name", "Custom field name"),
+        # edge cases
+        # empty string should return empty string
+        ("", ""),
+        # single word, no underscore
+        ("singleword", "Singleword"),
+    ],
+)
+def test_format_opensearch_field_name(field, expected):
+    assert format_opensearch_field_name(field) == expected

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -125,9 +125,6 @@ def test_clean_tags(input_text, expected_output):
         ("series_name", "Series name"),
         ("transferring_body_description", "Transferring body description"),
         ("consignment_reference", "Consignment ref"),
-        ("", None),
-        ("singleword", None),
-        ("unknown_field", None),
     ],
 )
 def test_format_opensearch_field_name(field, expected):

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -2027,6 +2027,8 @@ class TestSearchTransferringBody:
         checkbox = soup.find("input", {"name": "open_all"})
         details_elements = soup.find_all("details")
 
+        # we cant check CSS visibility with Beautiful soup, otherwise
+        # we'd check if the field count element is not visible here
         assert "checked" in checkbox.attrs
         assert all("open" in details.attrs for details in details_elements)
 

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -54,11 +54,11 @@ os_mock_return_tb = {
                     "opening_date": "fooDate",
                 },
                 "highlight": {
-                    "test_field_1": [
+                    "series_name": [
                         f"<{highlight_tag}>test1</{highlight_tag}> and",
                         f"this is just a sentence with a mark <{highlight_tag}>element</{highlight_tag}> in it",
                     ],
-                    "test_field_2": [
+                    "transferring_body": [
                         f"this is a <{highlight_tag}>cool test</{highlight_tag}> and",
                         f"sea shells <{highlight_tag}>on the</{highlight_tag}> sea shore",
                     ],
@@ -1801,7 +1801,7 @@ class TestSearchTransferringBody:
                 os_mock_return_tb,
                 [
                     [
-                        "Test field 1 +1",
+                        "Series name +1",
                         "<mark>test1</mark> and ... this is just a sentence with a mark <mark>element</mark> in it",
                     ],
                     [
@@ -1809,7 +1809,7 @@ class TestSearchTransferringBody:
                         "fifth_file.doc",
                     ],
                     [
-                        "Test field 2",
+                        "Transferring body",
                         "this is a <mark>cool test</mark> and ... sea shells <mark>on the</mark> sea shore",
                     ],
                 ],
@@ -1819,7 +1819,7 @@ class TestSearchTransferringBody:
                 os_mock_return_tb,
                 [
                     [
-                        "Test field 1 +1",
+                        "Series name +1",
                         "<mark>test1</mark> and ... this is just a sentence with a mark <mark>element</mark> in it",
                     ],
                     [
@@ -1827,7 +1827,7 @@ class TestSearchTransferringBody:
                         "fifth_file.doc",
                     ],
                     [
-                        "Test field 2",
+                        "Transferring body",
                         "this is a <mark>cool test</mark> and ... sea shells <mark>on the</mark> sea shore",
                     ],
                 ],
@@ -1837,7 +1837,7 @@ class TestSearchTransferringBody:
                 os_mock_return_tb,
                 [
                     [
-                        "Test field 1 +1",
+                        "Series name +1",
                         "<mark>test1</mark> and ... this is just a sentence with a mark <mark>element</mark> in it",
                     ],
                     [
@@ -1845,7 +1845,7 @@ class TestSearchTransferringBody:
                         "fifth_file.doc",
                     ],
                     [
-                        "Test field 2",
+                        "Transferring body",
                         "this is a <mark>cool test</mark> and ... sea shells <mark>on the</mark> sea shore",
                     ],
                 ],

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -90,11 +90,11 @@ os_mock_return_tb_closed_record = {
                     "opening_date": "2025-01-01T00:00:00",
                 },
                 "highlight": {
-                    "test_field_1": [
+                    "series_name": [
                         "<mark>test1</mark>",
                         "this is just a sentence with a mark <mark>element</mark> in it",
                     ],
-                    "test_field_2": [
+                    "transferring_body": [
                         "t<mark>est2</mark>",
                         "sea shells <mark>on the</mark> sea shore",
                     ],
@@ -2101,8 +2101,8 @@ class TestSearchTransferringBody:
                                 "file_name": "fifth_file.doc",
                             },
                             "highlight": {
-                                "foo": ["bar"],
-                                "marco": ["polo"],
+                                "series_name": ["bar"],
+                                "transferring_body": ["polo"],
                                 "file_name": [
                                     f"<{highlight_tag}>fifth_file.doc</{highlight_tag}>"
                                 ],

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -19,6 +19,21 @@ from app.main.util.search_utils import (
     setup_opensearch,
 )
 
+fields_all = [
+    "file_name",
+    "description",
+    "transferring_body",
+    "foi_exemption_code",
+    "content",
+    "closure_start_date",
+    "end_date",
+    "date_last_modified",
+    "citeable_reference",
+    "series_name",
+    "transferring_body_description",
+    "consignment_reference",
+]
+
 expected_base_dsl_search_query = {
     "query": {
         "bool": {
@@ -106,35 +121,36 @@ def test_format_opensearch_results(results, expected):
     "search_area, expected_fields",
     [
         # default "all" fields (no specific search area)
-        ("all", ["*"]),
+        ("all", fields_all),
         # "metadata" search area
         (
             "metadata",
-            ["metadata_field_1", "metadata_field_2", "metadata_field_3"],
+            [
+                "file_name",
+                "description",
+                "transferring_body",
+                "foi_exemption_code",
+                "closure_start_date",
+                "end_date",
+                "date_last_modified",
+                "citeable_reference",
+                "series_name",
+                "transferring_body_description",
+                "consignment_reference",
+            ],
         ),
         # "record" search area
         ("record", ["content"]),
         # empty search_area string (should default to "all" behavior)
-        ("", ["*"]),
+        ("", fields_all),
         # none as search_area (should default to "all" behavior)
-        (None, ["*"]),
+        (None, fields_all),
         # invalid search_area (should default to "all" behavior)
-        ("invalid_area", ["*"]),
+        ("invalid_area", fields_all),
     ],
 )
-@patch("app.main.util.search_utils.OpenSearch")
-@patch("app.main.util.search_utils.get_all_fields_excluding")
-def test_get_open_search_fields_to_search_on(
-    mock_get_all_fields_excluding, mock_opensearch, search_area, expected_fields
-):
-    mock_get_all_fields_excluding.return_value = [
-        "metadata_field_1",
-        "metadata_field_2",
-        "metadata_field_3",
-    ]
-    actual_fields = get_open_search_fields_to_search_on(
-        mock_opensearch, search_area
-    )
+def test_get_open_search_fields_to_search_on(search_area, expected_fields):
+    actual_fields = get_open_search_fields_to_search_on(search_area)
     assert actual_fields == expected_fields
 
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Added Jinja filter utility to format the names of fields 
- Modified styles so the field count element is not visible when the accordion is open
- Added tests

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1327

## Screenshots of UI changes

### Before
<img width="673" alt="image" src="https://github.com/user-attachments/assets/a59d07f1-f566-4200-a0eb-ec2ae16843bd">

### After
<img width="685" alt="image" src="https://github.com/user-attachments/assets/c12e1cdc-7405-4544-a2bb-ea2dca80be3a">

- [ ] Requires env variable(s) to be updated
