### PR TITLE
Hot reloading for dev webapp container

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,41 @@
+# Python
+.venv
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.pytest_cache
+.coverage
+*.egg-info
+
+# Node.js
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Development and testing
+.env*
+.git
+.gitignore
+README.md
+*.log
+pytestdebug.log
+
+# IDEs and editors
+.vscode
+.idea
+*.swp
+*.swo
+
+# Build artifacts
+.DS_Store
+Thumbs.db
+
+# Local services and development files
+local_services
+e2e_tests
+performance_tests
+snapshots
+
+# CI/CD
+.github

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -12,131 +12,41 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.1.1
 
-    - name: Set up environment variables
+    - name: Set up Docker Compose
+      uses: docker/setup-compose-action@364cc21a5de5b1ee4a7f5f9d3fa374ce0ccde746 # v1.2.0
+      with:
+        version: v2.40.3
+
+    - name: Pre-build webapp image with cache
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        push: false
+        load: true
+        tags: "da-ayr-beta-webapp:latest"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Set up environment variables for services
       run: | # pragma: allowlist secret
         cd local_services
-        cat > .docker.env << EOF
-        CONFIG_SOURCE=ENVIRONMENT_VARIABLES
-        PYTHONUNBUFFERED=1
-        FLASK_ENV=development
-        DB_HOST=webapp_postgres
-        DB_PORT=5432
-        DB_NAME=local_db
-        DB_USER=local_db_user
-        DB_PASSWORD=local_db_user_password
-        DB_SSL_ROOT_CERTIFICATE=/app/local_services/webapp_postgres_certs/root-ca.pem
-        SQLALCHEMY_SSL_MODE=disable
-        KEYCLOAK_BASE_URI=http://keycloak:8080
-        KEYCLOAK_CLIENT_ID=ayr-beta
-        KEYCLOAK_REALM_NAME=tdr
-        KEYCLOAK_CLIENT_SECRET=test-client-secret
-        AWS_ENDPOINT_URL=http://minio:9000
-        AWS_ACCESS_KEY_ID=ROOTNAME
-        AWS_SECRET_ACCESS_KEY=CHANGEME123
-        AWS_REGION=eu-west-2
-        SECRET_KEY=test-secret-key
-        DEFAULT_PAGE_SIZE=10
-        DEFAULT_DATE_FORMAT=DD/MM/YYYY
-        RECORD_BUCKET_NAME=test-record-download
-        FLASKS3_ACTIVE=False
-        FLASKS3_CDN_DOMAIN=localhost
-        FLASKS3_BUCKET_NAME=test-record-download
-        PERF_TEST=False
-        OPEN_SEARCH_HOST=http://opensearch-node1:9200
-        OPEN_SEARCH_USERNAME=
-        OPEN_SEARCH_PASSWORD=
-        OPEN_SEARCH_CA_CERTS=
-        OPEN_SEARCH_TIMEOUT=20
-        OPEN_SEARCH_USE_SSL=false
-        OPEN_SEARCH_VERIFY_CERTS=false
-        ACCESS_COPY_BUCKET=test-access-copy
-        CONVERTIBLE_EXTENSIONS=.doc,.docx
+        cat > .env << EOF
+        OPENSEARCH_INITIAL_ADMIN_PASSWORD=FOOBARCARabc123!
+        POSTGRES_DB=local_db
+        POSTGRES_USER=local_db_user
+        POSTGRES_PASSWORD=local_db_user_password
+        KEYCLOAK_ADMIN=admin
+        KEYCLOAK_ADMIN_PASSWORD=password
+        KC_POSTGRES_PORT=5432
+        WEBAPP_POSTGRES_PORT=5433
+        MINIO_ROOT_USER=ROOTNAME
+        MINIO_ROOT_PASSWORD=CHANGEME123
         EOF
 
-    - name: Start services
-      run: |
-        cd local_services
-
-        # Start Docker Compose with CI-specific configuration
-        docker compose -f docker-compose.ci.yml up -d
-      env:
-        CONFIG_SOURCE: ENVIRONMENT_VARIABLES
-        OPENSEARCH_INITIAL_ADMIN_PASSWORD: FOOBARCARabc123! # pragma: allowlist secret
-        POSTGRES_USER: local_db_user
-        POSTGRES_PASSWORD: local_db_user_password # pragma: allowlist secret
-        POSTGRES_DB: local_db
-        KC_POSTGRES_PORT: 5432
-        WEBAPP_POSTGRES_PORT: 5433
-        KEYCLOAK_ADMIN: admin
-        KEYCLOAK_ADMIN_PASSWORD: password # pragma: allowlist secret
-        MINIO_ROOT_USER: ROOTNAME
-        MINIO_ROOT_PASSWORD: CHANGEME123 # pragma: allowlist secret
-
-    - name: Wait for services to be ready
-      run: |
-        echo "Waiting for services to start"
-        sleep 120
-
-        # Check Docker services status
-        cd local_services
-        echo "All services in docker-compose.ci.yml:"
-        docker compose -f docker-compose.ci.yml config --services
-        echo "Running services:"
-        docker compose -f docker-compose.ci.yml ps
-        echo "All containers (including stopped):"
-        docker compose -f docker-compose.ci.yml ps -a
-
-        # Check logs for failed services
-        echo "webapp_postgres logs:"
-        docker logs local_services-webapp_postgres-1 --tail 20
-
-        echo "opensearch-node1 logs:"
-        docker logs opensearch-node1 --tail 30 || echo "Failed to get opensearch-node1 logs"
-
-        echo "Network inspection:"
-        docker network ls
-        docker network inspect local_services_ci_network || echo "CI network not found"
-
-        echo "Webapp logs:"
-        docker logs webapp --tail 20
-
-        # Wait for postgres to be ready for connections
-        echo "Waiting for postgres to be ready..."
-        timeout 120 bash -c 'until docker exec local_services-webapp_postgres-1 pg_isready -h localhost -p 5432; do sleep 2; done'
-
-        # Test postgres connectivity
-        echo "Testing postgres connectivity..."
-        timeout 60 bash -c 'until docker exec webapp python -c "import psycopg2; psycopg2.connect(host=\"webapp_postgres\", port=5432, user=\"local_db_user\", password=\"local_db_user_password\", dbname=\"local_db\")" 2>/dev/null; do echo "Waiting for postgres..."; sleep 5; done'
-        echo "PostgreSQL connection successful"
-
-        echo "Final service status check:"
-        docker compose -f docker-compose.ci.yml ps
-
-        echo "Checking webapp logs:"
-        docker logs webapp --tail 20
-
-        echo "Checking postgres logs:"
-        docker logs local_services-webapp_postgres-1 --tail 20
-
-        timeout 120 bash -c 'until curl -k -f https://127.0.0.1:5000 || curl -f http://127.0.0.1:5000; do sleep 2; done'
-
-        # Wait for keycloak realm to be ready
-        timeout 120 bash -c 'until curl -f http://127.0.0.1:8080/realms/tdr/.well-known/openid-configuration; do sleep 2; done'
-      env:
-        CONFIG_SOURCE: ENVIRONMENT_VARIABLES
-        OPENSEARCH_INITIAL_ADMIN_PASSWORD: FOOBARCARabc123! # pragma: allowlist secret
-        POSTGRES_USER: local_db_user
-        POSTGRES_PASSWORD: local_db_user_password # pragma: allowlist secret
-        POSTGRES_DB: local_db
-        KC_POSTGRES_PORT: 5432
-        WEBAPP_POSTGRES_PORT: 5433
-        KEYCLOAK_ADMIN: admin
-        KEYCLOAK_ADMIN_PASSWORD: password # pragma: allowlist secret
-        MINIO_ROOT_USER: ROOTNAME
-        MINIO_ROOT_PASSWORD: CHANGEME123 # pragma: allowlist secret
-
-
+    - name: Start Docker Compose with CI-specific configuration
+      run: cd local_services && docker compose -f docker-compose.ci.yml --env-file .docker.env up -d --wait --no-build || exit $(docker compose ps -q | xargs docker inspect -f '{{.State.ExitCode}}' | grep -v '^0' | wc -l)
 
     - name: Set up E2E test environment
       run: | # pragma: allowlist secret
@@ -151,15 +61,20 @@ jobs:
         KEYCLOAK_CLIENT_SECRET=test-client-secret
         EOF
 
-    - name: Build E2E Docker image
-      run: |
-        cd e2e_tests
-        docker build -t e2e_tests .
+    - name: Build E2E Docker image with cache
+      uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0
+      with:
+        context: e2e_tests
+        push: false
+        load: true
+        tags: "e2e_tests:latest"
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Run E2E tests with Docker
       run: |
         docker run --rm --env-file .env.e2e_tests --network=host \
-          -v "$(pwd)/e2e_tests":/e2e_tests e2e_tests
+          -v "$(pwd)/e2e_tests":/e2e_tests e2e_tests:latest
 
     - name: Upload test results
       uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
@@ -186,17 +101,7 @@ jobs:
         retention-days: 7
     - name: Check logs after test failure
       if: failure()
-      run: |
-          echo "=== Webapp logs ==="
-          cd local_services
-          docker compose -f docker-compose.ci.yml logs webapp
-          echo "=== Database logs ==="
-          docker compose -f docker-compose.ci.yml logs webapp_postgres
-          echo "=== OpenSearch logs ==="
-          docker compose -f docker-compose.ci.yml logs opensearch-node1
-          echo "=== MinIO logs ==="
-          docker compose -f docker-compose.ci.yml logs minio
-
+      run: cd local_services && docker compose -f docker-compose.ci.yml logs
     - name: Stop services
       if: always()
       run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,44 +1,48 @@
-# Build stage for Node.js assets
-FROM node:24-slim AS node-builder
+FROM python:3.13-slim
 
-WORKDIR /app
+WORKDIR /docker_app
 
-COPY package*.json ./
-
-RUN npm ci
-
-COPY app/static/src app/static/src
-
-RUN npm run build
-
-# Production stage
-FROM python:3.11-slim
-
-WORKDIR /app
-
+# Install system dependencies including Node.js (cached layer)
 RUN apt-get update && apt-get install -y \
     gcc \
     libpq-dev \
     openssl \
     curl \
+    nodejs \
+    npm \
     && rm -rf /var/lib/apt/lists/*
 
+# Install Poetry (cached layer)
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="/root/.local/bin:$PATH"
 
-COPY pyproject.toml poetry.lock ./
+# Copy Python dependency files first for better caching
+COPY pyproject.toml poetry.lock /docker_app/
+RUN poetry config virtualenvs.create false && \
+    poetry install --no-root
 
-RUN poetry config virtualenvs.create false
+# Copy Node.js dependency files and install
+COPY package*.json /docker_app/
+RUN npm ci
+COPY app/static/src/scss /docker_app/app/static/src/scss
+# Build CSS files before copying the rest of the app as
+# we won't update them as often as other source files
+RUN npm run build
 
-RUN poetry install --no-root
+# Preserve CSS files as copying app directory will overwrite them
+RUN cp -r /docker_app/app/static/src/css /tmp/css_backup
+COPY app/ /docker_app/app
+COPY configs/ /docker_app/configs
+COPY main_app.py .flaskenv /docker_app/
+# Restore the built CSS files
+RUN cp -r /tmp/css_backup /docker_app/app/static/src/css
 
-COPY . .
+ENV FLASK_ENV=development
+ENV FLASK_DEBUG=1
+ENV PYTHONUNBUFFERED=1
 
-COPY --from=node-builder /app/app/static/src/css app/static/src/css
-
-RUN openssl req -x509 -newkey rsa:4096 -nodes -out cert.pem -keyout key.pem -days 365 \
-    -subj "/C=GB/ST=England/L=London/O=Test/CN=DNS:localhost,IP:127.0.0.1"
+RUN openssl req -x509 -newkey rsa:2048 -nodes -out /docker_app/cert.pem -keyout /docker_app/key.pem -days 365 -subj '/C=GB/ST=Test/L=Test/O=Test/CN=localhost'
 
 EXPOSE 5000
 
-CMD ["poetry", "run", "python", "-m", "flask", "--app", "main_app:app", "run", "--host=0.0.0.0", "--port=5000"]
+CMD ["poetry", "run", "flask", "run", "--host=0.0.0.0", "--port=5000", "--debug"]

--- a/local_services/.docker.env
+++ b/local_services/.docker.env
@@ -1,33 +1,67 @@
+# Configuration source
 CONFIG_SOURCE=ENVIRONMENT_VARIABLES
-KEYCLOAK_BASE_URI=http://localhost:8080
-KEYCLOAK_CLIENT_ID=ayr-beta
-KEYCLOAK_REALM_NAME=tdr
-KEYCLOAK_CLIENT_SECRET=test-client-secret # pragma: allowlist secret
+
+# Flask and Python settings
+PYTHONUNBUFFERED=1
+FLASK_ENV=development
+FLASK_DEBUG=1
+
+# Database settings for webapp
+DB_HOST=webapp_postgres
 DB_PORT=5432
-DB_HOST=localhost
 DB_NAME=local_db
 DB_USER=local_db_user
 DB_PASSWORD=local_db_user_password # pragma: allowlist secret
+DB_SSL_ROOT_CERTIFICATE=/app/local_services/webapp_postgres_certs/root-ca.pem
 SQLALCHEMY_SSL_MODE=disable
+
+# Keycloak settings
+KEYCLOAK_BASE_URI=http://keycloak:8080
+KEYCLOAK_CLIENT_ID=ayr-beta
+KEYCLOAK_REALM_NAME=tdr
+KEYCLOAK_CLIENT_SECRET=test-client-secret # pragma: allowlist secret
+KEYCLOAK_ADMIN=admin
+KEYCLOAK_ADMIN_PASSWORD=password # pragma: allowlist secret
+
+# AWS/MinIO settings
 AWS_ACCESS_KEY_ID=ROOTNAME
 AWS_SECRET_ACCESS_KEY=CHANGEME123 # pragma: allowlist secret
 AWS_REGION=eu-west-2
-AWS_ENDPOINT_URL=https://127.0.0.1:9000
+AWS_ENDPOINT_URL=http://localhost:9000
+AWS_CA_BUNDLE=/app/local_services/minio_certs/root-ca.crt
+
+# Application settings
 SECRET_KEY=test-secret-key # pragma: allowlist secret
 DEFAULT_PAGE_SIZE=10
 DEFAULT_DATE_FORMAT=DD/MM/YYYY
 RECORD_BUCKET_NAME=test-record-download
-FLASK_ENV=development
+ACCESS_COPY_BUCKET=test-access-copy
+PERF_TEST=False
+
+# Flask S3 settings
 FLASKS3_ACTIVE=False
 FLASKS3_CDN_DOMAIN=localhost
 FLASKS3_BUCKET_NAME=test-record-download
-PERF_TEST=False
-DB_SSL_ROOT_CERTIFICATE=/var/lib/postgresql/root-ca.pem
-OPEN_SEARCH_HOST=http://localhost:9200
-OPEN_SEARCH_USERNAME=admin
+
+# OpenSearch settings
+OPEN_SEARCH_HOST=http://opensearch-node1:9200
+OPEN_SEARCH_USERNAME=
 OPEN_SEARCH_PASSWORD=
-OPEN_SEARCH_CA_CERTS=/usr/share/opensearch/config/certs/root-ca.pem
-OPEN_SEARCH_TIMEOUT=10
+OPEN_SEARCH_CA_CERTS=
+OPEN_SEARCH_TIMEOUT=30
 OPEN_SEARCH_USE_SSL=false
 OPEN_SEARCH_VERIFY_CERTS=false
-OPENSEARCH_INITIAL_ADMIN_PASSWORD=admin # pragma: allowlist secret
+
+# PostgreSQL settings for other services
+POSTGRES_DB=local_db
+POSTGRES_USER=local_db_user
+POSTGRES_PASSWORD=local_db_user_password # pragma: allowlist secret
+KC_POSTGRES_PORT=5432
+WEBAPP_POSTGRES_PORT=5433
+
+# MinIO settings
+MINIO_ROOT_USER=ROOTNAME
+MINIO_ROOT_PASSWORD=CHANGEME123 # pragma: allowlist secret
+
+# OpenSearch admin settings
+OPENSEARCH_INITIAL_ADMIN_PASSWORD=FOOBARCARabc123! # pragma: allowlist secret

--- a/local_services/docker-compose.ci.yml
+++ b/local_services/docker-compose.ci.yml
@@ -1,5 +1,4 @@
 services:
-  # Single OpenSearch node for CI
   opensearch-node1:
     image: opensearchproject/opensearch@sha256:6ab2d7f30f6b30f97ceab4fe2a4d371f734e18c6b7639468af30db93c33316ca # opensearch:latest with digest for immutability
     container_name: opensearch-node1
@@ -27,6 +26,12 @@ services:
       - 9600:9600
     networks:
       - opensearch-net
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards@sha256:d82c6cd0306cba75735e99f940abb98dbbd6621b6b704db6bd4cf9313054e20e # opensearch-dashboards:latest with digest for immutability
@@ -37,28 +42,36 @@ services:
       - "5601"
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch-node1:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: 'true'
     networks:
       - opensearch-net
     depends_on:
       - opensearch-node1
 
   opensearch-restore:
-    image: python
+    env_file:
+      - .docker.env
+    image: curlimages/curl:latest
     environment:
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
     depends_on:
-      - opensearch-node1
+      opensearch-node1:
+        condition: service_healthy
     networks:
       - opensearch-net
+    volumes:
+      - ./snapshots:/mnt/snapshots
     command: |
-      bash -c "
-        # Wait until OpenSearch is available via HTTP (no auth needed)
-        until curl -s http://opensearch-node1:9200 -o /dev/null; do
-          echo 'Waiting for OpenSearch to be available...'
+      sh -c "
+        echo 'Waiting for OpenSearch to be ready...'
+
+        # Wait for OpenSearch to be fully ready
+        until curl -s http://opensearch-node1:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'; do
+          echo 'Waiting for OpenSearch cluster...'
           sleep 5
         done
 
-        echo 'OpenSearch is available!'
+        echo 'OpenSearch is ready. Starting restore process...'
 
         # Register the snapshot repository (no auth needed)
         curl -s -X PUT 'http://opensearch-node1:9200/_snapshot/my-fs-repository' -H 'Content-Type: application/json' -d '{\"type\": \"fs\", \"settings\": {\"location\": \"/mnt/snapshots\"}}'
@@ -71,16 +84,27 @@ services:
         echo 'Existing index cleared.'
 
         # Restore from snapshot (no auth needed)
-        curl -s -X POST 'http://opensearch-node1:9200/_snapshot/my-fs-repository/1/_restore' -H 'Content-Type: application/json' -d '{\"indices\": \"documents\", \"include_global_state\": false}'
+        restore_response=\$$(curl -s -X POST 'http://opensearch-node1:9200/_snapshot/my-fs-repository/1/_restore' -H 'Content-Type: application/json' -d '{\"indices\": \"documents\", \"include_global_state\": false}')
+        echo \"Restore response: \$$restore_response\"
 
-        echo 'Restore completed.'
+        # Wait for restore to complete
+        echo 'Waiting for restore to complete...'
+        until curl -s 'http://opensearch-node1:9200/documents/_search?size=0' | grep -q '\"total\"'; do
+          echo 'Waiting for documents to be available...'
+          sleep 2
+        done
 
-        # Keep container running briefly to see results
-        sleep 10
+        # Verify the restore was successful
+        doc_count=\$$(curl -s 'http://opensearch-node1:9200/documents/_count' | grep -o '\"count\":[0-9]*' | cut -d':' -f2)
+        echo \"Restore completed successfully. Document count: \$$doc_count\"
+
+        exit 0
       "
 
   postgres:
     image: postgres@sha256:41fc5342eefba6cc2ccda736aaf034bbbb7c3df0fdb81516eba1ba33f360162c # postgres:18.0 with digest for immutability
+    env_file:
+      - .docker.env
     volumes:
       - kc_postgres_data:/var/lib/postgresql
     environment:
@@ -94,6 +118,8 @@ services:
 
   webapp_postgres:
     image: postgres@sha256:41fc5342eefba6cc2ccda736aaf034bbbb7c3df0fdb81516eba1ba33f360162c # postgres:18.0 with digest for immutability
+    env_file:
+      - .docker.env
     user: postgres
     volumes:
       - webapp_postgres_data:/var/lib/postgresql
@@ -112,6 +138,8 @@ services:
 
   keycloak:
     image: quay.io/keycloak/keycloak:26.4.4
+    env_file:
+      - .docker.env
     command: start-dev --import-realm --spi-login-protocol-openid-connect-legacy-logout-redirect-uri=true
     environment:
       KC_HOSTNAME: localhost
@@ -137,36 +165,16 @@ services:
       - postgres
     networks:
       - keycloak_network
-
-  keycloak-config:
-    image: alpine/curl
-    depends_on:
-      - keycloak
-    networks:
-      - keycloak_network
-    entrypoint: |
-      sh -c "
-        # Wait for Keycloak to be ready
-        echo 'Waiting for Keycloak to be ready...'
-        until curl -f http://keycloak:8080/realms/master/.well-known/openid-configuration; do
-          echo 'Still waiting for Keycloak...'
-          sleep 5
-        done
-
-        echo 'Keycloak is ready!'
-        echo 'Note: You may need to manually run the following commands in the keycloak container:'
-        echo 'docker exec keycloak /opt/keycloak/bin/kcadm.sh config credentials --server http://localhost:8080 --realm master --user admin --password password'
-        echo 'docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/master -s sslRequired=NONE'
-        echo 'docker exec keycloak /opt/keycloak/bin/kcadm.sh update realms/tdr -s sslRequired=NONE'
-
-        # Keep container running briefly
-        sleep 30
-      "
-    environment:
-      KEYCLOAK_ADMIN: ${KEYCLOAK_ADMIN}
-      KEYCLOAK_ADMIN_PASSWORD: ${KEYCLOAK_ADMIN_PASSWORD}
+    # healthcheck:
+    #   test: ["CMD", "curl", "-f", "http://localhost:8080/realms/master/.well-known/openid-configuration"]
+    #   interval: 10s
+    #   timeout: 5s
+    #   retries: 30
+    #   start_period: 10s
 
   minio:
+    env_file:
+      - .docker.env
     image: quay.io/minio/minio
     container_name: minio
     ports:
@@ -178,15 +186,25 @@ services:
     volumes:
       - minio_data:/data
     command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 30s
     networks:
       minio_network:
         aliases:
           - 127.0.0.1
 
   minio-init:
+    env_file:
+      - .docker.env
     image: minio/mc:latest
     depends_on:
-      - minio
+      minio:
+        condition: service_healthy
+    restart: "no"
     volumes:
       - ./files:/tmp/files:ro
     networks:
@@ -197,6 +215,7 @@ services:
       /usr/bin/mc alias set myminio http://minio:9000 ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD};
       /usr/bin/mc mb myminio/test-record-download --ignore-existing;
       /usr/bin/mc cp --recursive /tmp/files/ myminio/test-record-download/ || echo 'No files to copy or copy failed';
+      exit 0;
       "
 
   socat-localhost:
@@ -209,16 +228,26 @@ services:
   webapp:
     env_file:
       - .docker.env
+    image: da-ayr-beta-webapp:latest
     build:
       context: ..
       dockerfile: Dockerfile
     container_name: webapp
+    command: >
+      sh -c "
+        echo 'Building CSS files...' &&
+        npm run build &&
+        poetry run flask run --host=0.0.0.0 --port=5000 --debug
+      "
     ports:
       - "5000:5000"
     volumes:
-      - ./minio_certs:/app/local_services/minio_certs
-      - ./opensearch_certs:/app/local_services/opensearch_certs
-      - ./webapp_postgres_certs:/app/local_services/webapp_postgres_certs
+      # Mount source code for hot reloading directly
+      - ../app:/docker_app/app
+      # Mount certificates
+      - ./minio_certs:/docker_app/local_services/minio_certs
+      - ./opensearch_certs:/docker_app/local_services/opensearch_certs
+      - ./webapp_postgres_certs:/docker_app/local_services/webapp_postgres_certs
     networks:
       - default
       - keycloak_network
@@ -226,50 +255,18 @@ services:
       - minio_network
     links:
       - opensearch-node1
-    environment:
-      - PYTHONUNBUFFERED=1
-      - FLASK_ENV=development
-      - CONFIG_SOURCE=ENVIRONMENT_VARIABLES
-      - DB_HOST=webapp_postgres
-      - DB_PORT=5432
-      - DB_NAME=${POSTGRES_DB}
-      - DB_USER=${POSTGRES_USER}
-      - DB_PASSWORD=${POSTGRES_PASSWORD}
-      - DB_SSL_ROOT_CERTIFICATE=/app/local_services/webapp_postgres_certs/root-ca.pem
-      - SQLALCHEMY_SSL_MODE=disable
-      - KEYCLOAK_BASE_URI=http://keycloak:8080
-      - KEYCLOAK_CLIENT_ID=ayr-beta
-      - KEYCLOAK_REALM_NAME=tdr
-      - KEYCLOAK_CLIENT_SECRET=test-client-secret
-      - AWS_ENDPOINT_URL=http://127.0.0.1:9000
-      - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
-      - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD}
-      - AWS_REGION=eu-west-2
-      - AWS_CA_BUNDLE=/app/local_services/minio_certs/root-ca.crt
-      - SECRET_KEY=test-secret-key
-      - DEFAULT_PAGE_SIZE=10
-      - DEFAULT_DATE_FORMAT=DD/MM/YYYY
-      - RECORD_BUCKET_NAME=test-record-download
-      - FLASKS3_ACTIVE=False
-      - FLASKS3_CDN_DOMAIN=localhost
-      - FLASKS3_BUCKET_NAME=test-record-download
-      - ACCESS_COPY_BUCKET=test-access-copy
-      - PERF_TEST=False
-      # Use service name for OpenSearch with HTTP
-      - OPEN_SEARCH_HOST=http://opensearch-node1:9200
-      # Remove auth since security is disabled
-      - OPEN_SEARCH_USERNAME=
-      - OPEN_SEARCH_PASSWORD=
-      - OPEN_SEARCH_TIMEOUT=30
-      # Disable SSL for CI
-      - OPEN_SEARCH_USE_SSL=false
-      - OPEN_SEARCH_VERIFY_CERTS=false
-      - OPEN_SEARCH_CA_CERTS=
     depends_on:
       - webapp_postgres
       - keycloak
       - minio
       - opensearch-node1
+      - opensearch-restore
+    healthcheck:
+      test: ["CMD", "curl", "-f", "-k", "https://localhost:5000"]
+      interval: 10s
+      timeout: 5s
+      retries: 30
+      start_period: 60s
 
 volumes:
   opensearch-data1:


### PR DESCRIPTION
## Changes in this PR

Enabled Hot reloading for dev webapp container

Can now `docker compose -f local_services/docker-compose.ci.yml up -d -wait` and make changes to the webapp code and they get reflected automatically at https://localhost:5000/ whereas previously we needed to docker compose down, rebuild the webapp docker image and spin up a new container from that. Uses mounted volumes to do so.


Please verify this works for you locally.


Also makes the docker build of the webapp and e2e containers cached in Github actions.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1741