### PR TITLE
AYR-1524 - Record total column width on mobile

### DIFF
--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -43,7 +43,7 @@
                                 Last transfer date
                             </th>
                             <th scope="col"
-                                class="govuk-table__header govuk-table--right-align govuk-table--on-mobile--width-30-percent">
+                                class="govuk-table__header govuk-table--right-align govuk-table--on-mobile--width-20-percent">
                                 Record total
                             </th>
                             <th scope="col" class="govuk-table__header">Consignment reference</th>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- On mobile, reduced the width of the record total column on the series browse page to 20% from 30%

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1524

## Screenshots of UI changes

### Before
<img width="395" alt="image" src="https://github.com/user-attachments/assets/5c99e479-3d75-45d3-ac74-d990121ae697" />

### After
<img width="396" alt="image" src="https://github.com/user-attachments/assets/156a0817-2117-4a22-a6b9-65a8113e2552" />

- [ ] Requires env variable(s) to be updated
