### PR TITLE
AYR-1654 - Add semantic dates 

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import inspect
+from datetime import datetime
 
 import bleach
 from flask import Flask, g
@@ -45,6 +46,18 @@ def format_number_with_commas(number):
     return f"{number:,}"
 
 
+def format_date_iso(value):
+    """Convert 'DD/MM/YYYY' to 'YYYY-MM-DD' if input is a string."""
+    if not isinstance(value, str):
+        return value
+
+    try:
+        date_obj = datetime.strptime(value, "%d/%m/%Y")
+        return date_obj.strftime("%Y-%m-%d")
+    except ValueError:
+        return value
+
+
 def create_app(config_class, database_uri=None):
     app = Flask(__name__, static_url_path="/assets")
     config = config_class()
@@ -65,6 +78,7 @@ def create_app(config_class, database_uri=None):
     app.jinja_env.filters["format_number_with_commas"] = (
         format_number_with_commas
     )
+    app.jinja_env.filters["format_date_iso"] = format_date_iso
     app.jinja_loader = ChoiceLoader(
         [
             PackageLoader("app"),

--- a/app/templates/main/browse-all.html
+++ b/app/templates/main/browse-all.html
@@ -68,7 +68,7 @@
                                     <a href="{{ url_for('main.browse_series', _id= record['series_id']) }}">{{ record["series"] }}</a>
                                 </td>
                                 <td class="govuk-table__cell govuk-table--right-align govuk-table--on-mobile--no-padding-right">
-                                    {{ record["last_record_transferred"] }}
+                                    <time datetime="{{ record["last_record_transferred"] | format_date_iso }}">{{ record["last_record_transferred"] }}</time>
                                 </td>
                                 <td class="govuk-table__cell govuk-table--right-align govuk-table--invisible-on-mobile">
                                     {{ record["records_held"] | format_number_with_commas }}

--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -65,7 +65,7 @@
                         {% for record in results %}
                             <tr class="govuk-table__row govuk-table__row-ref">
                                 <td class="govuk-table__cell govuk-table__cell--word-break-all govuk-table__cell--on-mobile--flex-layout-col">
-                                    {{ record["date_of_record"] }}
+                                    <time datetime="{{ record["date_of_record"] | format_date_iso }}">{{ record["date_of_record"] }}</time>
                                     <a class="govuk-table--invisible-on-desktop govuk-!-static-margin-top-2"
                                        href="{{ url_for('main.record', record_id=record['file_id']) }}">{{ record["file_name"] }}</a>
                                 </td>
@@ -79,7 +79,7 @@
                                 </td>
                                 <td class="govuk-table__cell govuk-table--right-align">
                                     {% if record['opening_date'] %}
-                                        {{ record['opening_date'] }}
+                                        <time datetime="{{ record['opening_date'] | format_date_iso }}">{{ record['opening_date'] }}</time>
                                     {% else %}
                                         –
                                     {% endif %}

--- a/app/templates/main/browse-series.html
+++ b/app/templates/main/browse-series.html
@@ -57,7 +57,9 @@
                                     {{ record["transferring_body"] }}
                                 </td>
                                 <td class="govuk-table__cell govuk-table--invisible-on-mobile">{{ record["series"] }}</td>
-                                <td class="govuk-table__cell govuk-table--on-desktop--right-align">{{ record["last_record_transferred"] }}</td>
+                                <td class="govuk-table__cell govuk-table--on-desktop--right-align">
+                                    <time datetime="{{ record["last_record_transferred"] | format_date_iso }}">{{ record["last_record_transferred"] }}</time>
+                                </td>
                                 <td class="govuk-table__cell govuk-table--right-align">{{ record["records_held"] | format_number_with_commas }}</td>
                                 <td class="govuk-table__cell">
                                     <a href="{{ url_for('main.browse_consignment', _id=record['consignment_id']) }}">{{ record["consignment_reference"] }}</a>

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -212,7 +212,7 @@
                                                                         </td>
                                                                         <td class="govuk-table__cell govuk-table__cell--metadata govuk-table--right-align">
                                                                             {% if record['_source']['opening_date'] %}
-                                                                                {{ record['_source']['opening_date'] }}
+                                                                                <time datetime="{{ record['_source']['opening_date'] | format_date_iso }}">{{ record['_source']['opening_date'] }}</time>
                                                                             {% else %}
                                                                                 –
                                                                             {% endif %}

--- a/app/tests/test_jinja_filters.py
+++ b/app/tests/test_jinja_filters.py
@@ -2,6 +2,7 @@ import pytest
 
 from app import (
     clean_tags_and_replace_highlight_tag,
+    format_date_iso,
     format_number_with_commas,
     format_opensearch_field_name,
     null_to_dash,
@@ -147,3 +148,32 @@ def test_format_opensearch_field_name(field, expected):
 )
 def test_format_number_with_commas(input_value, expected_output):
     assert format_number_with_commas(input_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        # Valid date
+        ("13/03/2025", "2025-03-13"),
+        # Leading zeros
+        ("01/01/2000", "2000-01-01"),
+        # End of year
+        ("31/12/1999", "1999-12-31"),
+        # Invalid format: wrong order
+        ("2025/03/13", "2025/03/13"),
+        # Invalid separator
+        ("13-03-2025", "13-03-2025"),
+        # Completely invalid string
+        ("not a date", "not a date"),
+        # Empty string
+        ("", ""),
+        # None input
+        (None, None),
+        # Integer input
+        (12345, 12345),
+        # List input
+        (["13/03/2025"], ["13/03/2025"]),
+    ],
+)
+def test_format_date_iso(input_value, expected_output):
+    assert format_date_iso(input_value) == expected_output


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Added a jinja filter that converts our dates from format `DD/MM/YYYY` to `YYYY-MM-DD` (needed for the time element) plus unit tests
- Replaced instances where we had dates as plain text as `<time>` HTML elements with attribute `datetime` that takes in the converted date in the format `YYYY-MM-DD`

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-1654

## Screenshots of UI changes

N/A

- [ ] Requires env variable(s) to be updated
