### PR TITLE
AYR-1455 - Changes to dates filters styling

### DIFF
--- a/app/static/src/scss/includes/_browse-consignment.scss
+++ b/app/static/src/scss/includes/_browse-consignment.scss
@@ -162,6 +162,10 @@
     margin-bottom: 0;
   }
 
+  &--dates {
+    margin-bottom: 1rem;
+  }
+
   &__consignment-form-group {
     display: inline-block;
     margin-bottom: 0;

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -130,7 +130,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label__filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -87,7 +87,7 @@
                          class="browse-all-filter__icon"
                          alt="">
                 </div>
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -111,7 +111,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/date-filters.html
+++ b/app/templates/main/date-filters.html
@@ -1,6 +1,5 @@
-<br>
 <div class="browse-all-filter-from-dates">
-    <div class="govuk-form-group {% if date_validation_errors %}{% if date_validation_errors.get('date_from') %}govuk-form-group--error{% endif %}{% endif %}">
+    <div class="{% if date_validation_errors %}{% if date_validation_errors.get('date_from') %}govuk-form-group--error{% endif %}{% endif %}">
         <fieldset class="govuk-fieldset govuk-fieldset--date-from" role="group">
             <legend aria-label="{% if view_type=='consignment' %}Record date from{% else %}Date consignment transferred from{% endif %}">
                 <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date from</h3>
@@ -12,7 +11,7 @@
             {% endif %}
             <div class="govuk-date-input govuk-date-input--browse-all-date-from">
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_from_day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if date_error_fields %}{% if 'date_from_day' in date_error_fields or 'date_from' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"
@@ -25,7 +24,7 @@
                     </div>
                 </div>
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_from_month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if date_error_fields %}{% if 'date_from_month' in date_error_fields or 'date_from' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"
@@ -38,7 +37,7 @@
                     </div>
                 </div>
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_from_year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4 {% if date_error_fields %}{% if 'date_from_year' in date_error_fields or 'date_from' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"
@@ -55,7 +54,7 @@
     </div>
 </div>
 <div class="browse-all-filter-to-dates">
-    <div class="govuk-form-group {% if date_validation_errors %} {% if date_validation_errors.get('date_to') %}govuk-form-group--error{% endif %}{% endif %}">
+    <div class="{% if date_validation_errors %} {% if date_validation_errors.get('date_to') %}govuk-form-group--error{% endif %}{% endif %}">
         <fieldset class="govuk-fieldset govuk-fieldset--date-to" role="group">
             <legend aria-label="{% if view_type=='consignment' %}Record date to{% else %}Date consignment transferred to{% endif %}">
                 <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date to</h3>
@@ -67,7 +66,7 @@
             {% endif %}
             <div class="govuk-date-input govuk-date-input--browse-all-date-to">
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_to_day">Day</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if date_error_fields %}{% if 'date_to_day' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"
@@ -80,7 +79,7 @@
                     </div>
                 </div>
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_to_month">Month</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-2 {% if date_error_fields %}{% if 'date_to_month' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"
@@ -93,7 +92,7 @@
                     </div>
                 </div>
                 <div class="govuk-date-input__item govuk-date-input__item--browse-all">
-                    <div class="govuk-form-group">
+                    <div class="govuk-form-group govuk-form-group--dates">
                         <label class="govuk-label govuk-date-input__label filters-form__date__label"
                                for="date_to_year">Year</label>
                         <input class="govuk-input govuk-date-input__input govuk-input--width-4 {% if date_error_fields %}{% if 'date_to_year' in date_error_fields %}govuk-input--error{% endif %}{% endif %}"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Modified the `Transfer date` label across pages to match the styling of all the other labels we use in weight and size
- Removed the use of a <br> tag between the `Transfer date` label 
- By removing the tag mentioned above the gap between the `Transfer date` label and the input group below it has been decreased 
- Reduced the spacing between the two groups of date inputs to 1 rem (plus the padding of the label below it)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1455

## Screenshots of UI changes

### Before
<img width="310" alt="image" src="https://github.com/user-attachments/assets/30b1ea7e-cf27-4e05-8523-7a88eeaa7b6a" />

### After
<img width="318" alt="image" src="https://github.com/user-attachments/assets/16472bd9-3fbe-4308-aef6-3a4a41349931" />

- [ ] Requires env variable(s) to be updated
