### PR TITLE
AYR-1377 - Survey band

### DIFF
--- a/app/static/src/scss/includes/components/_belly-band.scss
+++ b/app/static/src/scss/includes/components/_belly-band.scss
@@ -1,0 +1,13 @@
+.ayr-belly-band {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: 0.9rem 0 1.5rem;
+  border-top: 1px solid #b1b4b6;
+
+  .govuk-heading-m {
+    font-size: 22px;
+    margin-bottom: 0.8rem;
+  }
+}

--- a/app/static/src/scss/main.scss
+++ b/app/static/src/scss/main.scss
@@ -33,3 +33,4 @@ $govuk-font-family: Arial, Helvetica, sans-serif;
 
 // components
 @import "includes/components/alert-banner";
+@import "includes/components/belly-band";

--- a/app/templates/main/components/banners.html
+++ b/app/templates/main/components/banners.html
@@ -1,8 +1,0 @@
-{% macro alertBanner(variant='', heading='', message='') %}
-    <div class="ayr-alert-banner ayr-alert-banner--{{ variant }}"
-         role="alert"
-         aria-live="polite">
-        <h2 class="ayr-alert-banner__heading">{{ heading }}</h2>
-        <p class="ayr-alert-banner__message">{{ message }}</p>
-    </div>
-{% endmacro %}

--- a/app/templates/main/macros/banners.html
+++ b/app/templates/main/macros/banners.html
@@ -1,0 +1,15 @@
+{% macro alert_banner(variant='', heading='', message='') %}
+    <div class="ayr-alert-banner ayr-alert-banner--{{ variant }}"
+         role="alert"
+         aria-live="polite">
+        <h2 class="ayr-alert-banner__heading">{{ heading }}</h2>
+        <p class="ayr-alert-banner__message">{{ message }}</p>
+    </div>
+{% endmacro %}
+{% macro belly_band(heading='', link_text='', link_href='') %}
+    <div class="ayr-belly-band">
+        <h1 class="govuk-heading-m">{{ heading }}</h1>
+        <a href="{{ link_href }}"
+           class="govuk-link govuk-link--no-visited-state">{{ link_text }}</a>
+    </div>
+{% endmacro %}

--- a/app/templates/main/record-view.html
+++ b/app/templates/main/record-view.html
@@ -1,4 +1,4 @@
-{% import "components/banners.html" as banners %}
+{% from 'macros/banners.html' import alert_banner %}
 <div class="govuk-tabs__panel" id="record-view">
     {% if file_type == "iiif" %}
         <div class="record-view-header">
@@ -29,7 +29,7 @@
         </div>
     {% else %}
         <div class="record-view__banner-container">
-            {{ banners.alertBanner('error', 'Unable to display this record', 'We cannot currently render this file type.') }}
+            {{ alert_banner('error', 'Unable to display this record', 'We cannot currently render this file type.') }}
         </div>
     {% endif %}
 </div>

--- a/app/templates/template.html
+++ b/app/templates/template.html
@@ -2,6 +2,7 @@
 {% from "govuk_frontend_jinja/components/skip-link/macro.html" import govukSkipLink -%}
 {% from "govuk_frontend_jinja/components/header/macro.html" import govukHeader -%}
 {% from "govuk_frontend_jinja/components/footer/macro.html" import govukFooter -%}
+{% from 'main/macros/banners.html' import belly_band %}
 <!DOCTYPE html>
 <html lang="{{ htmlLang | default('en', true) }}"
       class="govuk-template {%- if htmlClasses %}{{ htmlClasses }}{% endif %}">
@@ -60,6 +61,7 @@
                 </main>
             </div>
         {% endblock %}
+        {{ belly_band('Help us to improve this service', 'Complete our short survey', 'https://www.smartsurvey.co.uk/s/AYRfeedback/') }}
         {% block footer %}{{ govukFooter({}) }}{% endblock %}
         {% block bodyEnd %}{% endblock %}
     </body>

--- a/app/tests/test_macros.py
+++ b/app/tests/test_macros.py
@@ -1,0 +1,134 @@
+import pytest
+from bs4 import BeautifulSoup
+from jinja2 import Environment, FileSystemLoader
+
+
+class TestBanners:
+    @property
+    def template(self):
+        """Dynamically load and return the Jinja2 template."""
+        env = Environment(loader=FileSystemLoader("app/templates"))
+        return env.get_template("main/macros/banners.html")
+
+    @property
+    def macros(self):
+        """Access the macros in the template."""
+        return self.template.make_module()
+
+    @pytest.mark.parametrize(
+        "variant, heading, message, expected_class, expected_heading, expected_message",
+        [
+            (
+                "",
+                "Default Heading",
+                "Default message",
+                "ayr-alert-banner--",
+                "Default Heading",
+                "Default message",
+            ),
+            (
+                "error",
+                "Error Heading",
+                "This is an error!",
+                "ayr-alert-banner--error",
+                "Error Heading",
+                "This is an error!",
+            ),
+            (
+                "success",
+                "Success Heading",
+                "This is a success!",
+                "ayr-alert-banner--success",
+                "Success Heading",
+                "This is a success!",
+            ),
+        ],
+    )
+    def test_alert_banner(
+        self,
+        variant,
+        heading,
+        message,
+        expected_class,
+        expected_heading,
+        expected_message,
+    ):
+        """Test the alert_banner macro."""
+        rendered = self.macros.alert_banner(
+            variant=variant, heading=heading, message=message
+        )
+        soup = BeautifulSoup(rendered, "html.parser")
+
+        alert_banner = soup.find("div", class_="ayr-alert-banner")
+        assert alert_banner is not None
+        assert expected_class in alert_banner["class"]
+
+        heading_tag = alert_banner.find(
+            "h2", class_="ayr-alert-banner__heading"
+        )
+        message_tag = alert_banner.find("p", class_="ayr-alert-banner__message")
+
+        assert heading_tag is not None
+        assert heading_tag.text == expected_heading
+
+        assert message_tag is not None
+        assert message_tag.text == expected_message
+
+    @pytest.mark.parametrize(
+        "heading, link_text, link_href, expected_heading, expected_link_text, expected_link_href",
+        [
+            (
+                "Help us to improve this service",
+                "Complete our short survey",
+                "https://www.smartsurvey.co.uk/s/AYRfeedback/",
+                "Help us to improve this service",
+                "Complete our short survey",
+                "https://www.smartsurvey.co.uk/s/AYRfeedback/",
+            ),
+            (
+                "Belly Band Heading",
+                "Click Here",
+                "http://example.com",
+                "Belly Band Heading",
+                "Click Here",
+                "http://example.com",
+            ),
+            (
+                "Welcome",
+                "Learn More",
+                "http://example.org",
+                "Welcome",
+                "Learn More",
+                "http://example.org",
+            ),
+        ],
+    )
+    def test_belly_band(
+        self,
+        heading,
+        link_text,
+        link_href,
+        expected_heading,
+        expected_link_text,
+        expected_link_href,
+    ):
+        """Test the belly_band macro."""
+        rendered = self.macros.belly_band(
+            heading=heading, link_text=link_text, link_href=link_href
+        )
+        soup = BeautifulSoup(rendered, "html.parser")
+
+        belly_band = soup.find("div", class_="ayr-belly-band")
+        assert belly_band is not None
+
+        heading_tag = belly_band.find("h1", class_="govuk-heading-m")
+        link_tag = belly_band.find(
+            "a", class_="govuk-link govuk-link--no-visited-state"
+        )
+
+        assert heading_tag is not None
+        assert heading_tag.text == expected_heading
+
+        assert link_tag is not None
+        assert link_tag.text == expected_link_text
+        assert link_tag["href"] == expected_link_href


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Renamed "components" dir to "macros" to be more consistent with Jinja naming standards
- Renamed the alert banner macro
- Created a belly_band macro for the survey band - aimed for this to be generic and reusable
- Added unit tests for both macros that resemble more traditional component unit tests

## JIRA ticket

## Screenshots of UI changes

### Before
<img width="1031" alt="image" src="https://github.com/user-attachments/assets/9d213e54-713c-4d22-8074-fd3c3cd4222c">

### After
<img width="1042" alt="image" src="https://github.com/user-attachments/assets/10fb3e81-914a-4c9d-bcfa-5d76c20ba6fd">


- [ ] Requires env variable(s) to be updated
