### PR TITLE
AYR-1286 - Anchor links inconsistency

### DIFF
--- a/app/static/src/scss/includes/_breadcrumbs.scss
+++ b/app/static/src/scss/includes/_breadcrumbs.scss
@@ -64,14 +64,6 @@
     }
   }
 
-  [class*="__link"] {
-    text-underline-offset: 3px;
-
-    &:hover {
-      text-decoration-thickness: 3px;
-    }
-  }
-
   &__link--record {
     color: $colour-link-default;
     font-size: 1rem;

--- a/app/static/src/scss/includes/_overrides.scss
+++ b/app/static/src/scss/includes/_overrides.scss
@@ -1,3 +1,11 @@
 legend {
   padding-inline: 0;
 }
+
+a {
+  text-underline-offset: 3px;
+
+  &:hover {
+    text-decoration-thickness: 3px;
+  }
+}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Removed breadcrumb link styling and replaced with an override style that sets underline offset for all links for consistency (the ticket says links with text-underline, however all anchor links have underline by default)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1286

## Screenshots of UI changes

### Before
<img width="657" alt="image" src="https://github.com/user-attachments/assets/23789b48-4ada-4985-8c50-1177a92c6a55">

### After
<img width="656" alt="image" src="https://github.com/user-attachments/assets/e9841abe-3413-4cd6-ad29-0ea1b54e5e9f">


- [ ] Requires env variable(s) to be updated
