### PR TITLE
AYR-1461 - Record page breadcrumbs bottom margin

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -30,7 +30,7 @@
 
 .govuk-grid-column-full {
   &__page-nav {
-    margin-bottom: 3rem;
+    margin-bottom: 1rem;
     padding-left: 2rem;
   }
 }
@@ -292,10 +292,6 @@
 .mode {
   width: 3rem;
   font-size: 1rem;
-}
-
-.universal-viewer {
-  padding-bottom: 1rem;
 }
 
 .uv {

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -148,9 +148,9 @@ class TestRecord:
 
         expected_breadcrumbs_html = f"""
         <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+        <p class="govuk-body browse__body">You are viewing</p>
 
-        <div class="govuk-breadcrumbs govuk-breadcrumbs--file">
+        <div class="govuk-breadcrumbs">
             <ol class="govuk-breadcrumbs__list">
                 <li class="govuk-breadcrumbs__list-item">
                 <a class="govuk-breadcrumbs__link--record" href="{browse_all_route_url}">All available records</a>

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -148,9 +148,9 @@ class TestRecord:
 
         expected_breadcrumbs_html = f"""
         <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-        <p class="govuk-body browse__body">You are viewing</p>
+        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
 
-        <div class="govuk-breadcrumbs">
+        <div class="govuk-breadcrumbs govuk-breadcrumbs--file">
             <ol class="govuk-breadcrumbs__list">
                 <li class="govuk-breadcrumbs__list-item">
                 <a class="govuk-breadcrumbs__link--record" href="{browse_all_route_url}">All available records</a>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Reduced the distance between the breadcrumbs and UV viewer on record page
## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1461
## Screenshots of UI changes

### Before
<img width="971" alt="image" src="https://github.com/user-attachments/assets/3493e4d8-813a-4023-9131-475e4a353327" />

### After
<img width="988" alt="image" src="https://github.com/user-attachments/assets/5e8a0c70-8b7d-42ab-9997-1bb323000fe4" />

- [ ] Requires env variable(s) to be updated
