### PR TITLE
add display none to navigation buttons

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -343,6 +343,11 @@
   display: none !important;
 }
 
+.paging.next .uv-icon-next,
+.paging.prev .uv-icon-prev {
+  display: none;
+}
+
 .thumb.selected .wrap {
   border: 5px solid yellow !important;
 }


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Set display none to added icons from UV 4.1.0.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1528

## Screenshots of UI changes


### Before
UV-4.0.25 PDF Viewer:
<img width="850" alt="Screenshot 2025-05-23 at 11 56 38" src="https://github.com/user-attachments/assets/3078a168-10ef-489c-8258-e0af16f7992c" />

UV-4.1.0 PDF Viewer Before:
<img width="856" alt="Screenshot 2025-05-23 at 13 48 01" src="https://github.com/user-attachments/assets/914b338e-951b-4c18-a0ff-e7d92ed67d23" />




### After
<img width="850" alt="Screenshot 2025-05-23 at 11 56 53" src="https://github.com/user-attachments/assets/d5f6cf2c-929c-4665-8634-d3af958371ab" />


- [ ] Requires env variable(s) to be updated
