### PR TITLE
Fix and simplify script-src csp config

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -109,7 +109,7 @@ def create_app(config_class, database_uri=None):
         content_security_policy=csp,
         force_https=force_https,
         content_security_policy_nonce_in=[
-            "script-src",
+            "script-src-elem",
         ],
     )
     WTFormsHelpers(app)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -2,6 +2,7 @@
 {%- from 'govuk_frontend_jinja/components/error-summary/macro.html' import govukErrorSummary -%}
 {%- from 'govuk_frontend_jinja/components/notification-banner/macro.html' import govukNotificationBanner -%}
 {%- from 'govuk_frontend_jinja/components/phase-banner/macro.html' import govukPhaseBanner -%}
+{% set cspNonce = csp_nonce() %}
 {% set assetPath = url_for('static', filename='').rstrip('/') %}
 {% block pageTitle %}{{ config['SERVICE_NAME'] }} – GOV.UK{% endblock %}
 {% block head %}
@@ -111,7 +112,7 @@
 {% endblock %}
 {% block bodyEnd %}
     <!--[if gt IE 8]><!-->
-    <script type="module">
+    <script nonce="{{ cspNonce }}" type="module">
         import { initAll } from "{{ url_for('static', filename='govuk-frontend.min.js') }}"
         initAll()
     </script>

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -108,21 +108,8 @@ def test_local_env_vars_config_initialized(monkeypatch):
     ]
     assert config.CSP_SCRIPT_SRC_ELEM == [
         "'self'",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
         "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
-        "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
-        "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
-        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+        "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/",
     ]
     assert config.CSP_STYLE_SRC == ["'self'"]
     assert config.CSP_STYLE_SRC_ELEM == [
@@ -344,21 +331,8 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
         ]
         assert config.CSP_SCRIPT_SRC_ELEM == [
             "'self'",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
             "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
-            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
-            "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/",
         ]
         assert config.CSP_STYLE_SRC == ["'self'"]
         assert config.CSP_STYLE_SRC_ELEM == [

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -180,22 +180,8 @@ class BaseConfig(object):
     def CSP_SCRIPT_SRC_ELEM(self):
         return [
             SELF,
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/561.9c9010d28f0e85a93735.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/132.71cff57d0df80961f8b1.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/UV.js",
             "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
-            "'sha256-GUQ5ad8JK5KmEWmROf3LZd9ge94daqNvd8xy9YS1iDw='",  # pragma: allowlist secret
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.0.25/",
-            "'sha256-JTVvglOxxHXAPZcB40r0wZGNZuFHt0cm0bQVn8LK5GQ='",  # pragma: allowlist secret
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/9501.18ecc99d0975318a991a.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/2568.692e9a5962ece6f2c181.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/560.38a617ba9e1573dfd7d4.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/429.37ac60eb90fcff97a797.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/4830.249a5be20dbe55155aae.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/8687.87c1b5ce857b3d6e05d0.js",
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/3708.6e3ce3d99cffbe4e2f14.js",
-            # for pdfs
-            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/dist/umd/7950.63bff638e4e0bfdfbc15.js",
+            "https://cdn.jsdelivr.net/npm/universalviewer@4.1.0/",
         ]
 
     @property


### PR DESCRIPTION
## Changes in this PR

Fix and simplify script-src csp config

Specifically, the script hashes were different when we deployed. Not too sure why, but we don't need to do that, as we can use nonce values. Previously the nonce wasn't being added to the request headers correctly, we need it in the script-style-elem, and now we have it.

Have deployed to int and it is working.

Did try doing similar for the styles but did not work due to the main min.css file stylesheet linking to sub resources without any SRI https://developer.mozilla.org/en-US/blog/securing-cdn-using-sri-why-how/.

That led me to reading into https://www.jsdelivr.com/using-sri-with-dynamic-files which suggests that really we should not use SRI like I am doing here - see `cobined files` section - essentially when using SRI with 3rd party CDNs, although this protects us against any potential changes which could be harmful, the flipside is that if. anything changes, the scripts would just be blocked, and this could happen without warning theoretically.

I think we should move away from using public CDNs, and instead either serve the file ourselves (flask server, or our own CDN) or using a universal npm package if available.

That is out of scope for this ticket, so I will create a dedicateds ticket for that

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1585
