### PR TITLE
Pin pre-commit safety version to 3.6.1

### DIFF
--- a/custom_hooks/safety_check.sh
+++ b/custom_hooks/safety_check.sh
@@ -10,7 +10,7 @@ fi
 # Install safety if not installed
 if ! command -v safety &> /dev/null; then
     echo "Safety is not installed. Installing..."
-    pip install safety==3.4.0b8
+    pip install safety==3.6.1
 fi
 # The --ignore flag was added here because the vulnerability with ID 70612 as reported by Safety CLI exists for all the latest versions of Jinja, it can be removed once fixed
 poetry export --without-hashes -f requirements.txt | safety check --full-report --stdin --ignore=70612


### PR DESCRIPTION
## Changes in this PR
Pin pre-commit safety version to 3.6.1

To fix https://github.com/pyupio/safety/issues/784 that is affecting all of our prs at the moment