### PR TITLE
Use https for iiif manifest urls not http

### DIFF
--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -96,7 +96,7 @@ def generate_pdf_manifest(record_id):
 
     manifest = {
         "@context": [
-            "http://iiif.io/api/presentation/3/context.json",
+            "https://iiif.io/api/presentation/3/context.json",
         ],
         "id": f"{url_for('main.generate_manifest', record_id=record_id, _external=True, render=True)}",
         "type": "Manifest",
@@ -173,7 +173,7 @@ def generate_image_manifest(s3_file_object, record_id):
     file_url = presigned_url
 
     manifest = {
-        "@context": "http://iiif.io/api/presentation/2/context.json",
+        "@context": "https://iiif.io/api/presentation/3/context.json",
         "@id": f"{url_for('main.generate_manifest', record_id=record_id, _external=True)}",
         "@type": "sc:Manifest",
         "label": filename,

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -133,7 +133,7 @@ class TestRoutes:
         assert response.status_code == 200
 
         expected_pdf_manifest = {
-            "@context": ["http://iiif.io/api/presentation/3/context.json"],
+            "@context": ["https://iiif.io/api/presentation/3/context.json"],
             "behavior": ["individuals"],
             "description": "Manifest for open_file_once_closed.pdf",
             "id": f"http://localhost/record/{file.FileId}/manifest?render=True",
@@ -205,7 +205,7 @@ class TestRoutes:
         assert response.status_code == 200
 
         expected_image_manifest = {
-            "@context": "http://iiif.io/api/presentation/2/context.json",
+            "@context": "https://iiif.io/api/presentation/3/context.json",
             "@id": f"http://localhost/record/{file.FileId}/manifest",
             "@type": "sc:Manifest",
             "description": f"Manifest for {file.FileName}",


### PR DESCRIPTION
- Use https for iiif manifest urls not http
- Use consistent context referebce if presentation api 3