### PR TITLE
AYR-1538 - Adjustments to table top margin

### DIFF
--- a/app/static/src/scss/includes/_browse-consignment.scss
+++ b/app/static/src/scss/includes/_browse-consignment.scss
@@ -254,5 +254,9 @@
 }
 
 .sort-container__form {
-  margin-bottom: 24px;
+  margin-bottom: 1.5rem;
+
+  @include on-mobile {
+    margin-bottom: 0.5rem;
+  }
 }

--- a/app/static/src/scss/includes/_browse.scss
+++ b/app/static/src/scss/includes/_browse.scss
@@ -315,6 +315,9 @@
     &-grid--mobile-table {
       order: 2;
       width: auto;
+      @include on-mobile {
+        margin-top: 1rem;
+      }
     }
 
     &__sort-container {


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- On desktop increased the gap between the sort panel and the table/filter to 1.5rem, on mobile this is 0.5rem
- On mobile, increased the gap between the filters and table to 1rem (on mobile the table sits under filters)

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1538

## Screenshots of UI changes

### Before
<img width="390" alt="image" src="https://github.com/user-attachments/assets/b8896e75-a81d-406f-a4a0-3ebd84775753" />

### After
<img width="401" alt="image" src="https://github.com/user-attachments/assets/87a2c537-59d4-444e-a1cc-2e327384f087" />


- [ ] Requires env variable(s) to be updated
