### PR TITLE
AYR-1572 - Heading levels [DAC]

### DIFF
--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -10,7 +10,7 @@
             <!-- TABLE -->
             <div class="govuk-grid-column-full govuk-grid-column-full__page_container">
                 <div class="browse-details">
-                    <h1 class="govuk-heading-l browse__records-found__text"
+                    <h2 class="govuk-heading-l browse__records-found__text"
                         id="browse-records"
                         aria-live="polite">
                         {% if num_records_found > 0 %}
@@ -18,8 +18,8 @@
                         {% else %}
                             No results found
                         {% endif %}
-                    </h1>
-                    <h2 class="govuk-body browse__body">You are viewing</h2>
+                    </h2>
+                    <p class="govuk-body browse__body">You are viewing</p>
                     {% if browse_type == "browse" %}
                         {% include "browse-all.html" %}
                     {% elif browse_type == "transferring_body" %}

--- a/app/templates/main/macros/banners.html
+++ b/app/templates/main/macros/banners.html
@@ -8,7 +8,7 @@
 {% endmacro %}
 {% macro belly_band(heading='', link_text='', link_href='') %}
     <div class="ayr-belly-band">
-        <h1 class="govuk-heading-m">{{ heading }}</h1>
+        <h3 class="govuk-heading-m">{{ heading }}</h3>
         <a href="{{ link_href }}"
            target="blank"
            class="govuk-link govuk-link--no-visited-state">{{ link_text }}</a>

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -10,7 +10,7 @@
         <!-- TABLE -->
         <div class="govuk-grid-column-full govuk-grid-column-full--mobile-search">
             <div class="browse-details">
-                <h1 class="govuk-heading-l browse__records-found__text"
+                <h2 class="govuk-heading-l browse__records-found__text"
                     id="browse-records"
                     aria-live="polite">
                     {% if num_records_found > 0 %}
@@ -18,9 +18,9 @@
                     {% else %}
                         No results found
                     {% endif %}
-                </h1>
+                </h2>
                 {% if num_records_found > 0 %}
-                    <h2 class="govuk-body browse__body">You are viewing</h2>
+                    <p class="govuk-body browse__body">You are viewing</p>
                     {% set breadcrumbs = {"everything": "All available records", "body": "Results summary"} %}
                     <!-- BREAD CRUMB -->
                     {% with dict = breadcrumbs %}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -27,7 +27,7 @@
         <!-- TABLE -->
         <div class="govuk-grid-column-full govuk-grid-column-full__page_container">
             <div class="browse-details">
-                <h1 class="govuk-heading-l browse__records-found__text"
+                <h2 class="govuk-heading-l browse__records-found__text"
                     id="browse-records"
                     aria-live="polite">
                     {% if num_records_found > 0 %}
@@ -35,8 +35,8 @@
                     {% else %}
                         No results found
                     {% endif %}
-                </h1>
-                <h2 class="govuk-body browse__body">You are viewing</h2>
+                </h2>
+                <p class="govuk-body browse__body">You are viewing</p>
                 <!-- BREAD CRUMB -->
                 {% with dict = breadcrumbs %}
                     {% include "breadcrumb.html" %}

--- a/app/templates/main/top-search.html
+++ b/app/templates/main/top-search.html
@@ -21,8 +21,8 @@
               method="get"
               action="{{ url_for('main.search') }}">
             <fieldset class="govuk-fieldset">
-                <legend class="govuk-fieldset__legend govuk-fieldset__legend--search">
-                    <h1 class="govuk-label top-search__els__heading">Search for digital records</h1>
+                <legend class="govuk-fieldset__legend govuk-fieldset__legend--search govuk-label top-search__els__heading">
+                    Search for digital records
                 </legend>
                 <div class="govuk-radios govuk-radios--small top-search__els__form__checkboxes"
                      data-module="govuk-radios">

--- a/app/tests/test_macros.py
+++ b/app/tests/test_macros.py
@@ -121,7 +121,7 @@ class TestBanners:
         belly_band = soup.find("div", class_="ayr-belly-band")
         assert belly_band is not None
 
-        heading_tag = belly_band.find("h1", class_="govuk-heading-m")
+        heading_tag = belly_band.find("h3", class_="govuk-heading-m")
         link_tag = belly_band.find(
             "a", class_="govuk-link govuk-link--no-visited-state"
         )

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -106,11 +106,12 @@ class TestRecord:
         html = response.data.decode()
 
         soup = BeautifulSoup(html, "html.parser")
-        label = soup.find("h1", string="Search for digital records")
+        label = soup.find("legend", {"class": "top-search__els__heading"})
+        label_text = label.get_text(strip=True)
         textbox = soup.find("input", {"id": "search-input"})
         button = soup.find("button", {"id": "search-submit"})
 
-        assert label is not None
+        assert label is not None and label_text == "Search for digital records"
         assert textbox is not None
         assert button is not None
 

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -342,7 +342,7 @@ class TestSearchResultsSummary:
         response = client.get(f"{self.route_url}", data=form_data)
         soup = BeautifulSoup(response.data, "html.parser")
         browse_details_div = soup.find("div", {"class": "browse-details"})
-        heading = browse_details_div.find("h1")
+        heading = browse_details_div.find("h2")
         heading_text = heading.get_text(strip=True)
         assert heading and browse_details_div
         assert heading_text == "Records found 69"
@@ -571,7 +571,8 @@ class TestSearchTransferringBody:
         html = response.data.decode()
 
         soup = BeautifulSoup(html, "html.parser")
-        label = soup.find("h1", string="Search for digital records")
+        label = soup.find("legend", {"class": "top-search__els__heading"})
+        label_text = label.get_text(strip=True)
         textbox = soup.find("input", {"id": "search-input"})
         button = soup.find("button", {"id": "search-submit"})
 
@@ -579,7 +580,7 @@ class TestSearchTransferringBody:
         radio_2 = soup.find("input", {"id": "metadata"})
         radio_3 = soup.find("input", {"id": "record"})
 
-        assert label is not None
+        assert label is not None and label_text == "Search for digital records"
         assert textbox is not None
         assert button is not None
         assert radio_1 and radio_2 and radio_3


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Replaced instances where some headings were h1s when it was more appropriate for them to be h2s
- In the top search element replaced h1 (or any other element that would have been invalid html) with just a styled legend element
- Some elements that were h2s were replaced with just p tags (e.g. the "You are viewing" text)
- The belly band heading is now a h3

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1572

## Screenshots of UI changes
N/A

- [ ] Requires env variable(s) to be updated
