### PR TITLE
added fallback to using file name to extract file extension 

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -717,7 +717,11 @@ def record(record_id: uuid.UUID):
     validate_body_user_groups_or_404(file.consignment.series.body.Name)
 
     file_metadata = get_file_metadata(file.FileId)
-    file_extension = file.ffid_metadata.Extension.lower()
+    if file.ffid_metadata and file.ffid_metadata.Extension:
+        file_extension = file.ffid_metadata.Extension.lower()
+    else:
+        file_extension = file.FileName.split(".")[-1].lower()
+
     can_render_file = (
         file_extension in current_app.config["SUPPORTED_RENDER_EXTENSIONS"]
     )
@@ -849,7 +853,10 @@ def generate_manifest(record_id: uuid.UUID) -> Response:
     file_name = file.FileName
     file_url = create_presigned_url(file)
     manifest_url = f"{url_for('main.generate_manifest', record_id=record_id, _external=True)}"
-    file_type = file.ffid_metadata.Extension.lower()
+    if file.ffid_metadata and file.ffid_metadata.Extension:
+        file_type = file.ffid_metadata.Extension.lower()
+    else:
+        file_type = file.FileName.split(".")[-1].lower()
 
     if (
         file_type

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -52,6 +52,7 @@ from app.main.util.render_utils import (
     generate_image_manifest,
     generate_pdf_manifest,
     get_download_filename,
+    get_file_extension,
 )
 from app.main.util.search_utils import (
     build_search_results_summary_query,
@@ -717,10 +718,8 @@ def record(record_id: uuid.UUID):
     validate_body_user_groups_or_404(file.consignment.series.body.Name)
 
     file_metadata = get_file_metadata(file.FileId)
-    if file.ffid_metadata and file.ffid_metadata.Extension:
-        file_extension = file.ffid_metadata.Extension.lower()
-    else:
-        file_extension = file.FileName.split(".")[-1].lower()
+
+    file_extension = get_file_extension(file)
 
     can_render_file = (
         file_extension in current_app.config["SUPPORTED_RENDER_EXTENSIONS"]
@@ -853,10 +852,8 @@ def generate_manifest(record_id: uuid.UUID) -> Response:
     file_name = file.FileName
     file_url = create_presigned_url(file)
     manifest_url = f"{url_for('main.generate_manifest', record_id=record_id, _external=True)}"
-    if file.ffid_metadata and file.ffid_metadata.Extension:
-        file_type = file.ffid_metadata.Extension.lower()
-    else:
-        file_type = file.FileName.split(".")[-1].lower()
+
+    file_type = get_file_extension(file)
 
     if (
         file_type

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -24,6 +24,15 @@ def generate_breadcrumb_values(file):
     }
 
 
+def get_file_extension(file):
+    """Extarct file_extension"""
+    if file.ffid_metadata and file.ffid_metadata.Extension is not None:
+        file_extension = file.ffid_metadata.Extension.lower()
+    else:
+        file_extension = file.FileName.split(".")[-1].lower()
+    return file_extension
+
+
 def get_download_filename(file):
     """Generate download filename for a file."""
     if file.CiteableReference:

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -263,6 +263,38 @@ class TestRecord:
         assert banner is not None
 
     @mock_aws
+    def test_record_record_alert_banner_is_visible_when_unsupported_file_extension_no_ffid_metadata(
+        self, app, client: FlaskClient, mock_standard_user
+    ):
+        """
+        Given a File with no FFID metadata in the database
+        When a standard user with request to view the record details page
+        Then the response status code should be 200
+        If the extension of the File requested is not compatible with IIIF
+        Then the alert banner responsible with alerting the user should be visible
+        """
+
+        file = FileFactory(
+            FileName="open_file.docx", ffid_metadata__Extension=None
+        )
+
+        bucket_name = "test_bucket"
+
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        mock_standard_user(client, file.consignment.series.body.Name)
+
+        response = client.get(f"{self.route_url}/{file.FileId}#record-details")
+
+        assert response.status_code == 200
+
+        html = response.data.decode()
+
+        soup = BeautifulSoup(html, "html.parser")
+        banner = soup.find("h2", string="Unable to display this record")
+        assert banner is not None
+
+    @mock_aws
     def test_record_record_alert_banner_is_not_visible_when_supported_file_extension(
         self, app, client: FlaskClient, mock_standard_user
     ):
@@ -275,6 +307,37 @@ class TestRecord:
         """
 
         file = FileFactory(ffid_metadata__Extension="pdf")
+        bucket_name = "test_bucket"
+
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+        create_mock_s3_bucket_with_object(bucket_name, file)
+        mock_standard_user(client, file.consignment.series.body.Name)
+
+        response = client.get(f"{self.route_url}/{file.FileId}#record-details")
+
+        assert response.status_code == 200
+
+        html = response.data.decode()
+
+        soup = BeautifulSoup(html, "html.parser")
+        banner = soup.find("h2", string="Unable to display this record")
+        assert banner is None
+
+    @mock_aws
+    def test_record_record_alert_banner_is_not_visible_when_supported_file_extension_no_ffid_metadata(
+        self, app, client: FlaskClient, mock_standard_user
+    ):
+        """
+        Given a File with no FFID metadata in the database
+        When a standard user with request to view the record details page
+        Then the response status code should be 200
+        If the extension of the File requested is compatible with IIIF
+        Then the alert banner responsible with alerting the user should NOT be visible
+        """
+
+        file = FileFactory(
+            FileName="open_file.pdf", ffid_metadata__Extension=None
+        )
         bucket_name = "test_bucket"
 
         app.config["RECORD_BUCKET_NAME"] = bucket_name

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -6,7 +6,26 @@ from app.main.util.render_utils import (
     create_presigned_url,
     generate_breadcrumb_values,
     get_download_filename,
+    get_file_extension,
 )
+
+
+def test_get_file_extension_with_ffid_extension():
+    mock_file = Mock()
+    mock_file.ffid_metadata.Extension = "PDF"
+    mock_file.FileName = "ignored.txt"
+
+    ext = get_file_extension(mock_file)
+    assert ext == "pdf"
+
+
+def test_get_file_extension_with_ffid_extension_none_uses_filename():
+    mock_file = Mock()
+    mock_file.ffid_metadata.Extension = None
+    mock_file.FileName = "example.DOC"
+
+    ext = get_file_extension(mock_file)
+    assert ext == "doc"
 
 
 def test_generate_breadcrumb_values():

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -31,90 +31,6 @@ def verify_cookies_header_row(data):
     ] == expected_row[0]
 
 
-def build_expected_pdf_manifest(file, extension):
-    return {
-        "@context": ["https://iiif.io/api/presentation/3/context.json"],
-        "behavior": ["individuals"],
-        "description": f"Manifest for {file.FileName}",
-        "id": f"http://localhost/record/{file.FileId}/manifest",
-        "items": [
-            {
-                "id": f"http://localhost/record/{file.FileId}/manifest",
-                "items": [
-                    {
-                        "id": f"https://presigned-url.com/download.{extension}",
-                        "items": [
-                            {
-                                "body": {
-                                    "format": f"application/{extension}",
-                                    "id": f"https://presigned-url.com/download.{extension}",
-                                    "type": "Text",
-                                },
-                                "id": f"https://presigned-url.com/download.{extension}",
-                                "label": {"en": ["test"]},
-                                "motivation": "painting",
-                                "target": f"https://presigned-url.com/download.{extension}",
-                                "type": "Annotation",
-                            }
-                        ],
-                        "label": {"en": ["test"]},
-                        "type": "AnnotationPage",
-                    }
-                ],
-                "label": {"en": ["test"]},
-                "type": "Canvas",
-            }
-        ],
-        "label": {"en": [f"{file.FileName}"]},
-        "requiredStatement": {
-            "label": {"en": ["File name"]},
-            "value": {"en": [f"{file.FileName}"]},
-        },
-        "type": "Manifest",
-        "viewingDirection": "left-to-right",
-    }
-
-
-def build_expected_image_manifest(file, extension):
-    return {
-        "@context": "https://iiif.io/api/presentation/3/context.json",
-        "@id": f"http://localhost/record/{file.FileId}/manifest",
-        "@type": "sc:Manifest",
-        "description": f"Manifest for {file.FileName}",
-        "label": {"en": [f"{file.FileName}"]},
-        "sequences": [
-            {
-                "@id": f"https://presigned-url.com/download.{extension}",
-                "@type": "sc:Sequence",
-                "canvases": [
-                    {
-                        "@id": f"https://presigned-url.com/download.{extension}",
-                        "@type": "sc:Canvas",
-                        "height": 600,
-                        "width": 800,
-                        "images": [
-                            {
-                                "@id": f"https://presigned-url.com/download.{extension}",
-                                "@type": "oa:Annotation",
-                                "motivation": "sc:painting",
-                                "on": f"https://presigned-url.com/download.{extension}",
-                                "resource": {
-                                    "@id": f"https://presigned-url.com/download.{extension}",
-                                    "format": f"image/{extension}",
-                                    "height": 600,
-                                    "type": "dctypes:Image",
-                                    "width": 800,
-                                },
-                            }
-                        ],
-                        "label": "Image 1",
-                    }
-                ],
-            }
-        ],
-    }
-
-
 def verify_cookies_data_rows(data, expected_rows):
     """
     this function check data rows for data table compared with expected rows
@@ -217,44 +133,49 @@ class TestRoutes:
         response = client.get(f"{self.record_route_url}/{file.FileId}/manifest")
         assert response.status_code == 200
 
-        expected_pdf_manifest = build_expected_pdf_manifest(
-            file, file.ffid_metadata.Extension
-        )
+        expected_pdf_manifest = {
+            "@context": ["https://iiif.io/api/presentation/3/context.json"],
+            "behavior": ["individuals"],
+            "description": f"Manifest for {file.FileName}",
+            "id": f"http://localhost/record/{file.FileId}/manifest",
+            "items": [
+                {
+                    "id": f"http://localhost/record/{file.FileId}/manifest",
+                    "items": [
+                        {
+                            "id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                            "items": [
+                                {
+                                    "body": {
+                                        "format": f"application/{file.ffid_metadata.Extension}",
+                                        "id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                        "type": "Text",
+                                    },
+                                    "id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                    "label": {"en": ["test"]},
+                                    "motivation": "painting",
+                                    "target": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                    "type": "Annotation",
+                                }
+                            ],
+                            "label": {"en": ["test"]},
+                            "type": "AnnotationPage",
+                        }
+                    ],
+                    "label": {"en": ["test"]},
+                    "type": "Canvas",
+                }
+            ],
+            "label": {"en": [f"{file.FileName}"]},
+            "requiredStatement": {
+                "label": {"en": ["File name"]},
+                "value": {"en": [f"{file.FileName}"]},
+            },
+            "type": "Manifest",
+            "viewingDirection": "left-to-right",
+        }
 
         actual_manifest = json.loads(response.text)
-        assert response.status_code == 200
-        assert actual_manifest == expected_pdf_manifest
-
-    @mock_aws
-    @patch("app.main.routes.create_presigned_url")
-    def test_route_generate_pdf_manifest_no_ffid_metadata(
-        self,
-        mock_create_presigned_url,
-        app,
-        client: FlaskClient,
-        mock_all_access_user,
-    ):
-        mock_create_presigned_url.return_value = (
-            "https://presigned-url.com/download.pdf"
-        )
-
-        mock_all_access_user(client)
-        file = FileFactory(
-            FileName="open_file.pdf", ffid_metadata__Extension=None
-        )
-
-        bucket_name = "test_bucket"
-        app.config["RECORD_BUCKET_NAME"] = bucket_name
-        create_mock_s3_bucket_with_object(bucket_name, file)
-
-        response = client.get(f"{self.record_route_url}/{file.FileId}/manifest")
-        assert response.status_code == 200
-
-        expected_pdf_manifest = build_expected_pdf_manifest(file, "pdf")
-
-        actual_manifest = json.loads(response.text)
-        print(f"Expected PDF manifest:\n{expected_pdf_manifest}")
-        print(f"Actual image Manifest:\n{actual_manifest}")
         assert response.status_code == 200
         assert actual_manifest == expected_pdf_manifest
 
@@ -281,42 +202,43 @@ class TestRoutes:
         response = client.get(f"{self.record_route_url}/{file.FileId}/manifest")
         assert response.status_code == 200
 
-        expected_image_manifest = build_expected_image_manifest(
-            file, file.ffid_metadata.Extension
-        )
-
-        actual_manifest = json.loads(response.text)
-
-        assert response.status_code == 200
-        assert actual_manifest == expected_image_manifest
-
-    @mock_aws
-    @patch("app.main.routes.create_presigned_url")
-    def test_route_generate_image_manifest_no_ffid_metadata(
-        self,
-        mock_create_presigned_url,
-        app,
-        client: FlaskClient,
-        mock_all_access_user,
-    ):
-
-        mock_all_access_user(client)
-        file = FileFactory(
-            FileName="open_file.png", ffid_metadata__Extension=None
-        )
-        bucket_name = "test_bucket"
-        app.config["RECORD_BUCKET_NAME"] = bucket_name
-        create_mock_s3_bucket_with_imaage_object(bucket_name, file)
-
-        mock_create_presigned_url.return_value = (
-            "https://presigned-url.com/download.png"
-        )
-
-        response = client.get(f"{self.record_route_url}/{file.FileId}/manifest")
-        assert response.status_code == 200
-
-        expected_image_manifest = build_expected_image_manifest(file, "png")
-
+        expected_image_manifest = {
+            "@context": "https://iiif.io/api/presentation/3/context.json",
+            "@id": f"http://localhost/record/{file.FileId}/manifest",
+            "@type": "sc:Manifest",
+            "description": f"Manifest for {file.FileName}",
+            "label": {"en": [f"{file.FileName}"]},
+            "sequences": [
+                {
+                    "@id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                    "@type": "sc:Sequence",
+                    "canvases": [
+                        {
+                            "@id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                            "@type": "sc:Canvas",
+                            "height": 600,
+                            "width": 800,
+                            "images": [
+                                {
+                                    "@id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                    "@type": "oa:Annotation",
+                                    "motivation": "sc:painting",
+                                    "on": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                    "resource": {
+                                        "@id": f"https://presigned-url.com/download.{file.ffid_metadata.Extension}",
+                                        "format": f"image/{file.ffid_metadata.Extension}",
+                                        "height": 600,
+                                        "type": "dctypes:Image",
+                                        "width": 800,
+                                    },
+                                }
+                            ],
+                            "label": "Image 1",
+                        }
+                    ],
+                }
+            ],
+        }
         actual_manifest = json.loads(response.text)
 
         assert response.status_code == 200
@@ -460,37 +382,6 @@ class TestRoutes:
         assert response.status_code == 200
         assert json.loads(response.text) == {"mock": "pdf_manifest"}
 
-    @mock_aws
-    @patch("app.main.routes.boto3.client")
-    @patch("app.main.routes.generate_pdf_manifest")
-    def test_generate_manifest_pdf_no_ffid_metadata(
-        self,
-        mock_pdf,
-        mock_boto_client,
-        app,
-        client: FlaskClient,
-        mock_all_access_user,
-    ):
-        """
-        Test that a PDF manifest is successfully generated when there's no FFID Metadata
-        """
-        mock_all_access_user(client)
-        file = FileFactory(
-            FileName="open_file.pdf", ffid_metadata__Extension=None
-        )
-        bucket_name = "test_bucket"
-        app.config["RECORD_BUCKET_NAME"] = bucket_name
-
-        s3_mock = mock_boto_client.return_value
-        s3_mock.get_object.return_value = {"Body": b"file content"}
-
-        mock_pdf.return_value = ({"mock": "pdf_manifest"}, 200)
-        response = client.get(f"/record/{file.FileId}/manifest")
-
-        mock_pdf.assert_called_once()
-        assert response.status_code == 200
-        assert json.loads(response.text) == {"mock": "pdf_manifest"}
-
     @pytest.mark.parametrize(
         "image_format", UNIVERSAL_VIEWER_SUPPORTED_IMAGE_TYPES
     )
@@ -527,42 +418,6 @@ class TestRoutes:
         assert response.status_code == 200
         assert json.loads(response.text) == {"mock": "image_manifest"}
 
-    @pytest.mark.parametrize(
-        "image_format", UNIVERSAL_VIEWER_SUPPORTED_IMAGE_TYPES
-    )
-    @mock_aws
-    @patch("app.main.routes.boto3.client")
-    @patch("app.main.routes.generate_image_manifest")
-    def test_generate_manifest_image_no_ffid_metadata(
-        self,
-        mock_image,
-        mock_boto_client,
-        app,
-        client: FlaskClient,
-        mock_all_access_user,
-        image_format,
-    ):
-        """
-        Test that a image manifest is successfully generated
-        """
-        mock_all_access_user(client)
-        file = FileFactory(
-            FileName=f"image.{image_format}",
-            ffid_metadata__Extension=None,
-        )
-        bucket_name = "test_bucket"
-        app.config["RECORD_BUCKET_NAME"] = bucket_name
-
-        s3_mock = mock_boto_client.return_value
-        s3_mock.get_object.return_value = {"Body": b"file content"}
-
-        mock_image.return_value = ({"mock": "image_manifest"}, 200)
-        response = client.get(f"/record/{file.FileId}/manifest")
-
-        mock_image.assert_called_once()
-        assert response.status_code == 200
-        assert json.loads(response.text) == {"mock": "image_manifest"}
-
     @mock_aws
     @patch("app.main.routes.boto3.client")
     def test_generate_manifest_unsupported(
@@ -578,33 +433,6 @@ class TestRoutes:
         """
         mock_all_access_user(client)
         file = FileFactory(ffid_metadata__Extension="docx")
-        bucket_name = "test_bucket"
-        app.config["RECORD_BUCKET_NAME"] = bucket_name
-
-        s3_mock = mock_boto_client.return_value
-        s3_mock.get_object.return_value = {"Body": b"file content"}
-
-        response = client.get(f"/record/{file.FileId}/manifest")
-        assert response.status_code == 400
-        assert "Failed to create manifest for file with ID" in caplog.text
-
-    @mock_aws
-    @patch("app.main.routes.boto3.client")
-    def test_generate_manifest_unsupported_no_ffid_metadata(
-        self,
-        mock_boto_client,
-        app,
-        client: FlaskClient,
-        mock_all_access_user,
-        caplog,
-    ):
-        """
-        Test that an unsupported format will return a bad request and log the error
-        """
-        mock_all_access_user(client)
-        file = FileFactory(
-            FileName="open_file.docx", ffid_metadata__Extension=None
-        )
         bucket_name = "test_bucket"
         app.config["RECORD_BUCKET_NAME"] = bucket_name
 

--- a/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
@@ -55,7 +55,11 @@ SUPPORTED_TEXTRACT_FORMATS = [
 
 
 def add_text_content(file: Dict, file_stream: bytes) -> Dict:
-    file_type = file["file_extension"].lower()
+
+    if file["file_extension"] is None:
+        file_type = file["file_name"].split(".")[-1].lower()
+    else:
+        file_type = file["file_extension"].lower()
     file_id = file["file_id"]
 
     if file_type not in SUPPORTED_TEXTRACT_FORMATS:

--- a/data_management/opensearch_indexer/tests/test_text_extraction.py
+++ b/data_management/opensearch_indexer/tests/test_text_extraction.py
@@ -137,6 +137,37 @@ def test_add_text_content_success(mock_extract_text, caplog):
     assert "Text extraction succeeded for file 1" in caplog.text
 
 
+def test_add_text_content_no_ffid_metadata_success(mock_extract_text, caplog):
+    """
+    Given a supported file type and a valid file stream and without FFID metadata,
+    When text extraction succeeds,
+    Then the content is updated and the status is set to SUCCEEDED.
+    """
+
+    # Given
+    file = {
+        "file_id": 1,
+        "file_name": "example.pdf",
+        "file_extension": None,
+        "content": "",
+        "text_extraction_status": "",
+    }
+    file_stream = b"Some file content"
+    mock_extract_text.return_value = "Extracted text"
+
+    # When
+    result = add_text_content(file, file_stream)
+
+    # Then
+    assert result["content"] == "Extracted text"
+    assert (
+        result["text_extraction_status"] == TextExtractionStatus.SUCCEEDED.value
+    )
+    mock_extract_text.assert_called_once_with(file_stream, "pdf")
+
+    assert "Text extraction succeeded for file 1" in caplog.text
+
+
 # Test for unsupported file type
 def test_add_text_content_unsupported_format(caplog):
     """


### PR DESCRIPTION
…Metadata not available

<!-- Amend as appropriate -->

## Changes in this PR
added fallback to using file name to extract file extension when FFIDMetadata not available
## JIRA ticket
[AYR-1658](https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?jql=assignee%20%3D%2060ba6c41f8a90b006f65b5fb&selectedIssue=AYR-1658)


[AYR-1658]: https://national-archives.atlassian.net/browse/AYR-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ