### PR TITLE
Install psycopg2-binary, not psycopg2 so doesnt build from source which requires pg_config to be installed

### DIFF
--- a/data_management/opensearch_indexer/requirements.txt
+++ b/data_management/opensearch_indexer/requirements.txt
@@ -5,4 +5,4 @@ SQLAlchemy==2.0.32
 pg8000==1.31.2
 textract==1.6.5
 testing-postgresql==1.3.0
-psycopg2==2.9.10
+psycopg2-binary==2.9.10


### PR DESCRIPTION
## Changes in this PR

Install psycopg2-binary, not psycopg2 so doesnt build from source which requires pg_config to be installed

To fix: https://github.com/nationalarchives/da-ayr-terraform/actions/runs/12790219707/job/35655476686

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1469