### PR TITLE
AYR-1457 - Fixed style inconsistencies in filters

### DIFF
--- a/app/static/src/scss/includes/_overrides.scss
+++ b/app/static/src/scss/includes/_overrides.scss
@@ -13,6 +13,11 @@ a {
 .govuk-label {
   &__filter {
     font-size: 16px;
+    font-weight: 700;
+  }
+
+  &__filter-date {
+    font-size: 16px;
   }
 }
 

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -94,17 +94,15 @@
         <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
             <div class="browse-all-filter-container">
                 <div class="browse-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filter</h2>
+                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filters</h2>
                     <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
                          alt="">
                 </div>
-                <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label govuk-label__filter"
-                           for="transferring_body_filter">Transferring body</label>
-                </h3>
+                <label class="govuk-label govuk-label__filter"
+                       for="transferring_body_filter">Transferring body</label>
                 <div class="govuk-form-group filters-form__group filters-form__transferring-body-group">
                     <input class="govuk-input"
                            id="transferring_body_filter"
@@ -118,9 +116,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container browse-all-filter-container--file-type">
-                <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label govuk-label__filter" for="series_filter">Series reference</label>
-                </h3>
+                <label class="govuk-label govuk-label__filter" for="series_filter">Series reference</label>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">
                     <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
                            id="series_filter"
@@ -130,7 +126,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -102,7 +102,7 @@
         <div class="govuk-grid-column-one-third govuk-grid-column-one-third--consignment-filters">
             <div class="consignment-filter-container">
                 <div class="consignment-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--consignment-filter-title">Filter</h2>
+                    <h2 class="govuk-heading-m govuk-heading-m--consignment-filter-title">Filters</h2>
                     <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
                          height="32px"
                          width="32px"

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -80,14 +80,14 @@
         <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
             <div class="browse-all-filter-container">
                 <div class="browse-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filter</h2>
+                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filters</h2>
                     <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
                          alt="">
                 </div>
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/browse-transferring-body.html
+++ b/app/templates/main/browse-transferring-body.html
@@ -90,17 +90,14 @@
         <div class="govuk-grid-column-one-third govuk-grid-column-one-third--browse-all-filters">
             <div class="browse-all-filter-container">
                 <div class="browse-filter__header">
-                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filter</h2>
+                    <h2 class="govuk-heading-m govuk-heading-m--browse-all-filter-title">Filters</h2>
                     <img src="{{ url_for('static', filename='image/filter-icon.svg') }}"
                          height="32px"
                          width="32px"
                          class="browse-all-filter__icon"
                          alt="">
                 </div>
-                <h3 class="govuk-heading-s govuk-heading-s--series">
-                    <label class="govuk-label govuk-heading-s govuk-heading-s--series"
-                           for="series_filter">Series reference</label>
-                </h3>
+                <label class="govuk-label govuk-label__filter" for="series_filter">Series reference</label>
                 <div class="govuk-form-group govuk-form-group--browse-all-filter">
                     <input class="govuk-input govuk-!-width-full govuk-input--browse-all-input"
                            id="series_filter"
@@ -111,7 +108,7 @@
                 </div>
             </div>
             <div class="browse-all-filter-container">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter govuk-label govuk-label__filter">Transfer date</h3>
+                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Transfer date</h3>
                 {% include "date-filters.html" %}
                 <div class="filters-form__buttons">
                     <button type="submit"

--- a/app/templates/main/date-filters.html
+++ b/app/templates/main/date-filters.html
@@ -1,8 +1,8 @@
-<div class="browse-all-filter-from-dates">
+<div class="browse-all-filter-from-dates govuk-!-margin-top-1">
     <div class="{% if date_validation_errors %}{% if date_validation_errors.get('date_from') %}govuk-form-group--error{% endif %}{% endif %}">
         <fieldset class="govuk-fieldset govuk-fieldset--date-from" role="group">
             <legend aria-label="{% if view_type=='consignment' %}Record date from{% else %}Date consignment transferred from{% endif %}">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date from</h3>
+                <label class="govuk-label govuk-label__filter-date">From date</label>
             </legend>
             {% if date_validation_errors %}
                 {% if date_validation_errors.get('date_from') %}
@@ -53,11 +53,11 @@
         </fieldset>
     </div>
 </div>
-<div class="browse-all-filter-to-dates">
+<div class="browse-all-filter-to-dates govuk-!-margin-top-1">
     <div class="{% if date_validation_errors %} {% if date_validation_errors.get('date_to') %}govuk-form-group--error{% endif %}{% endif %}">
         <fieldset class="govuk-fieldset govuk-fieldset--date-to" role="group">
             <legend aria-label="{% if view_type=='consignment' %}Record date to{% else %}Date consignment transferred to{% endif %}">
-                <h3 class="govuk-heading-s govuk-heading-s--browse-all-filter">Date to</h3>
+                <label class="govuk-label govuk-label__filter-date">To date</label>
             </legend>
             {% if date_validation_errors %}
                 {% if date_validation_errors.get('date_to') %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Changed wording of "Filter" heading to "Filters" across all pages
- Normally `govuk-labels__filters` now have a font weight of 700
- Deleted instances where labels were wrapped by `h3` elements 
- Made all labels use consistent classes for styles
- Changed wording of "Date from" and "Date to" to "From date" and "To date" respectively (to be more consistent with FCS, for example)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1457

## Screenshots of UI changes

### Before
Browse all
<img width="318" alt="image" src="https://github.com/user-attachments/assets/fd2288f0-9186-4195-91d0-1e91bdb541e8" />

Browse transferring body
<img width="317" alt="image" src="https://github.com/user-attachments/assets/f4c6adf3-8a0b-45fe-874e-356201cfeef2" />

Browse series
<img width="313" alt="image" src="https://github.com/user-attachments/assets/5499f150-11ad-410d-95cc-78b02911a0eb" />

Browse consignment
<img width="309" alt="image" src="https://github.com/user-attachments/assets/09f6afb3-d618-4e0b-83ff-5df153aa449f" />


### After
Browse all
<img width="314" alt="image" src="https://github.com/user-attachments/assets/b961b8a3-d3dd-44ef-bf47-f59cc07e3fa5" />

Browse transferring body
<img width="312" alt="image" src="https://github.com/user-attachments/assets/dbda8ffc-aa11-4522-9bcc-d8e6efd091e7" />

Browse series
<img width="312" alt="image" src="https://github.com/user-attachments/assets/44ad7d78-9a3e-4d4e-b681-82a48ff4ea37" />

Browse consignment
<img width="306" alt="image" src="https://github.com/user-attachments/assets/7bf2cd80-2ed4-4f87-98f7-3c70dccf28e4" />

- [ ] Requires env variable(s) to be updated
