### PR TITLE
AYR-1460 - Record page text inconsistencies 

### DIFF
--- a/app/templates/main/breadcrumb.html
+++ b/app/templates/main/breadcrumb.html
@@ -3,7 +3,7 @@
 {% set series_url = browse_url ~ "/series/" %}
 {% set consignment_url = browse_url ~ "/consignment/" %}
 {% set search_result_summary_url = "/search_results_summary?query=" %}
-<div class="govuk-breadcrumbs  {{ 'govuk-breadcrumbs--file' if 'record' in dict }}">
+<div class="govuk-breadcrumbs">
     <ol class="govuk-breadcrumbs__list">
         {% for key, value in dict.items() %}
             {% if loop.index != dict|length %}

--- a/app/templates/main/record.html
+++ b/app/templates/main/record.html
@@ -59,7 +59,7 @@
             <div class="govuk-grid-row govuk-grid-row--record-view mobile-record-layout">
                 <div class="govuk-grid-row govuk-grid-row-record">
                     <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-                        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+                        <p class="govuk-body browse__body">You are viewing</p>
                         {% with dict = breadcrumbs %}
                             {% set record_breadcrumbs = True %}
                             {% include "breadcrumb.html" %}

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -148,9 +148,9 @@ class TestRecord:
 
         expected_breadcrumbs_html = f"""
         <div class="govuk-grid-column-full govuk-grid-column-full__page-nav">
-        <p class="govuk-body-m govuk-body-m__record-view">You are viewing</p>
+        <p class="govuk-body browse__body">You are viewing</p>
 
-        <div class="govuk-breadcrumbs govuk-breadcrumbs--file">
+        <div class="govuk-breadcrumbs">
             <ol class="govuk-breadcrumbs__list">
                 <li class="govuk-breadcrumbs__list-item">
                 <a class="govuk-breadcrumbs__link--record" href="{browse_all_route_url}">All available records</a>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Adjusted styles for "You are viewing" text on record page to be consistent with all the other pages
- Also adjusted styles for breadcrumbs to be consistent with other pages - this is because 1) the gap between the text above it and itself wasnt consistent, 2) the space between the above breadcrumbs and the file name seemed too small - an in-line layout seems more natural

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1460

## Screenshots of UI changes

### Before
<img width="996" alt="image" src="https://github.com/user-attachments/assets/c0a255d5-6003-425f-b70f-61610e167a11" />

### After
<img width="1011" alt="image" src="https://github.com/user-attachments/assets/bb144d31-b46b-46fc-a5e3-5854077c3c9c" />


- [ ] Requires env variable(s) to be updated
