### PR TITLE
AYR-1265 - Table changes & fixes

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -38,6 +38,13 @@ def format_opensearch_field_name(field):
     return OPENSEARCH_FIELD_NAME_MAP[field]
 
 
+def format_number_with_commas(number):
+    """
+    Formats a given number with commas as thousand separators.
+    """
+    return f"{number:,}"
+
+
 def create_app(config_class, database_uri=None):
     app = Flask(__name__, static_url_path="/assets")
     config = config_class()
@@ -54,6 +61,9 @@ def create_app(config_class, database_uri=None):
     )
     app.jinja_env.filters["format_opensearch_field_name"] = (
         format_opensearch_field_name
+    )
+    app.jinja_env.filters["format_number_with_commas"] = (
+        format_number_with_commas
     )
     app.jinja_loader = ChoiceLoader(
         [

--- a/app/static/src/scss/includes/_browse-consignment.scss
+++ b/app/static/src/scss/includes/_browse-consignment.scss
@@ -247,3 +247,7 @@
     display: flex;
   }
 }
+
+.sort-container__form {
+  margin-bottom: 16px;
+}

--- a/app/static/src/scss/includes/_browse-consignment.scss
+++ b/app/static/src/scss/includes/_browse-consignment.scss
@@ -249,5 +249,5 @@
 }
 
 .sort-container__form {
-  margin-bottom: 16px;
+  margin-bottom: 24px;
 }

--- a/app/static/src/scss/includes/_overrides.scss
+++ b/app/static/src/scss/includes/_overrides.scss
@@ -9,3 +9,9 @@ a {
     text-decoration-thickness: 3px;
   }
 }
+
+.govuk-label {
+  &__filter {
+    font-size: 16px;
+  }
+}

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -244,6 +244,7 @@ a.govuk-link {
 
 [class*="hidden-row"] {
   display: none;
+  border-bottom: none;
 }
 
 @for $i from 1 through 15 {
@@ -389,6 +390,11 @@ a.govuk-link {
   &__row {
     &--primary {
       border-top: 1px solid #b1b4b6;
+      border-bottom: none;
+    }
+
+    &--file-name {
+      border-bottom: none;
     }
   }
 }

--- a/app/static/src/scss/includes/_table.scss
+++ b/app/static/src/scss/includes/_table.scss
@@ -2,6 +2,10 @@
   border-bottom: 1px solid #b1b4b6;
   font-size: 1rem;
 
+  &__row {
+    border-bottom: 1px solid $colour-border-normal;
+  }
+
   &__thead {
     border-bottom: 1px solid #b1b4b6;
   }

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -48,7 +48,7 @@
                                 Record total
                             </th>
                             <th scope="col"
-                                class="govuk-table__header govuk-table--right-align govuk-table--invisible-on-mobile">
+                                class="govuk-table__header govuk-table--right-align govuk-table--invisible-on-mobile govuk-table--width-15-percent">
                                 Consignments within series
                             </th>
                         </tr>
@@ -69,7 +69,7 @@
                                         {{ record["last_record_transferred"] }}
                                     </td>
                                     <td class="govuk-table__cell govuk-table--right-align govuk-table--invisible-on-mobile">
-                                        {{ record["records_held"] }}
+                                        {{ record["records_held"] | format_number_with_commas }}
                                     </td>
                                     <td class="govuk-table__cell govuk-table--right-align govuk-table--invisible-on-mobile">
                                         {{ record["consignment_in_series"] }}
@@ -102,7 +102,8 @@
                          alt="">
                 </div>
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="transferring_body_filter">Transferring body</label>
+                    <label class="govuk-label govuk-label__filter"
+                           for="transferring_body_filter">Transferring body</label>
                 </h3>
                 <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
                     <input class="govuk-input"
@@ -118,7 +119,7 @@
             </div>
             <div class="browse-all-filter-container browse-all-filter-container--file-type">
                 <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label" for="series_filter">Series reference</label>
+                    <label class="govuk-label govuk-label__filter" for="series_filter">Series reference</label>
                 </h3>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">
                     <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
@@ -129,7 +130,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label__filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -56,7 +56,7 @@
                                     <td class="govuk-table__cell govuk-table--invisible-on-mobile word-break">{{ record["transferring_body"] }}</td>
                                     <td class="govuk-table__cell govuk-table--invisible-on-mobile">{{ record["series"] }}</td>
                                     <td class="govuk-table__cell govuk-table--on-desktop--right-align">{{ record["last_record_transferred"] }}</td>
-                                    <td class="govuk-table__cell govuk-table--right-align">{{ record["records_held"] }}</td>
+                                    <td class="govuk-table__cell govuk-table--right-align">{{ record["records_held"] | format_number_with_commas }}</td>
                                     <td class="govuk-table__cell">
                                         <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>
                                     </td>

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -47,7 +47,7 @@
                             </th>
                             <th scope="col" class="govuk-table__header govuk-table--right-align">Record total</th>
                             <th scope="col"
-                                class="govuk-table__header govuk-table--right-align govuk-table--width-15-percent">
+                                class="govuk-table__header govuk-table--right-align govuk-table--width-10-percent">
                                 Consignments within series
                             </th>
                         </tr>

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -46,7 +46,10 @@
                                 Last transfer date
                             </th>
                             <th scope="col" class="govuk-table__header govuk-table--right-align">Record total</th>
-                            <th scope="col" class="govuk-table__header govuk-table--right-align">Consignments within series</th>
+                            <th scope="col"
+                                class="govuk-table__header govuk-table--right-align govuk-table--width-15-percent">
+                                Consignments within series
+                            </th>
                         </tr>
                     </thead>
                     <tbody class="govuk-table__body">

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -130,7 +130,7 @@
                                                         </td>
                                                     </tr>
                                                     {% if record['highlight'].keys() | list | first != 'file_name' %}
-                                                        <tr class="govuk-table__row">
+                                                        <tr class="govuk-table__row govuk-table__row--file-name">
                                                             <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">File name</td>
                                                             <td class="govuk-table__cell govuk-table__cell--no-pt">
                                                                 <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -2,6 +2,7 @@ import pytest
 
 from app import (
     clean_tags_and_replace_highlight_tag,
+    format_number_with_commas,
     format_opensearch_field_name,
     null_to_dash,
 )
@@ -129,3 +130,20 @@ def test_clean_tags(input_text, expected_output):
 )
 def test_format_opensearch_field_name(field, expected):
     assert format_opensearch_field_name(field) == expected
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        (1000, "1,000"),
+        (33000, "33,000"),
+        (123456789, "123,456,789"),
+        (0, "0"),
+        (-1000, "-1,000"),
+        (-9876543, "-9,876,543"),
+        (1000000.50, "1,000,000.5"),
+        (99999.999, "99,999.999"),
+    ],
+)
+def test_format_number_with_commas(input_value, expected_output):
+    assert format_number_with_commas(input_value) == expected_output


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Record number values should now be comma separated
- Gray lines between rows
- Labels for filters inputs in filters should now be 16px
- Added more space between top sort and table
- Reduced column space for “Consignment within series”

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1265

## Screenshots of UI changes

### Before
Browse all
<img width="993" alt="image" src="https://github.com/user-attachments/assets/fc364bd1-321a-4985-9b66-f29d60a1a79d" />

Browse transferring body
<img width="1023" alt="image" src="https://github.com/user-attachments/assets/25660dd2-eaf3-451c-87d4-32d77302273c" />


Browse series
<img width="1013" alt="image" src="https://github.com/user-attachments/assets/a8d7efb5-6a64-49dc-a82b-03d9f02b834a" />

### After
Browse all
<img width="981" alt="image" src="https://github.com/user-attachments/assets/4757519b-7153-435f-b8c1-b3edcc2a6c3b" />

Browse transferring body
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/f8857cb9-96ef-4141-b3ea-132dc81bc2da" />

Browse series
<img width="986" alt="image" src="https://github.com/user-attachments/assets/72c3e755-5a0a-4e20-83eb-6dc4ad237da4" />




- [ ] Requires env variable(s) to be updated
