### PR TITLE
Update opensearch indexer to use separate db secret

### DIFF
--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -175,7 +175,6 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
             "FLASKS3_BUCKET_NAME": "test_flasks3_bucket_name",
             "DEFAULT_DATE_FORMAT": "test_default_date_format",
             "SECRET_KEY": "test_secret_key",  # pragma: allowlist secret,
-            "DB_HOST": "test_db_host",
             "DB_SSL_ROOT_CERTIFICATE": "test_db_ssl_root_certificate",
             "DEFAULT_PAGE_SIZE": 10,
             "OPEN_SEARCH_MASTER_ROLE_ARN": "test_master_role_arn",
@@ -191,6 +190,7 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
             "username": "test_db_user",
             "password": "test_db_password",  # pragma: allowlist secret
             "port": "5432",
+            "proxy": "test_db_host",
             "dbname": "test_db_name",
         }
     )
@@ -292,7 +292,6 @@ def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
             "PERF_TEST": "False",
             "FLASKS3_BUCKET_NAME": "test_flasks3_bucket_name",
             "SECRET_KEY": "test_secret_key",  # pragma: allowlist secret
-            "DB_HOST": "test_db_host",
             "DB_SSL_ROOT_CERTIFICATE": "test_db_ssl_root_certificate",
             "DEFAULT_PAGE_SIZE": 10,
             "CSP_CONNECT_SRC": "",
@@ -315,6 +314,7 @@ def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
             "username": "test_db_user",
             "password": "test_db_password",  # pragma: allowlist secret
             "port": "5432",
+            "proxy": "test_db_host",
             "dbname": "test_db_name",
         }
     )

--- a/configs/aws_secrets_manager_config.py
+++ b/configs/aws_secrets_manager_config.py
@@ -58,6 +58,10 @@ class AWSSecretsManagerConfig(BaseConfig):
         )
 
     @property
+    def DB_HOST(self):
+        return self._DB_CONFIG["proxy"]
+
+    @property
     def DB_PORT(self):
         return self._DB_CONFIG["port"]
 

--- a/data_management/opensearch_indexer/opensearch_indexer/aws_helpers.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/aws_helpers.py
@@ -22,11 +22,11 @@ def get_secret_data(secret_id: str) -> Dict[str, Any]:
     return json.loads(secret_response["SecretString"])
 
 
-def _build_db_url(secret_string: Dict[str, Any]) -> str:
+def _build_db_url(db_secret_string: Dict[str, Any]) -> str:
     return (
         "postgresql+pg8000://"
-        f'{secret_string["DB_USER"]}:{quote_plus(secret_string["DB_PASSWORD"])}'
-        f'@{secret_string["DB_HOST"]}:{secret_string["DB_PORT"]}/{secret_string["DB_NAME"]}'
+        f'{db_secret_string["username"]}:{quote_plus(db_secret_string["password"])}'
+        f'@{db_secret_string["proxy"]}:{db_secret_string["port"]}/{db_secret_string["dbname"]}'
     )
 
 

--- a/data_management/opensearch_indexer/opensearch_indexer/index_consignment/bulk_index_consignment.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/index_consignment/bulk_index_consignment.py
@@ -30,7 +30,7 @@ class ConsignmentBulkIndexError(Exception):
 
 
 def bulk_index_consignment_from_aws(
-    consignment_reference: str, secret_id: str
+    consignment_reference: str, secret_id: str, db_secret_id: str
 ) -> None:
     """
     Retrieve credentials and host information from AWS Secrets Manager, fetch consignment data,
@@ -40,13 +40,15 @@ def bulk_index_consignment_from_aws(
         consignment_reference (str): The reference identifier for the consignment.
         secret_id (str): The ID of the AWS secret storing s3 record bucket name,
             and database and OpenSearch credentials.
+        db_secret_id (str): The ID of the AWS secret storing database credentials.
 
     Returns:
         None
     """
     secret_string = get_secret_data(secret_id)
+    db_secret_string = get_secret_data(db_secret_id)
     bucket_name = secret_string["RECORD_BUCKET_NAME"]
-    database_url = _build_db_url(secret_string)
+    database_url = _build_db_url(db_secret_string)
     open_search_host_url = secret_string["OPEN_SEARCH_HOST"]
     open_search_http_auth = _get_opensearch_auth(secret_string)
     open_search_bulk_index_timeout = int(

--- a/data_management/opensearch_indexer/opensearch_indexer/index_consignment/lambda_function.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/index_consignment/lambda_function.py
@@ -51,7 +51,18 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
         logger.error(error_message)
         raise Exception(error_message)
 
+    db_secret_id = os.getenv("DB_SECRET_ID")
+
+    if not db_secret_id:
+        error_message = (
+            "Missing DB_SECRET_ID environment variable required for indexing"
+        )
+        logger.error(error_message)
+        raise Exception(error_message)
+
     # Log and process the consignment reference
     logger.info(f"Processing consignment reference: {consignment_reference}")
-    bulk_index_consignment_from_aws(consignment_reference, secret_id)
+    bulk_index_consignment_from_aws(
+        consignment_reference, secret_id, db_secret_id
+    )
     logger.info("Lambda completed")

--- a/data_management/opensearch_indexer/opensearch_indexer/index_file_content_and_metadata_in_opensearch_from_aws.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/index_file_content_and_metadata_in_opensearch_from_aws.py
@@ -15,15 +15,16 @@ logger.setLevel(logging.INFO)
 
 
 def index_file_content_and_metadata_in_opensearch_from_aws(
-    bucket_name, object_key, secret_id
+    bucket_name, object_key, secret_id, db_secret_id
 ):
     secret_string = get_secret_data(secret_id)
+    db_secret_string = get_secret_data(db_secret_id)
 
     file_id = object_key.split("/")[-1]
 
     file_stream = get_s3_file(bucket_name, object_key)
 
-    database_url = _build_db_url(secret_string)
+    database_url = _build_db_url(db_secret_string)
 
     open_search_host_url = secret_string["OPEN_SEARCH_HOST"]
     open_search_http_auth = _get_opensearch_auth(secret_string)

--- a/data_management/opensearch_indexer/opensearch_indexer/lambda_function.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/lambda_function.py
@@ -16,8 +16,9 @@ def lambda_handler(event: Dict[str, Any], context: Any) -> None:
     logger.info("Event received: %s", json.dumps(event))
     bucket_name, object_key = _extract_s3_event_info(event)
     secret_id = os.getenv("SECRET_ID")
+    db_secret_id = os.getenv("DB_SECRET_ID")
     index_file_content_and_metadata_in_opensearch_from_aws(
-        bucket_name, object_key, secret_id
+        bucket_name, object_key, secret_id, db_secret_id
     )
     logger.info("Lambda complete")
 

--- a/data_management/opensearch_indexer/tests/test_consignment_lambda_handler.py
+++ b/data_management/opensearch_indexer/tests/test_consignment_lambda_handler.py
@@ -66,8 +66,10 @@ def test_lambda_handler_invokes_bulk_index_with_correct_file_data(
     session = Session()
 
     secret_name = "test_vars"  # pragma: allowlist secret
+    db_secret_name = "test_db_vars"  # pragma: allowlist secret
 
     monkeypatch.setenv("SECRET_ID", secret_name)
+    monkeypatch.setenv("DB_SECRET_ID", db_secret_name)
 
     bucket_name = "test_bucket"
 
@@ -76,16 +78,21 @@ def test_lambda_handler_invokes_bulk_index_with_correct_file_data(
     )
     secret_string = json.dumps(
         {
-            "DB_USER": "postgres",
-            "DB_PASSWORD": "",
-            "DB_HOST": "127.0.0.1",
-            "DB_PORT": database.settings["port"],
-            "DB_NAME": "test",
             "AWS_REGION": "eu-west-2",
             "RECORD_BUCKET_NAME": bucket_name,
             "OPEN_SEARCH_HOST": "https://test-opensearch.com",
             "OPEN_SEARCH_MASTER_ROLE_ARN": opensearch_master_role_arn,
             "OPEN_SEARCH_BULK_INDEX_TIMEOUT": 600,
+        }
+    )
+
+    db_secret_string = json.dumps(
+        {
+            "username": "postgres",
+            "password": "",
+            "proxy": "127.0.0.1",
+            "port": database.settings["port"],
+            "dbname": "test",
         }
     )
 
@@ -95,6 +102,9 @@ def test_lambda_handler_invokes_bulk_index_with_correct_file_data(
 
     secretsmanager_client.create_secret(
         Name=secret_name, SecretString=secret_string
+    )
+    secretsmanager_client.create_secret(
+        Name=db_secret_name, SecretString=db_secret_string
     )
 
     s3_client = boto3.client("s3", region_name="us-east-1")

--- a/data_management/opensearch_indexer/tests/test_lambda_handler.py
+++ b/data_management/opensearch_indexer/tests/test_lambda_handler.py
@@ -47,7 +47,9 @@ def test_lambda_handler_calls_index_file_content_and_metadata_in_opensearch(
       - An AWS4Auth object with the correct credentials determined by assuming the IAM role.
     """
     secret_name = "test_vars"  # pragma: allowlist secret
+    db_secret_name = "test_db_vars"  # pragma: allowlist secret
     monkeypatch.setenv("SECRET_ID", secret_name)
+    monkeypatch.setenv("DB_SECRET_ID", db_secret_name)
 
     opensearch_master_role_arn = (
         "arn:aws:iam::123456789012:role/test-opensearch-role"
@@ -57,15 +59,20 @@ def test_lambda_handler_calls_index_file_content_and_metadata_in_opensearch(
 
     secret_string = json.dumps(
         {
-            "DB_USER": "testuser",
-            "DB_PASSWORD": "testpassword",  # pragma: allowlist secret
-            "DB_HOST": "testhost",
-            "DB_PORT": "5432",
-            "DB_NAME": "testdb",
             "OPEN_SEARCH_HOST": "https://test-opensearch.com",
             "OPEN_SEARCH_MASTER_ROLE_ARN": opensearch_master_role_arn,
             "AWS_REGION": "eu-west-2",
             "RECORD_BUCKET_NAME": bucket_name,
+        }
+    )
+
+    db_secret_string = json.dumps(
+        {
+            "username": "testuser",
+            "password": "testpassword",  # pragma: allowlist secret
+            "proxy": "testhost",
+            "port": 5432,
+            "dbname": "testdb",
         }
     )
 
@@ -75,6 +82,9 @@ def test_lambda_handler_calls_index_file_content_and_metadata_in_opensearch(
 
     secretsmanager_client.create_secret(
         Name=secret_name, SecretString=secret_string
+    )
+    secretsmanager_client.create_secret(
+        Name=db_secret_name, SecretString=db_secret_string
     )
 
     s3_client = boto3.client("s3", region_name="us-east-1")


### PR DESCRIPTION
## Changes in this PR

Update opensearch indexer to use separate db secret
Use db secret for DB_AWSSecretsManagerConfig.DB_HOST

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1268