### PR TITLE
AYR-1578 - Letter spacing issue [DAC]

### DIFF
--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -123,15 +123,14 @@ a.govuk-link {
 
 .govuk-button {
   &__search-filters-form-apply-button {
-    height: 35px;
-    width: 110px;
-    font-size: 1rem;
-    margin: 0 26px 0 0;
+    margin: 0;
   }
 }
 
 .search-form__buttons {
   display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
   align-items: center;
   width: auto;
   margin-top: 0.9rem;

--- a/app/static/src/scss/includes/_search-transferring-body.scss
+++ b/app/static/src/scss/includes/_search-transferring-body.scss
@@ -130,7 +130,7 @@ a.govuk-link {
 .search-form__buttons {
   display: flex;
   flex-wrap: wrap;
-  gap: 1rem;
+  gap: 1.5rem;
   align-items: center;
   width: auto;
   margin-top: 0.9rem;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Adjusted styles on the search transferring body "Search within results" section to:
- Wrap the button and anchor elements when the letter spacing is too large
- Unpin the width of the apply button so the text affects width and doesn't break line and overflow the button element itself
- Increase the font size of the button so its consistent with all the other buttons we use within the app
## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1578
## Screenshots of UI changes

### Before
<img width="298" alt="image" src="https://github.com/user-attachments/assets/c00b9227-ba83-47ad-932d-d8470f216ece" />

With 2px letter spacing

<img width="305" alt="image" src="https://github.com/user-attachments/assets/956059b3-a24f-4b0d-ad85-26b6d1ac6676" />

### After

<img width="301" alt="image" src="https://github.com/user-attachments/assets/4820e747-b38f-49ff-840c-56c10dbdd27b" />

With 2px letter spacing

<img width="301" alt="image" src="https://github.com/user-attachments/assets/08e9bc8c-7aba-45d2-8b28-18b9de4514a4" />





- [ ] Requires env variable(s) to be updated
