### PR TITLE
AYR-1523 - Reduce font size of signpost text on mobile

### DIFF
--- a/app/static/src/scss/includes/_signposting-text.scss
+++ b/app/static/src/scss/includes/_signposting-text.scss
@@ -3,4 +3,8 @@
   font-size: 1.5rem;
   text-decoration: None;
   line-height: 1.3rem;
+
+  @media screen and (width <= $breakpoint-medium) {
+    font-size: 1.25rem;
+  }
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- On mobile, reduced the font size of the mixin for the signpost text to be 1.25rem (this is so all instances look the same)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1523

## Screenshots of UI changes

### Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/8948b0d8-240f-4d19-a00a-d4764c0ec914" />

### After
<img width="401" alt="image" src="https://github.com/user-attachments/assets/93cb626a-7109-474d-a619-4709ecacaf69" />

- [ ] Requires env variable(s) to be updated
