### PR TITLE
AYR-1532 - Modifications to no results found page

### DIFF
--- a/app/templates/main/no-results-found.html
+++ b/app/templates/main/no-results-found.html
@@ -1,5 +1,4 @@
-<div class="govuk-!-padding-bottom-9"></div>
-<div class="govuk-!-padding-bottom-5"></div>
+<div class="govuk-!-padding-bottom-7"></div>
 <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds__search-results-summary">
     <div class="main-content" id="main-content" role="main">
         <h2 class="govuk-heading-m">Help with your search</h2>
@@ -12,7 +11,9 @@
                     filters.
                 {% endif %}
             </li>
-            <li>Alternatively, use the breadcrumbs to navigate back to the browse view.</li>
+            <li>
+                Alternatively, use the breadcrumbs to navigate back to the <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
+            </li>
         </ul>
     </div>
 </div>

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -18,12 +18,14 @@
                         No results found
                     {% endif %}
                 </h1>
-                <h2 class="govuk-body browse__body">You are viewing</h2>
-                {% set breadcrumbs = {"everything": "All available records", "body": "Results summary"} %}
-                <!-- BREAD CRUMB -->
-                {% with dict = breadcrumbs %}
-                    {% include "breadcrumb.html" %}
-                {% endwith %}
+                {% if num_records_found > 0 %}
+                    <h2 class="govuk-body browse__body">You are viewing</h2>
+                    {% set breadcrumbs = {"everything": "All available records", "body": "Results summary"} %}
+                    <!-- BREAD CRUMB -->
+                    {% with dict = breadcrumbs %}
+                        {% include "breadcrumb.html" %}
+                    {% endwith %}
+                {% endif %}
                 {% if num_records_found > 0 %}
                     <div class="govuk-grid-column-two-thirds govuk-grid-column-two-thirds__search-results-summary">
                         <table class="govuk-table browse-grid__table govuk-!-margin-top-8"

--- a/app/tests/test_browse.py
+++ b/app/tests/test_browse.py
@@ -118,7 +118,8 @@ class TestBrowse:
                     filters.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200

--- a/app/tests/test_browse_consignment.py
+++ b/app/tests/test_browse_consignment.py
@@ -131,7 +131,8 @@ class TestConsignment:
                     filters.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200

--- a/app/tests/test_browse_series.py
+++ b/app/tests/test_browse_series.py
@@ -117,7 +117,8 @@ class TestSeries:
                     filters.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200

--- a/app/tests/test_browse_transferring_body.py
+++ b/app/tests/test_browse_transferring_body.py
@@ -125,7 +125,8 @@ class TestBrowseTransferringBody:
                     filters.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -273,7 +273,8 @@ class TestSearchResultsSummary:
                     search terms.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200
@@ -705,7 +706,8 @@ class TestSearchTransferringBody:
                     search terms.
         </li>
         <li>
-        Alternatively, use the breadcrumbs to navigate back to the browse view.
+        Alternatively, use the breadcrumbs to navigate back to the
+        <a class="govuk-link govuk-link--no-visited-state" href="/browse">browse view</a>.
         </li>
         </ul>"""
         assert response.status_code == 200


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- On `search_results_summary` page the breadcrumbs are now removed if there are not results
- The padding at the top of the `no_results_found` template is now been reduced
- "browse view" is now an anchor that leads to`/browse`

Note: the breadcrumbs are added in each individual page, meaning that they still exist inside other pages when there are no results, this made sense to me for `search/transferring_body` where the transferring body thats currently being searched within is important and should be displayed to the user @Terry-Price let me know your view on this

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1532

## Screenshots of UI changes

### Before
<img width="967" alt="image" src="https://github.com/user-attachments/assets/f39d573a-9cbe-4253-ad56-1576f53daffb" />

### After
<img width="978" alt="image" src="https://github.com/user-attachments/assets/e6c8ad71-6b9c-40d0-8695-929124c211d5" />

- [ ] Requires env variable(s) to be updated
