### PR TITLE
Automerge minor and patch version bump dependabot PRs

### DIFF
--- a/.github/workflows/dependabot_automerge_minor_and_patch.yml
+++ b/.github/workflows/dependabot_automerge_minor_and_patch.yml
@@ -1,0 +1,26 @@
+name: Dependabot auto-merge patch and minor updates
+# This workflow automatically merges Dependabot pull requests for minor and patch updates
+# when the PR is created by Dependabot and the repository matches 'nationalarchives/da-ayr-beta-webapp'.
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'nationalarchives/da-ayr-beta-webapp'
+    name: Auto-merge Dependabot PRs for minor and patch updates
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@d7267f607e9d3fb96fc2fbe83e0af444713e90b7
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for minor and patch updates
+        if: (steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+            PR_URL: ${{ github.event.pull_request.html_url }}
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes in this PR

Automerge minor and patch version bump dependabot PRs.

This will save us so much time approving and merging these manually. We currently do this without much checkign at the moment unless it is a major upgrade, so I think this is fine.

We could consider using compatibility scores but sometimes these don't exist and often they don't mean much to us as, as long as our CI tests pass, we should be ok.
