### PR TITLE
AYR-1487 - Deepen UV window

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,9 +118,9 @@
         "filename": "app/templates/main/record-view.html",
         "hashed_secret": "b49139ad0afdb487229b83c6d3bda217b7e14977",
         "is_verified": false,
-        "line_number": 15
+        "line_number": 7
       }
     ]
   },
-  "generated_at": "2024-09-02T20:02:22Z"
+  "generated_at": "2025-03-17T06:28:13Z"
 }

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -5,15 +5,13 @@ function initUniversalViewer() {
   const data = {
     manifest: manifest_url,
     embedded: true,
-    config: {
-      options: {
-        defaultZoomLevel: 2,
-      },
-    },
   };
 
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
+    config.modules.openSeadragonCenterPanel.options = {
+      defaultZoomLevel: 2,
+    };
     config.modules.centerPanel.options = {
       usePdfJs: true,
     };

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -5,13 +5,17 @@ function initUniversalViewer() {
   const data = {
     manifest: manifest_url,
     embedded: true,
+    config: {
+      options: {
+        defaultZoomLevel: 2,
+      },
+    },
   };
 
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
     config.modules.centerPanel.options = {
       usePdfJs: true,
-      defaultZoomLevel: 2,
     };
     config.modules.footerPanel.options = {
       downloadEnabled: false,

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -9,9 +9,6 @@ function initUniversalViewer() {
 
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
-    config.modules.openSeadragonCenterPanel.options = {
-      defaultZoomLevel: 2,
-    };
     config.modules.centerPanel.options = {
       usePdfJs: true,
     };

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -10,13 +10,13 @@ function initUniversalViewer() {
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
     config.modules.centerPanel.options.usePdfJs = true;
+    config.modules.centerPanel.options.defaultZoomLevel = 2;
     config.modules.footerPanel.options = {
       downloadEnabled: false,
       embedEnabled: false,
       fullscreenEnabled: false,
       moreInfoEnabled: false,
       shareEnabled: false,
-      defaultZoomLevel: 2,
     };
     cb({
       options: {

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -16,6 +16,7 @@ function initUniversalViewer() {
       fullscreenEnabled: false,
       moreInfoEnabled: false,
       shareEnabled: false,
+      defaultZoomLevel: 2,
     };
     cb({
       options: {

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -9,8 +9,10 @@ function initUniversalViewer() {
 
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
-    config.modules.centerPanel.options.usePdfJs = true;
-    config.modules.centerPanel.options.defaultZoomLevel = 2;
+    config.modules.centerPanel.options = {
+      usePdfJs: true,
+      defaultZoomLevel: 2,
+    };
     config.modules.footerPanel.options = {
       downloadEnabled: false,
       embedEnabled: false,

--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -73,11 +73,11 @@ document.addEventListener("DOMContentLoaded", function () {
   let uvElement = document.getElementById("uv");
   if (uvElement) {
     uvElement.style.width = "100%";
-    uvElement.style.height = "60vh";
+    uvElement.style.height = "80vh";
 
     // Apply media query for small devices
     if (window.matchMedia("(max-width: 810px)").matches) {
-      uvElement.style.height = "60vh";
+      uvElement.style.height = "80vh";
       uvElement.style.width = "85vw";
       uvElement.style.padding = "1rem";
     }

--- a/app/static/src/scss/includes/_search.scss
+++ b/app/static/src/scss/includes/_search.scss
@@ -2,7 +2,7 @@
   padding: 0;
 }
 
-.search {
+.top-search {
   padding: 16px 16px 28px;
   display: flex;
   flex-direction: column;

--- a/app/static/src/scss/includes/_uv.scss
+++ b/app/static/src/scss/includes/_uv.scss
@@ -9,6 +9,6 @@
 
   .centerOptions {
     width: fit-content;
-    top: -8px;
+    top: -10px;
   }
 }

--- a/app/static/src/scss/includes/_uv.scss
+++ b/app/static/src/scss/includes/_uv.scss
@@ -9,5 +9,6 @@
 
   .centerOptions {
     width: fit-content;
+    top: -10px;
   }
 }

--- a/app/static/src/scss/includes/_uv.scss
+++ b/app/static/src/scss/includes/_uv.scss
@@ -9,6 +9,6 @@
 
   .centerOptions {
     width: fit-content;
-    top: -10px;
+    top: -8px;
   }
 }

--- a/app/templates/main/record-view.html
+++ b/app/templates/main/record-view.html
@@ -1,14 +1,6 @@
 {% from 'macros/banners.html' import alert_banner %}
 <div class="govuk-tabs__panel" id="record-view">
     {% if file_type == "iiif" %}
-        <div class="record-view-header">
-            {% if can_download_records %}
-                <a href="{{ url_for('main.download_record', record_id=record['file_id']) }}"
-                   class="govuk-button govuk-button__download--record record-view-download-btn"
-                   data-module="govuk-button"
-                   aria-label="Download record {{ record['file_name'] }}">Download record</a>
-            {% endif %}
-        </div>
         <div class="universal-viewer" id="viewer">
             <script nonce="{{ csp_nonce() }}"
                     src="https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/dist/umd/UV.js"

--- a/app/templates/main/top-search.html
+++ b/app/templates/main/top-search.html
@@ -15,16 +15,16 @@
         "aria_label": "Search only within the record content"
     }
 ] %}
-<div class="search govuk-grid-column-full">
-    <div class="search__els">
-        <form class="search__els__form"
+<div class="top-search govuk-grid-column-full">
+    <div class="top-search__els">
+        <form class="top-search__els__form"
               method="get"
               action="{{ url_for('main.search') }}">
             <fieldset class="govuk-fieldset">
                 <legend class="govuk-fieldset__legend govuk-fieldset__legend--search">
-                    <h1 class="govuk-label search__els__heading">Search for digital records</h1>
+                    <h1 class="govuk-label top-search__els__heading">Search for digital records</h1>
                 </legend>
-                <div class="govuk-radios govuk-radios--small search__els__form__checkboxes"
+                <div class="govuk-radios govuk-radios--small top-search__els__form__checkboxes"
                      data-module="govuk-radios">
                     {% for area in search_areas %}
                         <div class="govuk-radios__item">
@@ -42,7 +42,7 @@
                         </div>
                     {% endfor %}
                 </div>
-                <div class="search__els__form__input-container">
+                <div class="top-search__els__form__input-container">
                     <input class="govuk-input"
                            id="search-input"
                            name="query"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- On desktop and tablet devices, increased the height of the UV window to 80vh from 60vh
- Removed download record button from the top of UV window per the catchup with @Terry-Price and @georgeopteryx 
- Increased default zoom of UV to 2
- Fixed case where styles of UV pagination would get overwritten by out own page styles and causing the page number input to be too large & obstruct other elements
- Distance between breadcrumbs and UV window should already be 1rem following changes from other older tickets

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1487

## Screenshots of UI changes

### Before
<img width="970" alt="image" src="https://github.com/user-attachments/assets/351ee08b-ad17-411d-8653-1fccdbb1e9de" />

### After
<img width="972" alt="image" src="https://github.com/user-attachments/assets/9e72dc34-a048-408a-9eff-66774ec5e438" />

- [ ] Requires env variable(s) to be updated
