### PR TITLE
Fix opensearch query api call for client v3 upgrade

### DIFF
--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -233,7 +233,7 @@ def execute_search(open_search, dsl_query, page, per_page):
     from_ = per_page * (page - 1)
     try:
         return open_search.search(
-            dsl_query,
+            body=dsl_query,
             from_=from_,
             size=per_page,
             timeout=current_app.config["OPEN_SEARCH_TIMEOUT"],

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -407,7 +407,7 @@ def test_execute_search(mock_open_search, app):
     dsl_query = {"query": {"match_all": {}}}
     execute_search(mock_open_search, dsl_query, page=1, per_page=10)
     mock_open_search.search.assert_called_once_with(
-        {"query": {"match_all": {}}}, from_=0, size=10, timeout=10
+        body={"query": {"match_all": {}}}, from_=0, size=10, timeout=10
     )
 
 


### PR DESCRIPTION
## Changes in this PR


Fix opensearch query api call for client v3 upgrade. See this discussion about the new enforcing of kwargs: https://github.com/opensearch-project/opensearch-py/pull/907#issuecomment-2981325016