### PR TITLE
Revert to reading host from main secret

### DIFF
--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -175,6 +175,7 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
             "FLASKS3_BUCKET_NAME": "test_flasks3_bucket_name",
             "DEFAULT_DATE_FORMAT": "test_default_date_format",
             "SECRET_KEY": "test_secret_key",  # pragma: allowlist secret,
+            "DB_HOST": "test_db_host",
             "DB_SSL_ROOT_CERTIFICATE": "test_db_ssl_root_certificate",
             "DEFAULT_PAGE_SIZE": 10,
             "OPEN_SEARCH_MASTER_ROLE_ARN": "test_master_role_arn",
@@ -189,7 +190,6 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
         {
             "username": "test_db_user",
             "password": "test_db_password",  # pragma: allowlist secret
-            "host": "test_db_host",
             "port": "5432",
             "dbname": "test_db_name",
         }
@@ -292,6 +292,7 @@ def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
             "PERF_TEST": "False",
             "FLASKS3_BUCKET_NAME": "test_flasks3_bucket_name",
             "SECRET_KEY": "test_secret_key",  # pragma: allowlist secret
+            "DB_HOST": "test_db_host",
             "DB_SSL_ROOT_CERTIFICATE": "test_db_ssl_root_certificate",
             "DEFAULT_PAGE_SIZE": 10,
             "CSP_CONNECT_SRC": "",
@@ -313,7 +314,6 @@ def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
         {
             "username": "test_db_user",
             "password": "test_db_password",  # pragma: allowlist secret
-            "host": "test_db_host",
             "port": "5432",
             "dbname": "test_db_name",
         }

--- a/configs/aws_secrets_manager_config.py
+++ b/configs/aws_secrets_manager_config.py
@@ -58,10 +58,6 @@ class AWSSecretsManagerConfig(BaseConfig):
         )
 
     @property
-    def DB_HOST(self):
-        return self._DB_CONFIG["host"]
-
-    @property
     def DB_PORT(self):
         return self._DB_CONFIG["port"]
 


### PR DESCRIPTION
## Changes in this PR

Revert to reading host from main secret, to give option of using db proxy, not only just actual db host since the db creds secret's "host" field refers to the actual db host and a proxy would use that secret as a target, so adding proxy host info there would not be appropriate.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1268