### PR TITLE
AYR-1520 - Spacing between browse all page elements

### DIFF
--- a/app/static/src/scss/includes/_browse-all.scss
+++ b/app/static/src/scss/includes/_browse-all.scss
@@ -154,6 +154,10 @@
     &--browse-all-signpost {
       @include signposting-text;
       margin-top: 15px;
+
+      @media screen and (width <= $breakpoint-medium) {
+        margin-top: 5px;
+      }
     }
   }
 

--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -323,10 +323,6 @@
       display: none;
     }
 
-    &__body {
-      margin-bottom: 0.5rem !important;
-    }
-
     &__table__series-row {
       margin-bottom: 0.5rem;
     }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- On mobile screens, reduced the space between ‘You are viewing’ and 'All available records to 5px

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1520

## Screenshots of UI changes

### Before
<img width="367" alt="image" src="https://github.com/user-attachments/assets/347d88b4-53a0-4a57-93e7-ef7d34a5e91d" />


### After
<img width="387" alt="image" src="https://github.com/user-attachments/assets/80083158-64ab-4ce5-b01a-acde8512ff34" />

- [ ] Requires env variable(s) to be updated
