### PR TITLE
Extend CSP_IMG_SRC to allow S3_BUCKET_URL

### DIFF
--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -104,7 +104,12 @@ def test_local_env_vars_config_initialized(monkeypatch):
         "'sha256-5F6wlVbvqAuNSR7vsCpdIP/UhcVEa+hoNTMpejqmEkY='",  # pragma: allowlist secret
         "'sha256-d+KBcHLMVDIG87TjOCYsHdPCu+k2B7Tld0nSNiwUllY='",  # pragma: allowlist secret
     ]
-    assert config.CSP_IMG_SRC == ["'self'", "test_flasks3_cdn_domain", "data:"]
+    assert config.CSP_IMG_SRC == [
+        "'self'",
+        "test_flasks3_cdn_domain",
+        "https://test_record_bucket_name.s3.amazonaws.com",
+        "data:",
+    ]
     assert config.CSP_FRAME_SRC == [
         "'self'",
         "https://test_record_bucket_name.s3.amazonaws.com",
@@ -336,6 +341,7 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
     assert config.CSP_IMG_SRC == [
         "'self'",
         "test_flasks3_cdn_domain",
+        "https://test_record_bucket_name.s3.amazonaws.com",
         "data:",
     ]
     assert config.CSP_FRAME_SRC == [

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -208,7 +208,7 @@ class BaseConfig(object):
 
     @property
     def CSP_IMG_SRC(self):
-        return [SELF, self.FLASKS3_CDN_DOMAIN, "data:"]
+        return [SELF, self.FLASKS3_CDN_DOMAIN, self.S3_BUCKET_URL, "data:"]
 
     @property
     def CSP_FRAME_SRC(self):


### PR DESCRIPTION
## Changes in this PR

Extend CSP_IMG_SRC to allow S3_BUCKET_URL


This is a temporary thing so that we can allow the origin of our s3 bucket where the images are stored, but we should probably move it to cloudfront like we do the static assets for the webapp. Will create a ticket for that