### PR TITLE
Trigger required-check github action workflows on merge_group

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,9 @@
 name: "CodeQL"
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ "main" ]
+  merge_group:
+
   schedule:
     - cron: '17 2 * * 4'
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -5,7 +5,9 @@
 # Source repository: https://github.com/actions/dependency-review-action
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: 'Dependency Review'
-on: [pull_request]
+on:
+  pull_request:
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,7 +1,7 @@
 name: Pre-commit check
 on:
   pull_request:
-    branches: ["main"]
+  merge_group:
 
 jobs:
   pre-commit:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,12 +1,8 @@
 name: Run Unit Tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
-    branches:
-      - main
+  merge_group:
 
 jobs:
   app_tests:


### PR DESCRIPTION
## Changes in this PR

Trigger required-check github action workflows on merge_group
Stop triggering these checks on main as validation of main is handled by merge queue

## Reason

Currently we have the “Require branches to be up to date before merging” setting enabled. This combined with auto-approve + auto-merge of Dependabot PRs causes the following when multiple Dependabot PRs are open:

1.One gets auto-approved and merged.
2. The others become out-of-date with main.
3. They no longer meet the branch protection rule and don’t auto-merge.

Solution:
Enable GitHub Merge Queue instead of "Require branches to be up to date before merging" which will keep branches up-to-date and auto-merge safely. See more details of how it works here: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

**To make it work, any required checks need to be triggered on merge_group as well, so that is why we have done this PR.**