### PR TITLE
Stop pinning xlrd in opensearch_indexer requirements.txt

### DIFF
--- a/data_management/opensearch_indexer/requirements.txt
+++ b/data_management/opensearch_indexer/requirements.txt
@@ -4,6 +4,5 @@ requests-aws4auth==1.3.1
 SQLAlchemy==2.0.41
 pg8000==1.31.2
 textract-py3==2.1.1
-xlrd==1.2.0
 testing-postgresql==1.3.0
 psycopg2-binary==2.9.10


### PR DESCRIPTION
**Change:**
Stop pinning xlrd in opensearch_indexer requirements.txt

**Reason:**
textract-py3 2.1.1 fixed its dependency tree, so no longer needed
