### PR TITLE
Fix for search results when there is no highlights

### DIFF
--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -132,13 +132,9 @@
                                                             </td>
                                                         {% else %}
                                                             {% set file_name = record['_source']['file_name'] %}
+                                                            <td class="govuk-table__cell">File name</td>
                                                             <td class="govuk-table__cell">
-                                                                File name
-                                                            </td>
-                                                            <td class="govuk-table__cell">
-                                                                <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">
-                                                                    {{ file_name }}
-                                                                </a>
+                                                                <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">{{ file_name }}</a>
                                                             </td>
                                                         {% endif %}
                                                     </tr>

--- a/app/templates/main/search-transferring-body.html
+++ b/app/templates/main/search-transferring-body.html
@@ -100,74 +100,80 @@
                                                 {% for record in results %}
                                                     {% set main_loop_index = loop.index %}
                                                     <tr class="govuk-table__row govuk-table__row--primary">
-                                                        {% set first_field = record['highlight'].keys() | list | first %}
-                                                        {% set first_field_formatted = first_field | format_opensearch_field_name %}
-                                                        {% set first_result_value = record['highlight'].values() | list | first | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe %}
-                                                        {% set total_fields = record['highlight'].keys() | length %}
-                                                        {% set file_name = record['_source']['file_name'] %}
-                                                        <td class="govuk-table__cell">
-                                                            <div class="govuk-table__cell__data">
-                                                                <button disabled
-                                                                        data-main-row="{{ main_loop_index }}"
-                                                                        data-file-name="{{ file_name }}"
-                                                                        class="govuk-table__toggle-button"
-                                                                        aria-label="Expand rows for file {{ file_name }}"
-                                                                        aria-controls="{% for i in range(total_fields) %}hidden-row-{{ main_loop_index }}-{{ i }}{% if not loop.last %} {% endif %}{% endfor %}"
-                                                                        aria-expanded="false"
-                                                                        type="button"></button>
-                                                                {% if record['highlight'] %}
+                                                        {% if record['highlight'] %}
+                                                            {% set first_field = record['highlight'].keys() | list | first %}
+                                                            {% set first_field_formatted = first_field | format_opensearch_field_name %}
+                                                            {% set first_result_value = record['highlight'].values() | list | first | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe %}
+                                                            {% set total_fields = record['highlight'].keys() | length %}
+                                                            {% set file_name = record['_source']['file_name'] %}
+                                                            <td class="govuk-table__cell">
+                                                                <div class="govuk-table__cell__data">
+                                                                    <button disabled
+                                                                            data-main-row="{{ main_loop_index }}"
+                                                                            data-file-name="{{ file_name }}"
+                                                                            class="govuk-table__toggle-button"
+                                                                            aria-label="Expand rows for file {{ file_name }}"
+                                                                            aria-controls="{% for i in range(total_fields) %}hidden-row-{{ main_loop_index }}-{{ i }}{% if not loop.last %} {% endif %}{% endfor %}"
+                                                                            aria-expanded="false"
+                                                                            type="button"></button>
                                                                     {% if total_fields > 1 %}
                                                                         <span>{{ first_field_formatted }} <span data-main-row="{{ main_loop_index }}" class="field-count hidden">+{{ total_fields - 1 }}</span></span>
                                                                     {% else %}
                                                                         {{ first_field_formatted }}
                                                                     {% endif %}
-                                                                {% else %}
-                                                                    None
-                                                                {% endif %}
-                                                            </div>
-                                                        </td>
-                                                        <td class="govuk-table__cell">
-                                                            {% if record['highlight'] %}
+                                                                </div>
+                                                            </td>
+                                                            <td class="govuk-table__cell">
                                                                 {% if first_field == "file_name" %}
                                                                     <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">{{ first_result_value }}</a>
                                                                 {% else %}
                                                                     {{ first_result_value }}
                                                                 {% endif %}
-                                                            {% else %}
-                                                                None
-                                                            {% endif %}
-                                                        </td>
-                                                    </tr>
-                                                    {% if record['highlight'].keys() | list | first != 'file_name' %}
-                                                        <tr class="govuk-table__row govuk-table__row--file-name">
-                                                            <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">File name</td>
-                                                            <td class="govuk-table__cell govuk-table__cell--no-pt">
+                                                            </td>
+                                                        {% else %}
+                                                            {% set file_name = record['_source']['file_name'] %}
+                                                            <td class="govuk-table__cell">
+                                                                File name
+                                                            </td>
+                                                            <td class="govuk-table__cell">
                                                                 <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">
-                                                                    {% if 'file_name' in record['highlight'].keys() | list %}
-                                                                        {{ record['highlight']['file_name'] | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe }}
-                                                                    {% else %}
-                                                                        {{ record['_source']['file_name'] }}
-                                                                    {% endif %}
+                                                                    {{ file_name }}
                                                                 </a>
                                                             </td>
-                                                        </tr>
-                                                    {% endif %}
-                                                    {% set items = record['highlight'].items() | list %}
-                                                    {% for key, value in items[1:] %}
-                                                        {% if key != 'file_name' %}
-                                                            <tr id="hidden-row-{{ main_loop_index }}-{{ loop.index }}"
-                                                                data-main-row="{{ main_loop_index }}"
-                                                                aria-expanded="false"
-                                                                class="govuk-table__row hidden-row-styles top-row">
-                                                                <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">
-                                                                    {{ key | format_opensearch_field_name }}
-                                                                </td>
+                                                        {% endif %}
+                                                    </tr>
+                                                    {% if record['highlight'] %}
+                                                        {% if record['highlight'].keys() | list | first != 'file_name' %}
+                                                            <tr class="govuk-table__row govuk-table__row--file-name">
+                                                                <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">File name</td>
                                                                 <td class="govuk-table__cell govuk-table__cell--no-pt">
-                                                                    {{ value | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe }}
+                                                                    <a href="{{ url_for('main.record', record_id=record['_source']['file_id']) }}">
+                                                                        {% if 'file_name' in record['highlight'].keys() | list %}
+                                                                            {{ record['highlight']['file_name'] | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe }}
+                                                                        {% else %}
+                                                                            {{ record['_source']['file_name'] }}
+                                                                        {% endif %}
+                                                                    </a>
                                                                 </td>
                                                             </tr>
                                                         {% endif %}
-                                                    {% endfor %}
+                                                        {% set items = record['highlight'].items() | list %}
+                                                        {% for key, value in items[1:] %}
+                                                            {% if key != 'file_name' %}
+                                                                <tr id="hidden-row-{{ main_loop_index }}-{{ loop.index }}"
+                                                                    data-main-row="{{ main_loop_index }}"
+                                                                    aria-expanded="false"
+                                                                    class="govuk-table__row hidden-row-styles top-row">
+                                                                    <td class="govuk-table__cell govuk-table__cell--with-padding govuk-table__cell--no-pt">
+                                                                        {{ key | format_opensearch_field_name }}
+                                                                    </td>
+                                                                    <td class="govuk-table__cell govuk-table__cell--no-pt">
+                                                                        {{ value | join(' ... ')| clean_tags_and_replace_highlight_tag(highlight_tag) | safe }}
+                                                                    </td>
+                                                                </tr>
+                                                            {% endif %}
+                                                        {% endfor %}
+                                                    {% endif %}
                                                     <tr id="hidden-row-{{ main_loop_index }}-0"
                                                         data-main-row="{{ main_loop_index }}"
                                                         aria-expanded="false"

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -2274,18 +2274,11 @@ class TestSearchTransferringBody:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         table_body = soup.find("tbody")
-        rows = table_body.find_all("tr")
-        # Find the row with file name
-        found = False
-        for row in rows:
-            cells = row.find_all("td")
-            if len(cells) == 2 and "File name" in cells[0].get_text():
-                link = cells[1].find("a")
-                assert link
-                assert file_name in link.get_text()
-                assert url_for("main.record", record_id=file_id) in link["href"]
-                found = True
-        assert found
+        table_rows_cell_values = get_table_rows_cell_values(table_body)
+        assert ["File name", file_name] in table_rows_cell_values
+
+        assert ["series_name", "series_y"] not in table_rows_cell_values
+        assert ["consignment_reference", "cref2"] not in table_rows_cell_values
 
     @patch("app.main.util.search_utils.OpenSearch")
     def test_search_transferring_body_empty_highlights_renders_file_name_and_search_results(
@@ -2339,14 +2332,8 @@ class TestSearchTransferringBody:
         assert response.status_code == 200
         soup = BeautifulSoup(response.data, "html.parser")
         table_body = soup.find("tbody")
-        rows = table_body.find_all("tr")
-        found = False
-        for row in rows:
-            cells = row.find_all("td")
-            if len(cells) == 2 and "File name" in cells[0].get_text():
-                link = cells[1].find("a")
-                assert link
-                assert file_name in link.get_text()
-                assert url_for("main.record", record_id=file_id) in link["href"]
-                found = True
-        assert found
+        table_rows_cell_values = get_table_rows_cell_values(table_body)
+        assert ["File name", file_name] in table_rows_cell_values
+
+        assert ["series_name", "series_y"] not in table_rows_cell_values
+        assert ["consignment_reference", "cref2"] not in table_rows_cell_values

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -2277,8 +2277,8 @@ class TestSearchTransferringBody:
         table_rows_cell_values = get_table_rows_cell_values(table_body)
         assert ["File name", file_name] in table_rows_cell_values
 
-        assert ["series_name", "series_y"] not in table_rows_cell_values
-        assert ["consignment_reference", "cref2"] not in table_rows_cell_values
+        assert ["series_name", "series_x"] not in table_rows_cell_values
+        assert ["consignment_reference", "cref"] not in table_rows_cell_values
 
     @patch("app.main.util.search_utils.OpenSearch")
     def test_search_transferring_body_empty_highlights_renders_file_name_and_search_results(
@@ -2335,5 +2335,5 @@ class TestSearchTransferringBody:
         table_rows_cell_values = get_table_rows_cell_values(table_body)
         assert ["File name", file_name] in table_rows_cell_values
 
-        assert ["series_name", "series_y"] not in table_rows_cell_values
-        assert ["consignment_reference", "cref2"] not in table_rows_cell_values
+        assert ["series_name", "series_x"] not in table_rows_cell_values
+        assert ["consignment_reference", "cref"] not in table_rows_cell_values

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -2335,5 +2335,5 @@ class TestSearchTransferringBody:
         table_rows_cell_values = get_table_rows_cell_values(table_body)
         assert ["File name", file_name] in table_rows_cell_values
 
-        assert ["series_name", "series_x"] not in table_rows_cell_values
-        assert ["consignment_reference", "cref"] not in table_rows_cell_values
+        assert ["series_name", "series_y"] not in table_rows_cell_values
+        assert ["consignment_reference", "cref2"] not in table_rows_cell_values

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -2229,7 +2229,7 @@ class TestSearchTransferringBody:
         client,
         mock_standard_user,
         browse_consignment_files,
-        ):
+    ):
         """
         Given a standard user accessing the search transferring body page
         When a record has no highlights
@@ -2264,7 +2264,9 @@ class TestSearchTransferringBody:
         mock_standard_user(
             client, browse_consignment_files[0].consignment.series.body.Name
         )
-        transferring_body_id = browse_consignment_files[0].consignment.series.body.BodyId
+        transferring_body_id = browse_consignment_files[
+            0
+        ].consignment.series.body.BodyId
 
         response = client.get(
             f"/search/transferring_body/{transferring_body_id}?query=plain"
@@ -2292,7 +2294,7 @@ class TestSearchTransferringBody:
         client,
         mock_standard_user,
         browse_consignment_files,
-        ):
+    ):
         """
         Given a standard user accessing the search transferring body page
         When a record has an empty highlights dict
@@ -2327,7 +2329,9 @@ class TestSearchTransferringBody:
         mock_standard_user(
             client, browse_consignment_files[0].consignment.series.body.Name
         )
-        transferring_body_id = browse_consignment_files[0].consignment.series.body.BodyId
+        transferring_body_id = browse_consignment_files[
+            0
+        ].consignment.series.body.BodyId
 
         response = client.get(
             f"/search/transferring_body/{transferring_body_id}?query=plain"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Showing search results if there is only `transferring_body` without highlights 

## JIRA ticket
[AYR-1749]([AYR-1749](https://national-archives.atlassian.net/browse/AYR-1749))

## Screenshots of UI changes

### Before
<img width="1351" height="414" alt="6bfb89d3-23e5-4061-8cf8-b3563485495c" src="https://github.com/user-attachments/assets/e13bf978-e8ac-49fa-8ad7-2f65eec9d0e8" />


### After
it should look like this without the highlight 
<img width="749" height="133" alt="f7928edc-06d1-4239-97c8-f37cf628db15" src="https://github.com/user-attachments/assets/e2cd531c-8b20-4093-ae3a-e196ed80fca4" />

- [ ] Requires env variable(s) to be updated


[AYR-1749]: https://national-archives.atlassian.net/browse/AYR-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AYR-1749]: https://national-archives.atlassian.net/browse/AYR-1749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ