### PR TITLE
AYR-1682 - Comma separated record count

### DIFF
--- a/app/templates/main/browse.html
+++ b/app/templates/main/browse.html
@@ -14,7 +14,7 @@
                         id="browse-records"
                         aria-live="polite">
                         {% if num_records_found > 0 %}
-                            Browse records {{ num_records_found }}
+                            Browse records {{ num_records_found | format_number_with_commas }}
                         {% else %}
                             No results found
                         {% endif %}

--- a/app/templates/main/search-results-summary.html
+++ b/app/templates/main/search-results-summary.html
@@ -14,7 +14,7 @@
                     id="browse-records"
                     aria-live="polite">
                     {% if num_records_found > 0 %}
-                        Records found {{ num_records_found }}
+                        Records found {{ num_records_found | format_number_with_commas }}
                     {% else %}
                         No results found
                     {% endif %}

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -32,7 +32,7 @@
                     id="browse-records"
                     aria-live="polite">
                     {% if num_records_found > 0 %}
-                        Records found {{ num_records_found }}
+                        Records found {{ num_records_found | format_number_with_commas }}
                     {% else %}
                         No results found
                     {% endif %}

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -10,12 +10,11 @@
                         {% else %}
                             <span class="govuk-tag govuk-tag--green">{{ value }}</span>
                         {% endif %}
-                        <span class="ayr-opening-date">Record opening date test</span>
-                        <!-- {% if dict.get("Closure start date") %}
+                        {% if dict.get("Closure start date") %}
                             {% if dict.get('opening_date') %}
                                 <p class="ayr-opening-date">Record opening date {{ dict.get('opening_date') }}</p>
                             {% endif %}
-                        {% endif %} -->
+                        {% endif %}
                     {% else %}
                         {{ value }}
                     {% endif %}

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -10,11 +10,12 @@
                         {% else %}
                             <span class="govuk-tag govuk-tag--green">{{ value }}</span>
                         {% endif %}
-                        {% if dict.get("Closure start date") %}
+                        <span class="ayr-opening-date">Record opening date test</span>
+                        <!-- {% if dict.get("Closure start date") %}
                             {% if dict.get('opening_date') %}
                                 <p class="ayr-opening-date">Record opening date {{ dict.get('opening_date') }}</p>
                             {% endif %}
-                        {% endif %}
+                        {% endif %} -->
                     {% else %}
                         {{ value }}
                     {% endif %}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- To record count on the browse and search pages above the table added the filter for comma separation of numbers (same one we user for the tables)

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1682

## Screenshots of UI changes

### Before

Browse pages
<img width="896" alt="image" src="https://github.com/user-attachments/assets/1e105286-a5f0-4747-8700-851eebcefa58" />


Search results summary
<img width="617" alt="image" src="https://github.com/user-attachments/assets/af0061f1-10ce-4018-8ae7-f593b8911946" />

Search results transferring body
<img width="612" alt="image" src="https://github.com/user-attachments/assets/f688486a-5b58-4175-a0b4-e830ec7df2a1" />

### After

Browse pages
<img width="911" alt="image" src="https://github.com/user-attachments/assets/4a8457ef-f0ef-4568-9cdc-b11d8172a239" />

Search results summary
<img width="600" alt="image" src="https://github.com/user-attachments/assets/9a571606-5a4d-4fce-8cc5-694372cc8387" />

Search results transferring body
<img width="674" alt="image" src="https://github.com/user-attachments/assets/4b5b1e4e-9e1d-4220-b7dc-8a57b3ddb1ca" />


- [ ] Requires env variable(s) to be updated
