### PR TITLE
AYR-1522 - Row margins on mobile

### DIFF
--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -59,7 +59,7 @@
                                 <tr class="govuk-table__row govuk-table__row-ref">
                                     <td class="govuk-table__cell govuk-table__cell--on-mobile--flex-layout-col">
                                         <a href="{{ url_for('main.browse_transferring_body', _id=record['transferring_body_id']) }}">{{ record["transferring_body"] }}</a>
-                                        <a class="govuk-table--invisible-on-desktop govuk-!-static-margin-top-4"
+                                        <a class="govuk-table--invisible-on-desktop govuk-!-static-margin-top-3 govuk-!-margin-bottom-1"
                                            href="{{ url_for('main.browse_series', _id= record['series_id']) }}">{{ record["series"] }}</a>
                                     </td>
                                     <td class="govuk-table__cell govuk-table--invisible-on-mobile">


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- On mobile, on the browse all page, modified the 2nd row in the first column (that becomes visible on mobile) to have 5px less margin above and 5px more margin below it

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1522

## Screenshots of UI changes

### Before
<img width="394" alt="image" src="https://github.com/user-attachments/assets/782c7974-b78a-4355-a7f3-52dd7bb67c48" />

### After
<img width="396" alt="image" src="https://github.com/user-attachments/assets/a1864c78-5b06-4fba-a874-502a2c39f9a3" />

- [ ] Requires env variable(s) to be updated
