### PR TITLE
AYR-1539 - Closure start date styling on mobile

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -110,6 +110,7 @@
   &__value--record {
     font-size: 1rem;
     text-align: left;
+    word-break: break-all;
   }
 
   /* TNA DESIGNER HAS ASKED THAT WE LEAVE THIS STYLE COMMENTED OUT FOR FUTURE USE */
@@ -209,10 +210,6 @@
   }
 }
 
-.ayr-opening-date {
-  padding-left: 1rem;
-}
-
 .record-container .record-arrangement-list {
   list-style-type: none;
   padding: 0;
@@ -276,6 +273,9 @@
 
 .govuk-tabs__panel {
   padding: "3rem 0:0";
+  @include on-mobile {
+    padding: 0;
+  }
 }
 
 .js-enabled .govuk-tabs__panel {

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -12,7 +12,7 @@
                         {% endif %}
                         {% if dict.get("Closure start date") %}
                             {% if dict.get('opening_date') %}
-                                <span class="ayr-opening-date">Record opening date {{ dict.get('opening_date') }}</span>
+                                <p class="ayr-opening-date">Record opening date {{ dict.get('opening_date') }}</p>
                             {% endif %}
                         {% endif %}
                     {% else %}

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -605,7 +605,7 @@ class TestRecord:
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                 <span class="govuk-tag govuk-tag--green">{record_files[1]["closure_type"].Value}</span>
-<span class="ayr-opening-date">Record opening date {opening_date}</span></dd>
+<p class="ayr-opening-date">Record opening date {opening_date}</p></dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Closure start date</dt>
@@ -775,7 +775,7 @@ class TestRecord:
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Status</dt>
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                 <span class="govuk-tag govuk-tag--red">{record_files[2]["closure_type"].Value}</span>
-                <span class="ayr-opening-date">Record opening date {opening_date}</span></dd>
+                <p class="ayr-opening-date">Record opening date {opening_date}</p></dd>
             </div>
             <div class="govuk-summary-list__row govuk-summary-list__row--record">
                 <dt class="govuk-summary-list__key govuk-summary-list__key--record-table">Closure start date</dt>


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Made the closure start date element a `p` element so it naturally sits under the status span without the need of extra CSS
- Made the contents of the values break anywhere to prevent overflow in the case of large titles (similar to the issue we had with the tables)

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1539

## Screenshots of UI changes

### Before

<img width="323" alt="image" src="https://github.com/user-attachments/assets/db1dbceb-df78-4e50-813a-b613095d0525" />
<img width="271" alt="image" src="https://github.com/user-attachments/assets/ee5d4c5e-ded7-43e2-bf14-06587f5276ae" />


### After

<img width="313" alt="Alternative file name" src="https://github.com/user-attachments/assets/bde2a7bf-3d99-4b05-9701-a35cfa23f4e4" />


- [ ] Requires env variable(s) to be updated
