### PR TITLE
AYR-1552 - Overflowing text inside record arrangement

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -230,6 +230,7 @@
   font-size: 1rem;
   line-height: 1.2rem;
   text-wrap: wrap;
+  word-break: break-all;
 }
 
 .record-container .record-arrangement-list li::before {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Modified styles for `Record arrangement` component so text inside `li` elements does not overflow its container

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1552

## Screenshots of UI changes

### Before
<img width="359" alt="image" src="https://github.com/user-attachments/assets/cecc3ce0-2450-4c35-b9d0-2a0b8a5acb78" />

### After
<img width="282" alt="image" src="https://github.com/user-attachments/assets/292773fe-baaa-421e-9623-244bf83eebf1" />

- [ ] Requires env variable(s) to be updated
