### PR TITLE
revise highlighting params

### DIFF
--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -378,7 +378,13 @@ def build_search_transferring_body_query(
             "pre_tags": [f"<{highlight_tag}>"],
             "post_tags": [f"</{highlight_tag}>"],
             "fields": {
-                "*": {},
+                "*": {
+                    "type": "unified",  # default
+                    "fragment_size": 200,  # limit amount of text
+                    "number_of_fragments": 1,  # remove fragment splits
+                    "phrase_limit": 256,  # default
+                    "require_field_match": False,  # default, highlights only in fields that were searched
+                },
             },
         },
     }

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -379,7 +379,7 @@ def build_search_transferring_body_query(
             "post_tags": [f"</{highlight_tag}>"],
             "type": "unified",  # default
             "fragment_size": 200,  # limit amount of text
-            "number_of_fragments": 0,  # remove fragment splits
+            "number_of_fragments": 0,
             "phrase_limit": 256,  # default
             "require_field_match": False,  # default, highlights only in fields that were searched
             "boundary_scanner": "sentence",

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -377,17 +377,18 @@ def build_search_transferring_body_query(
         "highlight": {
             "pre_tags": [f"<{highlight_tag}>"],
             "post_tags": [f"</{highlight_tag}>"],
-            "fields": {
-                "*": {
-                    "type": "unified",  # default
-                    "fragment_size": 200,  # limit amount of text
-                    "number_of_fragments": 1,  # remove fragment splits
-                    "phrase_limit": 256,  # default
-                    "require_field_match": False,  # default, highlights only in fields that were searched
-                },
-            },
+            "type": "unified",  # default
+            "fragment_size": 200,  # limit amount of text
+            "number_of_fragments": 0,  # remove fragment splits
+            "phrase_limit": 256,  # default
+            "require_field_match": False,  # default, highlights only in fields that were searched
+            "boundary_scanner": "sentence",
+            "boundary_scanner_locale": "en",
+            "order": "score",
+            "fields": {"*": {}},
         },
     }
+
     return {**dsl_query, **highlighting}
 
 

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -379,7 +379,7 @@ def build_search_transferring_body_query(
             "post_tags": [f"</{highlight_tag}>"],
             "type": "unified",  # default
             "fragment_size": 200,  # limit amount of text
-            "number_of_fragments": 0,
+            "number_of_fragments": 5,  # default
             "phrase_limit": 256,  # default
             "require_field_match": False,  # default, highlights only in fields that were searched
             "boundary_scanner": "sentence",

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -606,7 +606,7 @@ def test_build_search_transferring_body_query():
             "post_tags": ["</test_highlight_key>"],
             "type": "unified",
             "fragment_size": 200,
-            "number_of_fragments": 0,
+            "number_of_fragments": 5,
             "phrase_limit": 256,
             "require_field_match": False,
             "boundary_scanner": "sentence",

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -604,15 +604,15 @@ def test_build_search_transferring_body_query():
         "highlight": {
             "pre_tags": ["<test_highlight_key>"],
             "post_tags": ["</test_highlight_key>"],
-            "fields": {
-                "*": {
-                    "fragment_size": 200,
-                    "number_of_fragments": 1,
-                    "phrase_limit": 256,
-                    "require_field_match": False,
-                    "type": "unified",
-                },
-            },
+            "type": "unified",
+            "fragment_size": 200,
+            "number_of_fragments": 0,
+            "phrase_limit": 256,
+            "require_field_match": False,
+            "boundary_scanner": "sentence",
+            "boundary_scanner_locale": "en",
+            "order": "score",
+            "fields": {"*": {}},
         },
     }
 

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -605,7 +605,13 @@ def test_build_search_transferring_body_query():
             "pre_tags": ["<test_highlight_key>"],
             "post_tags": ["</test_highlight_key>"],
             "fields": {
-                "*": {},
+                "*": {
+                    "fragment_size": 200,
+                    "number_of_fragments": 1,
+                    "phrase_limit": 256,
+                    "require_field_match": False,
+                    "type": "unified",
+                },
             },
         },
     }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Set highlighting params to prevent search result splitting
```
"type": "unified",  # default
"fragment_size": 200,  # limit amount of text
"number_of_fragments": 1,  # remove fragment splits
"phrase_limit": 256,  # default
"require_field_match": False,  # default, highlights only in fields that were searched
```

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1280


## Screenshots of UI changes

### Before
<img width="1596" alt="Screenshot 2025-03-13 at 17 00 15" src="https://github.com/user-attachments/assets/28ddfb48-cc08-4ff9-b9d2-77f22ac09b59" />


### After
<img width="1595" alt="Screenshot 2025-03-13 at 17 00 45" src="https://github.com/user-attachments/assets/56411c46-dbb2-458e-bb25-67fb4bf03df4" />



- [ ] Requires env variable(s) to be updated
