### PR TITLE
AYR-1563 - Overflowing table on consignment browse page

### DIFF
--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -65,10 +65,10 @@
                             <tr class="govuk-table__row govuk-table__row-ref">
                                 <td class="govuk-table__cell govuk-table__cell--on-mobile--flex-layout-col">
                                     {{ record["date_last_modified"] }}
-                                    <a class="govuk-table--invisible-on-desktop govuk-!-static-margin-top-4"
+                                    <a class="govuk-table--invisible-on-desktop govuk-!-static-margin-top-4 word-break"
                                        href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                 </td>
-                                <td class="govuk-table__cell govuk-table--invisible-on-mobile">
+                                <td class="govuk-table__cell govuk-table--invisible-on-mobile word-break">
                                     <a href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                 </td>
                                 <td class="govuk-table__cell">


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Made content in the file name column break text anywhere and not just words

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1563

## Screenshots of UI changes

### Before
<img width="976" alt="image" src="https://github.com/user-attachments/assets/a23685dd-e068-472f-8ea6-9c4785ba8075" />

### After
<img width="980" alt="image" src="https://github.com/user-attachments/assets/41f25450-6b55-4b4b-9383-bd444d4c9520" />

- [ ] Requires env variable(s) to be updated
