### PR TITLE
AYR-1441 -  Missing footer logo alt text

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -68,7 +68,7 @@
                          height="100px"
                          width="100px"
                          src="{{ url_for('static', filename='image/the-national-archives-logo.svg') }}"
-                         alt="">
+                         alt="The National Archives logo">
                 </div>
                 <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
                     <h2 class="govuk-visually-hidden">Support links</h2>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Added alt text to footer TNA logo of "The National Archives logo"

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1441

## Screenshots of UI changes

N/A

- [ ] Requires env variable(s) to be updated
