### PR TITLE
Update opensearch indexer lambda dockerfile dependencies

### DIFF
--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -1,13 +1,24 @@
-FROM public.ecr.aws/lambda/python:3.11
-# use python 3.11, not 3.12 due to issues with textract on 3.12 at the moment
+FROM python:3.13.2
 
-RUN yum install -y python-dev libxml2-dev libxslt1-dev antiword unrtf poppler-utils pstotext tesseract-ocr \
-flac ffmpeg lame libmad0 libsox-fmt-mp3 sox libjpeg-dev swig
+RUN apt-get update && apt-get install -y \
+    python-dev-is-python3 \
+    libxml2-dev libxslt1-dev \
+    antiword unrtf poppler-utils tesseract-ocr \
+    flac ffmpeg lame libmad0 libsox-fmt-mp3 sox \
+    libjpeg-dev swig
+
 
 COPY requirements.txt ${LAMBDA_TASK_ROOT}
 
-RUN pip install -r requirements.txt
+# Install the function's dependencies
+RUN pip install \
+        awslambdaric \
+        -r requirements.txt
 
 COPY opensearch_indexer/ ${LAMBDA_TASK_ROOT}/opensearch_indexer
 
+# Set runtime interface client as default command for the container runtime
+ENTRYPOINT [ "/usr/local/bin/python", "-m", "awslambdaric" ]
+
+# Pass the name of the function handler as an argument to the runtime
 CMD [ "opensearch_indexer.index_consignment.lambda_function.lambda_handler" ]

--- a/data_management/opensearch_indexer/requirements.txt
+++ b/data_management/opensearch_indexer/requirements.txt
@@ -3,6 +3,7 @@ opensearch-py==2.7.1
 requests-aws4auth==1.3.1
 SQLAlchemy==2.0.32
 pg8000==1.31.2
-textract==1.6.5
+textract-py3==2.1.0
+xlrd==1.2.0
 testing-postgresql==1.3.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
## Changes in this PR

- Update opensearch indexer lambda dockerfile base image to custom image (and thus explicit awslambdric calling)
- Upgrade to ptypon 3.13 and Use temporary fork of textract https://pypi.org/project/textract-py3/ which has fixed the dep issue with python 3.12 and above (see https://github.com/deanmalmgren/textract/issues/476#issuecomment-1676351111)

Reasoning:

bug found in prod where antiword was not installed when trying to extract text from .doc files, and similarly on staging for tesseract-ocr (on pdfs I think).

We were previously using an amazon linux base docker image. They only allow certain restricted packages on that distro. Things like antiword and tesseract-ocr were not actually being installed due to yum being silent when it could not find anything to install.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1526
https://national-archives.atlassian.net/browse/AYR-1527