### PR TITLE
Simplify CSP for constant urls and hashes, and build dynamic parts from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -708,34 +708,7 @@ Uses [Flask Talisman](https://github.com/GoogleCloudPlatform/flask-talisman) to 
 
 A strict default [Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) (CSP) is set using [Flask Talisman](https://github.com/GoogleCloudPlatform/flask-talisman) to mitigate [Cross Site Scripting](https://developer.mozilla.org/en-US/docs/Web/Security/Types_of_attacks#cross-site_scripting_xss) (XSS) and packet sniffing attacks. This prevents loading any resources that are not in the same domain as the application.
 
-To define the scripts and styles allowed in the Content Security Policy (CSP), you can configure the following environment variables in a .env file. This configuration includes a set of hashes for inline scripts, as well as specific domains used by AYR.
-
-These ENV variables should be comma delimited strings with hashes prefixed "sha256-hash" and any urls to be in the form https://example-url.com/
-
-
-### Local Usage
-CSP_DEFAULT_SRC=""
-
-CSP_CONNECT_SRC=""
-
-CSP_SCRIPT_SRC="https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/, https://cdnjs.cloudflare.com/ajax/libs/pdf.js/, sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=, sha256-l1eTVSK8DTnK8+yloud7wZUqFrI0atVo6VlC6PJvYaQ=, sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ="
-
-CSP_SCRIPT_SRC_ELEM="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/, https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/, https://127.0.0.1:5000/, sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw=, sha256-bxI3qvjziRybgoaeQYcUjRHcCTdbUu/A9xFMlfNGZAQ=, sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ="
-
-CSP_STYLE_SRC="sha256-aqNNdDLnnrDOnTNdkJpYlAxKVJtLt9CtFLklmInuUAE=, sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
-
-CSP_STYLE_SRC_ELEM="https://cdn.jsdelivr.net/jsdelivr-header.css, https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/, sha256-aqNNdDLnnrDOnTNdkJpYlAxKVJtLt9CtFLklmInuUAE=,
-
-CSP_IMG_SRC=""
-
-CSP_FRAME_SRC=""
-
-CSP_OBJECT_SRC=""
-
-CSP_WORKER_SRC="https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.11.174/pdf.worker.min.js"
-
-### Environment-Specific CSP Policies
-We use AWS Secrets Manager to manage and update CSP directives. Each CSP directive is stored as a comma-delimited string in AWS.
+The scripts and styles in the Content Security Policy (CSP) for Universal Viewer related code are all pre-defined in the config, whilst those referring to the objects in s3 are built dynamically from the other S3 Bucket related config values already set.
 
 ### Response compression
 

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -96,6 +96,62 @@ def test_local_env_vars_config_initialized(monkeypatch):
     )
     assert config.OPEN_SEARCH_TIMEOUT == 10
 
+    assert config.CSP_CONNECT_SRC == [
+        "'self'",
+        "test_flasks3_cdn_domain",
+        "https://test_record_bucket_name.s3.amazonaws.com",
+    ]
+    assert config.CSP_SCRIPT_SRC == [
+        "'self'",
+        "test_flasks3_cdn_domain",
+        "https://test_record_bucket_name.s3.amazonaws.com",
+    ]
+    assert config.CSP_SCRIPT_SRC_ELEM == [
+        "'self'",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
+        "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
+        "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
+        "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+    ]
+    assert config.CSP_STYLE_SRC == ["'self'"]
+    assert config.CSP_STYLE_SRC_ELEM == [
+        "'self'",
+        "test_flasks3_cdn_domain",
+        "https://cdn.jsdelivr.net/jsdelivr-header.css",
+        "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",  # pragma: allowlist secret
+        "'sha256-7smvP9yjKljPbeD/NRIE3XgBZUTCaF936I8yK6wJUM4='",  # pragma: allowlist secret
+        "'sha256-V4SarAiVbO77lJTzMaRut9Qr7Cx4R8jo8vH1dIFkVSc='",  # pragma: allowlist secret
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/uv.min.css",
+        "'sha256-XawOsBXgsJP8SK/f+1r5Hi9mlYtBA/KzL3kNIn0YzA4='",  # pragma: allowlist secret
+        "'sha256-cngw11JRRopLh6RDda+MT7Jk/9a0aKtyuseJMoDvEow='",  # pragma: allowlist secret
+    ]
+    assert config.CSP_IMG_SRC == ["'self'", "test_flasks3_cdn_domain", "data:"]
+    assert config.CSP_FRAME_SRC == [
+        "'self'",
+        "https://test_record_bucket_name.s3.amazonaws.com",
+    ]
+    assert config.CSP_OBJECT_SRC == [
+        "'self'",
+        "https://test_record_bucket_name.s3.amazonaws.com",
+    ]
+    assert config.CSP_WORKER_SRC == [
+        "blob:",
+        "'self'",
+        "test_flasks3_cdn_domain",
+    ]
+    assert config.CSP_DEFAULT_SRC == ["'self'", "test_flasks3_cdn_domain"]
+
 
 def test_local_env_config_variable_not_set_error(monkeypatch):
     """
@@ -134,16 +190,6 @@ def test_local_env_config_variable_not_set_error(monkeypatch):
     monkeypatch.setenv("OPEN_SEARCH_USERNAME", "test_os_username")
     monkeypatch.setenv("OPEN_SEARCH_PASSWORD", "test_os_password")
     monkeypatch.setenv("OPEN_SEARCH_TIMEOUT", 10)
-    monkeypatch.setenv("CSP_CONNECT_SRC", "")
-    monkeypatch.setenv("CSP_DEFAULT_SRC", "")
-    monkeypatch.setenv("CSP_FRAME_SRC", "")
-    monkeypatch.setenv("CSP_IMG_SRC", "")
-    monkeypatch.setenv("CSP_OBJECT_SRC", "")
-    monkeypatch.setenv("CSP_SCRIPT_SRC", "")
-    monkeypatch.setenv("CSP_SCRIPT_SRC_ELEM", "")
-    monkeypatch.setenv("CSP_STYLE_SRC", "")
-    monkeypatch.setenv("CSP_STYLE_SRC_ELEM", "")
-    monkeypatch.setenv("CSP_WORKER_SRC", "")
 
     config = EnvConfig()
 
@@ -151,6 +197,23 @@ def test_local_env_config_variable_not_set_error(monkeypatch):
         inspect.getmembers(config)
 
     assert str(error.value) == "'DEFAULT_DATE_FORMAT'"
+
+
+def test_local_s3_bucket_url_with_non_s3_server(monkeypatch):
+    """
+    GIVEN environment variables are set with AWS_ENDPOINT_URL
+    WHEN Config is initialized
+    THEN it should have S3_BUCKET_URL with the expected value
+    """
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://test_endpoint_url")
+    monkeypatch.setenv("RECORD_BUCKET_NAME", "test_record_bucket_name")
+
+    config = EnvConfig()
+
+    assert (
+        config.S3_BUCKET_URL
+        == "http://test_endpoint_url/test_record_bucket_name/"
+    )
 
 
 @mock_aws
@@ -269,6 +332,66 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
             == "test_secret_key"  # pragma: allowlist secret
         )
 
+        assert config.CSP_CONNECT_SRC == [
+            "'self'",
+            "test_flasks3_cdn_domain",
+            "https://test_record_bucket_name.s3.amazonaws.com",
+        ]
+        assert config.CSP_SCRIPT_SRC == [
+            "'self'",
+            "test_flasks3_cdn_domain",
+            "https://test_record_bucket_name.s3.amazonaws.com",
+        ]
+        assert config.CSP_SCRIPT_SRC_ELEM == [
+            "'self'",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
+            "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
+            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
+            "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+        ]
+        assert config.CSP_STYLE_SRC == ["'self'"]
+        assert config.CSP_STYLE_SRC_ELEM == [
+            "'self'",
+            "test_flasks3_cdn_domain",
+            "https://cdn.jsdelivr.net/jsdelivr-header.css",
+            "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",  # pragma: allowlist secret
+            "'sha256-7smvP9yjKljPbeD/NRIE3XgBZUTCaF936I8yK6wJUM4='",  # pragma: allowlist secret
+            "'sha256-V4SarAiVbO77lJTzMaRut9Qr7Cx4R8jo8vH1dIFkVSc='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/uv.min.css",
+            "'sha256-XawOsBXgsJP8SK/f+1r5Hi9mlYtBA/KzL3kNIn0YzA4='",  # pragma: allowlist secret
+            "'sha256-cngw11JRRopLh6RDda+MT7Jk/9a0aKtyuseJMoDvEow='",  # pragma: allowlist secret
+        ]
+        assert config.CSP_IMG_SRC == [
+            "'self'",
+            "test_flasks3_cdn_domain",
+            "data:",
+        ]
+        assert config.CSP_FRAME_SRC == [
+            "'self'",
+            "https://test_record_bucket_name.s3.amazonaws.com",
+        ]
+        assert config.CSP_OBJECT_SRC == [
+            "'self'",
+            "https://test_record_bucket_name.s3.amazonaws.com",
+        ]
+        assert config.CSP_WORKER_SRC == [
+            "blob:",
+            "'self'",
+            "test_flasks3_cdn_domain",
+        ]
+        assert config.CSP_DEFAULT_SRC == ["'self'", "test_flasks3_cdn_domain"]
+
 
 @mock_aws
 def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
@@ -294,16 +417,6 @@ def test_aws_secrets_manager_config_variable_not_set_error(monkeypatch):
             "SECRET_KEY": "test_secret_key",  # pragma: allowlist secret
             "DB_SSL_ROOT_CERTIFICATE": "test_db_ssl_root_certificate",
             "DEFAULT_PAGE_SIZE": 10,
-            "CSP_CONNECT_SRC": "",
-            "CSP_DEFAULT_SRC": "",
-            "CSP_FRAME_SRC": "",
-            "CSP_IMG_SRC": "",
-            "CSP_OBJECT_SRC": "",
-            "CSP_SCRIPT_SRC": "",
-            "CSP_SCRIPT_SRC_ELEM": "",
-            "CSP_STYLE_SRC": "",
-            "CSP_STYLE_SRC_ELEM": "",
-            "CSP_WORKER_SRC": "",
         }
     )
 

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -118,6 +118,10 @@ class BaseConfig(object):
         return self._get_config_value("RECORD_BUCKET_NAME")
 
     @property
+    def S3_BUCKET_URL(self):
+        return f"https://{self.RECORD_BUCKET_NAME}.s3.amazonaws.com"
+
+    @property
     def FLASKS3_ACTIVE(self):
         return self._get_config_value("FLASKS3_ACTIVE") == "True"
 
@@ -154,83 +158,80 @@ class BaseConfig(object):
 
     @property
     def CSP_DEFAULT_SRC(self):
-        return self._get_config_list(
-            "CSP_DEFAULT_SRC", [SELF, self.FLASKS3_CDN_DOMAIN]
-        )
+        return [SELF, self.FLASKS3_CDN_DOMAIN]
 
     @property
     def CSP_CONNECT_SRC(self):
-        return self._get_config_list(
-            "CSP_CONNECT_SRC",
-            [
-                SELF,
-                self.FLASKS3_CDN_DOMAIN,
-                f"https://{self.RECORD_BUCKET_NAME}.s3.amazonaws.com",
-            ],
-        )
+        return [
+            SELF,
+            self.FLASKS3_CDN_DOMAIN,
+            self.S3_BUCKET_URL,
+        ]
 
     @property
     def CSP_SCRIPT_SRC(self):
-        return self._get_config_list(
-            "CSP_SCRIPT_SRC",
-            [
-                SELF,
-                self.FLASKS3_CDN_DOMAIN,
-                f"https://{self.RECORD_BUCKET_NAME}.s3.amazonaws.com",
-            ],
-        )
+        return [
+            SELF,
+            self.FLASKS3_CDN_DOMAIN,
+            self.S3_BUCKET_URL,
+        ]
 
     @property
     def CSP_SCRIPT_SRC_ELEM(self):
-        return self._get_config_list(
-            "CSP_SCRIPT_SRC_ELEM",
-            [
-                "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
-                "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
-            ],
-        )
+        return [
+            SELF,
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
+            "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
+            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
+            "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
+            # for pdfs
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+        ]
 
     @property
     def CSP_STYLE_SRC(self):
-        return self._get_config_list("CSP_STYLE_SRC", [SELF])
+        return [SELF]
 
     @property
     def CSP_STYLE_SRC_ELEM(self):
-        return self._get_config_list(
-            "CSP_STYLE_SRC_ELEM",
-            [
-                SELF,
-                self.FLASKS3_CDN_DOMAIN,
-                "https://cdn.jsdelivr.net/jsdelivr-header.css",
-                "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/dist/uv.min.css",
-            ],
-        )
+        return [
+            SELF,
+            self.FLASKS3_CDN_DOMAIN,
+            "https://cdn.jsdelivr.net/jsdelivr-header.css",
+            "'sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU='",  # pragma: allowlist secret
+            "'sha256-7smvP9yjKljPbeD/NRIE3XgBZUTCaF936I8yK6wJUM4='",  # pragma: allowlist secret
+            "'sha256-V4SarAiVbO77lJTzMaRut9Qr7Cx4R8jo8vH1dIFkVSc='",  # pragma: allowlist secret
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/uv.min.css",
+            "'sha256-XawOsBXgsJP8SK/f+1r5Hi9mlYtBA/KzL3kNIn0YzA4='",  # pragma: allowlist secret
+            # for pdfs
+            "'sha256-cngw11JRRopLh6RDda+MT7Jk/9a0aKtyuseJMoDvEow='",  # pragma: allowlist secret
+        ]
 
     @property
     def CSP_IMG_SRC(self):
-        return self._get_config_list(
-            "CSP_IMG_SRC", [SELF, self.FLASKS3_CDN_DOMAIN, "data:"]
-        )
+        return [SELF, self.FLASKS3_CDN_DOMAIN, "data:"]
 
     @property
     def CSP_FRAME_SRC(self):
-        return self._get_config_list(
-            "CSP_FRAME_SRC",
-            [SELF, f"https://{self.RECORD_BUCKET_NAME}.s3.amazonaws.com"],
-        )
+        return [SELF, self.S3_BUCKET_URL]
 
     @property
     def CSP_OBJECT_SRC(self):
-        return self._get_config_list(
-            "CSP_OBJECT_SRC",
-            [SELF, f"https://{self.RECORD_BUCKET_NAME}.s3.amazonaws.com"],
-        )
+        return [SELF, self.S3_BUCKET_URL]
 
     @property
     def CSP_WORKER_SRC(self):
-        return self._get_config_list(
-            "CSP_WORKER_SRC", ["blob:", SELF, self.FLASKS3_CDN_DOMAIN]
-        )
+        return ["blob:", SELF, self.FLASKS3_CDN_DOMAIN]
 
     def _get_config_value(self, variable_name):
         pass

--- a/configs/env_config.py
+++ b/configs/env_config.py
@@ -10,3 +10,10 @@ class EnvConfig(BaseConfig):
             return os.getenv(variable_name)
         else:
             raise KeyError(f"{variable_name}")
+
+    @property
+    def S3_BUCKET_URL(self):
+        aws_endpoint_url = os.getenv("AWS_ENDPOINT_URL")
+        if aws_endpoint_url:
+            return f"{aws_endpoint_url}/{self.RECORD_BUCKET_NAME}/"
+        return super().S3_BUCKET_URL


### PR DESCRIPTION
## Changes in this PR

Simplify CSP for constant urls and hashes, and build dynamic parts from config

Once this is merged in you can get rid of the CSP specific env vars from your local .env file. And once deployed to aws can remove from secrets manager.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1585