### PR TITLE
fix critical indexer image vulnerabilities

### DIFF
--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     python-dev-is-python3 \
     libxml2-dev libxslt1-dev \
     antiword unrtf poppler-utils tesseract-ocr \
-    flac ffmpeg lame libmad0 libsox-fmt-mp3 sox \
+    flac lame libmad0 libsox-fmt-mp3 sox \
     libjpeg-dev swig \
     libreoffice \
     && apt-get clean

--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -5,11 +5,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-dev \
     libxml2-dev libxslt1-dev \
     antiword unrtf poppler-utils tesseract-ocr \
-    flac lame libmad0 libsox-fmt-mp3 sox \
-    libjpeg-dev swig libreoffice \
-    ffmpeg \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    flac ffmpeg lame libmad0 libsox-fmt-mp3 sox \
+    libjpeg-dev swig \
+    libreoffice \
+    && apt-get clean
 
 # Set working directory
 WORKDIR /app
@@ -20,8 +19,7 @@ COPY requirements.txt .
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy app
 COPY opensearch_indexer/ ./opensearch_indexer
 
-# Run main
+# Run main.py
 CMD ["python", "-m", "opensearch_indexer.index_consignment.main"]

--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -1,14 +1,15 @@
-FROM python:3.13.5
+FROM python:3.13-slim-bookworm
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
-    python-dev-is-python3 \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3-dev \
     libxml2-dev libxslt1-dev \
     antiword unrtf poppler-utils tesseract-ocr \
     flac lame libmad0 libsox-fmt-mp3 sox \
-    libjpeg-dev swig \
-    libreoffice \
-    && apt-get clean
+    libjpeg-dev swig libreoffice \
+    ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Set working directory
 WORKDIR /app
@@ -19,7 +20,8 @@ COPY requirements.txt .
 # Install Python dependencies
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Copy app
 COPY opensearch_indexer/ ./opensearch_indexer
 
-# Run main.py
+# Run main
 CMD ["python", "-m", "opensearch_indexer.index_consignment.main"]


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Changed indexer base image to  `python:3.13-slim-bookworm`
## JIRA ticket
[AYR-1706](https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?jql=assignee%20%3D%2060ba6c41f8a90b006f65b5fb&selectedIssue=AYR-1706)


[AYR-1706]: https://national-archives.atlassian.net/browse/AYR-1706?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ