### PR TITLE
Bug fix for current sort value not showing in OS search dropdown

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -514,9 +514,8 @@ def search_results_summary():
         search_fields, sorting = (
             get_open_search_fields_to_search_on_and_sorting(search_area)
         )
-        sorting_orders = build_sorting_orders(request.args)
         dsl_query = build_search_results_summary_query(
-            search_fields, sorting_orders, quoted_phrases, single_terms, sorting
+            search_fields, quoted_phrases, single_terms, sorting
         )
         search_results = execute_search(open_search, dsl_query, page, per_page)
         results = search_results["aggregations"][
@@ -578,7 +577,6 @@ def search_transferring_body(_id: uuid.UUID):
         3: {"search_terms": "‘’"},
     }
 
-    sorting_orders = build_sorting_orders(request.args)
     search_terms, results, pagination, num_records_found = (
         [],
         {"hits": {"total": {"value": 0}, "hits": []}},
@@ -609,10 +607,8 @@ def search_transferring_body(_id: uuid.UUID):
         search_fields, sorting = (
             get_open_search_fields_to_search_on_and_sorting(search_area, sort)
         )
-        sorting_orders = build_sorting_orders(request.args)
         dsl_query = build_search_transferring_body_query(
             search_fields,
-            sorting_orders,
             _id,
             highlight_tag,
             quoted_phrases,
@@ -633,12 +629,12 @@ def search_transferring_body(_id: uuid.UUID):
     return render_template(
         "search-transferring-body.html",
         form=form,
+        sort=sort,
         current_page=page,
         filters=filters,
         breadcrumb_values=breadcrumb_values,
         results=results,
         num_records_found=num_records_found,
-        sorting_orders=sorting_orders,
         search_terms=search_terms,
         search_area=search_area,
         pagination=pagination,

--- a/app/main/util/filter_sort_builder.py
+++ b/app/main/util/filter_sort_builder.py
@@ -38,34 +38,6 @@ def build_sorting_orders(args):
     return sorting_orders
 
 
-def build_sorting_orders_open_search(args):
-    sorting_type_map = {
-        "series_id": "series_id.keyword",
-        "series_name": "series_name.keyword",
-        "consignment_reference": "consignment_reference.keyword",
-        "opening_date": "metadata.opening_date",
-        "file_name": "file_name.keyword",
-        "closure_type": "metadata.closure_type.keyword",
-    }
-    sorting_orders = ["asc", "desc"]
-    sorting_query = {}
-    if args:
-        if args.get("sort"):
-            sort_details = args.get("sort").split("-")
-            sort_by = sort_details[0].strip()
-            sort_order = sort_details[1].strip()
-
-            if (
-                sort_by
-                and sort_order
-                and sort_by in sorting_type_map
-                and sort_order in sorting_orders
-            ):
-                sorting_query[sorting_type_map[sort_by]] = {"order": sort_order}
-
-    return sorting_query
-
-
 def build_browse_consignment_filters(args, date_from, date_to):
     filters = {}
     filter_items = []

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -235,7 +235,6 @@ def build_must_clauses(search_fields, quoted_phrases, single_terms):
 
 def build_dsl_search_query(
     search_fields,
-    sorting_orders,
     filter_clauses,
     quoted_phrases,
     single_terms,
@@ -261,7 +260,6 @@ def build_dsl_search_query(
 
 def build_search_results_summary_query(
     search_fields,
-    sorting_orders,
     quoted_phrases,
     single_terms,
     sorting,
@@ -269,7 +267,6 @@ def build_search_results_summary_query(
     filter_clauses = []
     dsl_query = build_dsl_search_query(
         search_fields,
-        sorting_orders,
         filter_clauses,
         quoted_phrases,
         single_terms,
@@ -295,7 +292,6 @@ def build_search_results_summary_query(
 
 def build_search_transferring_body_query(
     search_fields,
-    sorting_orders,
     transferring_body_id,
     highlight_tag,
     quoted_phrases,
@@ -307,7 +303,6 @@ def build_search_transferring_body_query(
     ]
     dsl_query = build_dsl_search_query(
         search_fields,
-        sorting_orders,
         filter_clauses,
         quoted_phrases,
         single_terms,

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -46,9 +46,19 @@
                         <!-- SORT -->
                         {% if num_records_found > 0 %}
                             <div class="govuk-grid-column-two-thirds filter-group">
-                                {% with dict = sorting_list %}
-                                    {% include "sorting-list.html" %}
-                                {% endwith %}
+                                <div class="browse__sort-container">
+                                    <label class="govuk-label" for="sort">Sort by</label>
+                                    <select class="govuk-select govuk-select__sort-container-select"
+                                            id="sort"
+                                            name="sort">
+                                        {% for key, value in sorting_list.items() %}
+                                            <option value="{{ value }}" {% if value == sort %}selected{% endif %}>{{ key }}</option>
+                                        {% endfor %}
+                                    </select>
+                                    <button type="submit"
+                                            class="govuk-button govuk-button__sort-container-update-button"
+                                            data-module="govuk-button">Apply</button>
+                                </div>
                                 <form>
                                     <div class="filter-group__checkboxes">
                                         <div class="govuk-checkboxes__item govuk-checkboxes govuk-checkboxes--small">

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1611,58 +1611,46 @@ class TestSearchTransferringBody:
         "query_params, mock_open_search_return, expected_cell_values, expected_sort_select_value",
         [
             (
-                "sort=series_name-desc&query=foobar",
+                "&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "series_name-desc",
+                "file_name",
             ),
             (
-                "sort=consignment_reference-desc&query=foobar",
+                "sort=file_name&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "consignment_reference-desc",
+                "file_name",
             ),
             (
-                "sort=consignment_reference-asc&query=foobar",
+                "sort=description&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "consignment_reference-asc",
+                "description",
             ),
             (
-                "sort=opening_date-desc&query=foobar",
+                "sort=metadata&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "opening_date-desc",
+                "metadata",
             ),
             (
-                "sort=opening_date-asc&query=foobar",
+                "sort=content&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "opening_date-asc",
+                "content",
             ),
             (
-                "sort=file_name-asc&query=foobar",
+                "sort=most_matches&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "file_name-asc",
+                "most_matches",
             ),
             (
-                "sort=file_name-desc&query=foobar",
+                "sort=least_matches&query=foobar",
                 os_mock_return_tb,
                 [["first_series", "cbar", "Open", "fooDate"]],
-                "file_name-desc",
-            ),
-            (
-                "sort=closure_type-asc&query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "Open", "fooDate"]],
-                "closure_type-asc",
-            ),
-            (
-                "sort=closure_type-desc&query=foobar",
-                os_mock_return_tb,
-                [["first_series", "cbar", "Open", "fooDate"]],
-                "closure_type-desc",
+                "least_matches",
             ),
         ],
     )
@@ -1699,8 +1687,8 @@ class TestSearchTransferringBody:
         soup = BeautifulSoup(response.data, "html.parser")
         select = soup.find("select", {"id": "sort"})
         # BUG: value not being saved in dropdown
-        # option = select.find("option", selected=True)
-        # option_value = option.get("value")
+        option = select.find("option", selected=True)
+        option_value = option.get("value")
 
         decompose_desktop_invisible_elements(soup)
         inner_table = soup.find("table", {"id": "inner-table"})
@@ -1708,7 +1696,7 @@ class TestSearchTransferringBody:
         inner_table_cell_values = get_table_rows_cell_values(inner_table_body)
 
         assert select
-        # assert option_value == expected_sort_select_value
+        assert option_value == expected_sort_select_value
         assert inner_table_cell_values == expected_cell_values
 
         # check all accordions are closed by default (no "open" attr)
@@ -1718,7 +1706,7 @@ class TestSearchTransferringBody:
     @pytest.mark.parametrize(
         "query_params, mock_open_search_return, expected_cell_values, expected_sort_select_value",
         [
-            # without any sort term the select value should be series_id-asc by default
+            # without any sort term the select value should be file_name by default
             (
                 "query=foobar",
                 os_mock_return_tb,
@@ -1780,10 +1768,9 @@ class TestSearchTransferringBody:
         soup = BeautifulSoup(response.data, "html.parser")
 
         select = soup.find("select", {"id": "sort"})
-        option_selected = select.find("option", selected=True)
-        # BUG: value not being saved in dropdown
-        # option_first = select.find("option")
-        # option_first_value = option_first.get("value")
+
+        option_first = select.find("option")
+        option_first_value = option_first.get("value")
 
         decompose_desktop_invisible_elements(soup)
         inner_table = soup.find("table", {"id": "inner-table"})
@@ -1791,8 +1778,7 @@ class TestSearchTransferringBody:
         inner_table_cell_values = get_table_rows_cell_values(inner_table_body)
 
         assert select
-        assert option_selected is None
-        # assert option_first_value == expected_sort_select_value
+        assert option_first_value == expected_sort_select_value
         assert inner_table_cell_values == expected_cell_values
 
     @pytest.mark.parametrize(

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -1686,7 +1686,6 @@ class TestSearchTransferringBody:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         select = soup.find("select", {"id": "sort"})
-        # BUG: value not being saved in dropdown
         option = select.find("option", selected=True)
         option_value = option.get("value")
 

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -462,7 +462,6 @@ def test_build_dsl_search_query():
     quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_dsl_search_query(
         ["field_1"],
-        {"sort_1": "test_1"},
         [{"clause_1": "test_2"}],
         quoted_phrases,
         single_terms,
@@ -474,7 +473,6 @@ def test_build_dsl_search_query():
 def test_build_dsl_search_query_and_exact_fuzzy_search():
     query = '"exact match", fuzzy, search'
     search_fields = ["field_1"]
-    sorting_orders = {"sort_1": "test_1"}
     filter_clauses = [{"clause_1": "test_2"}]
     quoted_phrases, single_terms = extract_search_terms(query)
 
@@ -516,7 +514,6 @@ def test_build_dsl_search_query_and_exact_fuzzy_search():
 
     dsl_query = build_dsl_search_query(
         search_fields,
-        sorting_orders,
         filter_clauses,
         quoted_phrases,
         single_terms,
@@ -530,7 +527,6 @@ def test_build_search_results_summary_query():
     quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_search_results_summary_query(
         ["field_1"],
-        {"sort_1": "test_1"},
         quoted_phrases,
         single_terms,
         {"sort": "foobar"},
@@ -574,7 +570,6 @@ def test_build_search_transferring_body_query():
     quoted_phrases, single_terms = extract_search_terms(query)
     dsl_query = build_search_transferring_body_query(
         ["field_1"],
-        {"sort_1": "test_1"},
         transferring_body_id,
         "test_highlight_key",
         quoted_phrases,


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Removed mentions of `build_sorting_orders` in the search endpoints - these weren't needed anymore as we don't pass sorting to the query building functions in that format anymore
- Replaced the sort list template reference on TB search page with a much simpler duplicate, isolated from the sorting on other types of templates. This now uses the `sort` variable passed to the template context - going forwards a refactor of the original template to use this simpler strategy would be ideal
- Updated tests to reflect changes and removed the `build_sorting_orders_open_search` deprecated function

## JIRA ticket

N/A

## Screenshots of UI changes

N/A

- [ ] Requires env variable(s) to be updated
