### PR TITLE
Stop using request args directly in routes

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -184,7 +184,7 @@ def browse():
 
         validated_data = request.validated_data
         page = validated_data["page"]
-        per_page = validated_data.get("per_page") or int(
+        per_page = validated_data["per_page"] or int(
             current_app.config["DEFAULT_PAGE_SIZE"]
         )
 
@@ -275,7 +275,7 @@ def browse_transferring_body(_id: uuid.UUID):
     form = SearchForm()
     validated_data = request.validated_data
     page = validated_data["page"]
-    per_page = validated_data.get("per_page") or int(
+    per_page = validated_data["per_page"] or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
 
@@ -372,7 +372,7 @@ def browse_series(_id: uuid.UUID):
     form = SearchForm()
     validated_data = request.validated_data
     page = validated_data["page"]
-    per_page = validated_data.get("per_page") or int(
+    per_page = validated_data["per_page"] or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
 
@@ -472,7 +472,7 @@ def browse_consignment(_id: uuid.UUID):
     form = SearchForm()
     validated_data = request.validated_data
     page = validated_data["page"]
-    per_page = validated_data.get("per_page") or int(
+    per_page = validated_data["per_page"] or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
 
@@ -544,7 +544,7 @@ def browse_consignment(_id: uuid.UUID):
 @validate_request(SearchRequestSchema, location="combined")
 def search():
     validated_data = request.validated_data
-    transferring_body_id = validated_data.get("transferring_body_id", "")
+    transferring_body_id = validated_data["transferring_body_id"]
 
     ayr_user = AYRUser(session.get("user_groups"))
 
@@ -579,7 +579,7 @@ def search_results_summary():
     form = SearchForm()
     validated_data = request.validated_data
     page = validated_data["page"]
-    per_page = validated_data.get("per_page") or int(
+    per_page = validated_data["per_page"] or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
 
@@ -640,7 +640,7 @@ def search_transferring_body(_id: uuid.UUID):
     form = SearchForm()
     validated_data = request.validated_data
     page = validated_data["page"]
-    per_page = validated_data.get("per_page") or int(
+    per_page = validated_data["per_page"] or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
     open_all = validated_data["open_all"]
@@ -650,7 +650,7 @@ def search_transferring_body(_id: uuid.UUID):
     query = validated_data["query"]
     search_area = validated_data["search_area"]
 
-    additional_term = validated_data.get("search_filter", "").strip()
+    additional_term = validated_data["search_filter"]
 
     check_additional_term(additional_term, query, validated_data.copy())
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -203,9 +203,12 @@ def browse():
                 date_error_fields,
             ) = validate_date_filters(request.args)
 
-        filters = build_filters(request.args, from_date, to_date)
-        sorting_orders = build_sorting_orders(request.args)
-
+        filters = build_filters(
+            validated_data,
+            date_from=from_date,
+            date_to=to_date,
+        )
+        sorting_orders = build_sorting_orders(validated_data)
         # set default sort
         if len(sorting_orders) == 0:
             sorting_orders["transferring_body"] = "asc"
@@ -291,8 +294,12 @@ def browse_transferring_body(_id: uuid.UUID):
             date_error_fields,
         ) = validate_date_filters(request.args)
 
-    filters = build_filters(request.args, from_date, to_date)
-    sorting_orders = build_sorting_orders(request.args)
+    filters = build_filters(
+        validated_data,
+        date_from=from_date,
+        date_to=to_date,
+    )
+    sorting_orders = build_sorting_orders(validated_data)
 
     # set default sort
     if len(sorting_orders) == 0:
@@ -382,10 +389,14 @@ def browse_series(_id: uuid.UUID):
             to_date,
             date_filters,
             date_error_fields,
-        ) = validate_date_filters(request.args)
+        ) = validate_date_filters(validated_data)
 
-    filters = build_filters(request.args, from_date, to_date)
-    sorting_orders = build_sorting_orders(request.args)
+    filters = build_filters(
+        validated_data,
+        date_from=from_date,
+        date_to=to_date,
+    )
+    sorting_orders = build_sorting_orders(validated_data)
 
     # set default sort
     if len(sorting_orders) == 0:
@@ -480,8 +491,12 @@ def browse_consignment(_id: uuid.UUID):
             date_error_fields,
         ) = validate_date_filters(request.args, browse_consignment=True)
 
-    filters = build_browse_consignment_filters(request.args, from_date, to_date)
-    sorting_orders = build_sorting_orders(request.args)
+    filters = build_browse_consignment_filters(
+        validated_data,
+        date_from=from_date,
+        date_to=to_date,
+    )
+    sorting_orders = build_sorting_orders(validated_data)
 
     # set default sort
     if len(sorting_orders) == 0:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -703,7 +703,7 @@ def search_transferring_body(_id: uuid.UUID):
             search_results, page, per_page
         )
         num_records_found = total_records
-    # breakpoint()
+
     query_string_parameters = validated_data.copy()
     query_string_parameters.pop("page", None)
     query_string_parameters.pop("_id", None)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -61,6 +61,7 @@ from app.main.util.schemas import (
     BrowseRequestSchema,
     BrowseSeriesRequestSchema,
     BrowseTransferringBodyRequestSchema,
+    CallbackRequestSchema,
     DownloadRequestSchema,
     GenerateManifestRequestSchema,
     RecordRequestSchema,
@@ -116,15 +117,11 @@ def sign_in():
 
 @bp.route("/callback", methods=["GET"])
 @log_page_view
+@validate_request(CallbackRequestSchema, location="args")
 def callback():
     keycloak_openid = get_keycloak_instance_from_flask_config()
-    code = request.args.get("code")
-
-    if not code:
-        current_app.app_logger.warning(
-            "Missing 'code' parameter in OIDC callback"
-        )
-        return redirect(url_for("main.sign_in"))
+    validated_data = request.validated_data
+    code = validated_data["code"]
 
     try:
         access_token_response = keycloak_openid.token(

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -245,9 +245,7 @@ def browse():
             date_filters=date_filters,
             sorting_orders=sorting_orders,
             num_records_found=num_records_found,
-            query_string_parameters={
-                k: v for k, v in request.args.items() if k not in "page"
-            },
+            query_string_parameters={k: v for k, v in validated_data.items()},
             id=None,
         )
 
@@ -338,9 +336,7 @@ def browse_transferring_body(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v for k, v in request.args.items() if k not in "page"
-        },
+        query_string_parameters={k: v for k, v in validated_data.items()},
     )
 
 
@@ -435,9 +431,7 @@ def browse_series(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v for k, v in request.args.items() if k not in "page"
-        },
+        query_string_parameters={k: v for k, v in validated_data.items()},
     )
 
 
@@ -532,9 +526,7 @@ def browse_consignment(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v for k, v in request.args.items() if k not in "page"
-        },
+        query_string_parameters={k: v for k, v in validated_data.items()},
     )
 
 
@@ -543,13 +535,8 @@ def browse_consignment(_id: uuid.UUID):
 @log_page_view
 @validate_request(SearchRequestSchema, location="combined")
 def search():
-    form_data = request.form.to_dict()
-    args_data = request.args.to_dict()
-
-    # merge both dictionaries (args takes precedence over form if there are overlapping keys)
-    params = {**form_data, **args_data}
-
-    transferring_body_id = params.get("transferring_body_id", "")
+    validated_data = request.validated_data
+    transferring_body_id = validated_data.get("transferring_body_id", "")
 
     ayr_user = AYRUser(session.get("user_groups"))
 
@@ -564,11 +551,10 @@ def search():
             url_for(
                 "main.search_transferring_body",
                 _id=transferring_body_id,
-                **params,
+                **validated_data,
             )
         )
-    else:
-        return redirect(url_for("main.search_results_summary", **params))
+    return redirect(url_for("main.search_results_summary", **validated_data))
 
 
 @bp.route("/search_results_summary", methods=["GET"])
@@ -625,9 +611,7 @@ def search_results_summary():
         results=paginated_results,
         pagination=pagination,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v for k, v in request.args.items() if k not in "page"
-        },
+        query_string_parameters={k: v for k, v in validated_data.items()},
         id=None,
     )
 
@@ -652,7 +636,7 @@ def search_transferring_body(_id: uuid.UUID):
 
     query, search_area = get_query_and_search_area(request)
 
-    additional_term = request.args.get("search_filter", "").strip()
+    additional_term = validated_data.get("search_filter", "").strip()
 
     check_additional_term(additional_term, query, request.args.copy(), _id)
 
@@ -743,7 +727,7 @@ def search_transferring_body(_id: uuid.UUID):
         open_all=open_all,
         highlight_tag=highlight_tag,
         query_string_parameters={
-            k: v for k, v in request.args.items() if k != "page"
+            k: v for k, v in validated_data.items() if k != "page"
         },
     )
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -650,28 +650,7 @@ def search_transferring_body(_id: uuid.UUID):
     query = validated_data["query"]
     search_area = validated_data["search_area"]
 
-    additional_term = validated_data["search_filter"]
-
-    check_additional_term(additional_term, query, validated_data.copy())
-
-    if additional_term:
-        if " " in additional_term and not (
-            additional_term.startswith('"') and additional_term.endswith('"')
-        ):
-            additional_term = f'"{additional_term}"'
-
-        query = f"{query}+{additional_term}" if query else additional_term
-
-        args = validated_data.copy()
-        args.pop("search_filter", None)
-        args["query"] = query
-        return redirect(
-            url_for(
-                "main.search_transferring_body",
-                **args,
-                _anchor="browse-records",
-            )
-        )
+    check_additional_term(query, validated_data.copy())
 
     filters = {"query": query}
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -191,14 +191,14 @@ def browse():
         date_filters = {}
         date_error_fields = []
 
-        if len(request.args) > 0:
+        if len(validated_data) > 0:
             (
                 date_validation_errors,
                 from_date,
                 to_date,
                 date_filters,
                 date_error_fields,
-            ) = validate_date_filters(request.args)
+            ) = validate_date_filters(validated_data)
 
         filters = build_filters(
             validated_data,
@@ -280,14 +280,14 @@ def browse_transferring_body(_id: uuid.UUID):
     date_filters = {}
     date_error_fields = []
 
-    if len(request.args) > 0:
+    if len(validated_data) > 0:
         (
             date_validation_errors,
             from_date,
             to_date,
             date_filters,
             date_error_fields,
-        ) = validate_date_filters(request.args)
+        ) = validate_date_filters(validated_data)
 
     filters = build_filters(
         validated_data,
@@ -375,7 +375,7 @@ def browse_series(_id: uuid.UUID):
     date_filters = {}
     date_error_fields = []
 
-    if len(request.args) > 0:
+    if len(validated_data) > 0:
         (
             date_validation_errors,
             from_date,
@@ -473,14 +473,14 @@ def browse_consignment(_id: uuid.UUID):
     date_filters = {}
     date_error_fields = []
 
-    if len(request.args) > 0:
+    if len(validated_data) > 0:
         (
             date_validation_errors,
             from_date,
             to_date,
             date_filters,
             date_error_fields,
-        ) = validate_date_filters(request.args, browse_consignment=True)
+        ) = validate_date_filters(validated_data, browse_consignment=True)
 
     filters = build_browse_consignment_filters(
         validated_data,
@@ -635,7 +635,7 @@ def search_transferring_body(_id: uuid.UUID):
 
     additional_term = validated_data.get("search_filter", "").strip()
 
-    check_additional_term(additional_term, query, request.args.copy(), _id)
+    check_additional_term(additional_term, query, validated_data.copy(), _id)
 
     if additional_term:
         if " " in additional_term and not (
@@ -645,7 +645,7 @@ def search_transferring_body(_id: uuid.UUID):
 
         query = f"{query}+{additional_term}" if query else additional_term
 
-        args = request.args.copy()
+        args = validated_data.copy()
         args.pop("search_filter", None)
         args["query"] = query
         return redirect(

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -77,8 +77,6 @@ from app.main.util.search_utils import (
     extract_search_terms,
     get_open_search_fields_to_search_on_and_sorting,
     get_pagination_info,
-    get_param,
-    get_query_and_search_area,
     post_process_opensearch_results,
     setup_opensearch,
 )
@@ -585,7 +583,8 @@ def search_results_summary():
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
 
-    query, search_area = get_query_and_search_area(request)
+    query = validated_data["query"]
+    search_area = validated_data["search_area"]
     filters = {"query": query}
     num_records_found, paginated_results, pagination = 0, [], None
 
@@ -644,11 +643,12 @@ def search_transferring_body(_id: uuid.UUID):
     per_page = validated_data.get("per_page") or int(
         current_app.config["DEFAULT_PAGE_SIZE"]
     )
-    open_all = get_param("open_all", request)
-    sort = get_param("sort", request) or "file_name"
+    open_all = validated_data["open_all"]
+    sort = validated_data["sort"] or "file_name"
     highlight_tag = f"uuid_prefix_{uuid.uuid4().hex}"
 
-    query, search_area = get_query_and_search_area(request)
+    query = validated_data["query"]
+    search_area = validated_data["search_area"]
 
     additional_term = validated_data.get("search_filter", "").strip()
 

--- a/app/main/util/filter_sort_builder.py
+++ b/app/main/util/filter_sort_builder.py
@@ -2,12 +2,12 @@ def build_filters(args, date_from, date_to):
     filters = {}
     filter_items = []
     if args:
-        transferring_body = args.get("transferring_body_filter", "").lower()
+        transferring_body = args["transferring_body_filter"]
 
         if transferring_body and transferring_body != "all":
             filter_items.append({"transferring_body": transferring_body})
 
-        series = args.get("series_filter", "").lower()
+        series = args["series_filter"]
         if series:
             filter_items.append({"series": series})
 

--- a/app/main/util/schemas.py
+++ b/app/main/util/schemas.py
@@ -24,7 +24,9 @@ class CallbackRequestSchema(Schema):
     """OIDC callback request validation schema."""
 
     code = fields.String(
-        required=True, validate=validate.Length(min=1, max=500)
+        allow_none=True,
+        load_default=None,
+        validate=validate.Length(min=1, max=500),
     )
 
     class Meta:
@@ -86,7 +88,7 @@ class SearchResultsSummaryRequestSchema(PaginationSchema, SearchQuerySchema):
 class SearchTransferringBodyRequestSchema(PaginationSchema, SearchQuerySchema):
     """Search transferring body request validation schema."""
 
-    _id = UUIDField(required=False, data_key="_id", load_default=None)
+    _id = UUIDField(required=True, data_key="_id")
 
     class Meta:
         unknown = EXCLUDE

--- a/app/main/util/schemas.py
+++ b/app/main/util/schemas.py
@@ -20,6 +20,17 @@ from app.main.util.base_schemas import (
 )
 
 
+class CallbackRequestSchema(Schema):
+    """OIDC callback request validation schema."""
+
+    code = fields.String(
+        required=True, validate=validate.Length(min=1, max=500)
+    )
+
+    class Meta:
+        unknown = EXCLUDE
+
+
 class BrowseRequestSchema(PaginationSchema, BrowseFilterSchema):
     """Browse request validation schema."""
 

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -2,7 +2,7 @@ import re
 import urllib.parse
 
 import opensearchpy
-from flask import abort, current_app, redirect, request, url_for
+from flask import abort, current_app, redirect, url_for
 from opensearchpy import OpenSearch, RequestsHttpConnection
 
 from app.main.util.date_validator import format_opensearch_date
@@ -421,7 +421,8 @@ def extract_search_terms(query):
     return quoted_phrases, single_terms
 
 
-def check_additional_term(additional_term, query, args):
+def check_additional_term(query, validated_data):
+    additional_term = validated_data["search_filter"]
     if additional_term:
         if " " in additional_term and not (
             additional_term.startswith('"') and additional_term.endswith('"')
@@ -430,13 +431,11 @@ def check_additional_term(additional_term, query, args):
 
         query = f"{query}+{additional_term}" if query else additional_term
 
-        args = request.args.copy()
-        args.pop("search_filter", None)
-        args["query"] = query
+        validated_data["query"] = query
         return redirect(
             url_for(
                 "main.search_transferring_body",
-                **args,
+                **validated_data,
                 _anchor="browse-records",
             )
         )

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -204,18 +204,6 @@ def apply_field_boosts(fields, boost_map):
     return [f"{field}^{boost_map.get(field, 1)}" for field in fields]
 
 
-def get_param(param, request):
-    """Get a specific param from either form or args"""
-    return request.form.get(param, "") or request.args.get(param, "")
-
-
-def get_query_and_search_area(request):
-    """Fetch query and search_area from form or request args"""
-    query = get_param("query", request)
-    search_area = get_param("search_area", request)
-    return query.strip(), search_area
-
-
 def setup_opensearch():
     """Setup and return an OpenSearch client"""
     verify_certs = current_app.config.get("OPEN_SEARCH_VERIFY_CERTS", True)

--- a/app/main/util/search_utils.py
+++ b/app/main/util/search_utils.py
@@ -433,7 +433,7 @@ def extract_search_terms(query):
     return quoted_phrases, single_terms
 
 
-def check_additional_term(additional_term, query, args, _id):
+def check_additional_term(additional_term, query, args):
     if additional_term:
         if " " in additional_term and not (
             additional_term.startswith('"') and additional_term.endswith('"')
@@ -448,7 +448,6 @@ def check_additional_term(additional_term, query, args, _id):
         return redirect(
             url_for(
                 "main.search_transferring_body",
-                _id=_id,
                 **args,
                 _anchor="browse-records",
             )

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -300,14 +300,14 @@ class TestRoutes:
                 {},
                 {"some_param": "some_value"},
                 "main.search_results_summary",
-                {"some_param": "some_value"},
+                {},
             ),
             # all access user with form data and args data (args takes precedence)
             (
                 {"some_param": "form_value"},
                 {"some_param": "args_value"},
                 "main.search_results_summary",
-                {"some_param": "args_value"},
+                {},
             ),
         ],
     )

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -342,20 +342,20 @@ class TestRoutes:
         "form_data, args_data, expected_redirect_route, expected_params",
         [
             # standard user with both form and args data, args has precedence for overlapping keys
+            # Note: only valid schema fields are passed through (unknown fields are filtered out)
             (
                 {
                     "transferring_body_id": "form_value",
-                    "other_param": "form_other_value",
+                    "query": "form_query_value",
                 },
                 {
                     "transferring_body_id": "args_value",
-                    "another_param": "args_another_value",
+                    "search_area": "metadata",
                 },
                 "main.search_transferring_body",
                 {
                     "_id": "args_value",
-                    "other_param": "form_other_value",
-                    "another_param": "args_another_value",
+                    "search_area": "metadata",
                 },
             ),
             # standard user with only form data, no transferring_body_id in args

--- a/app/tests/test_schemas.py
+++ b/app/tests/test_schemas.py
@@ -350,11 +350,11 @@ class TestSearchTransferringBodyRequestSchema:
         assert isinstance(data["_id"], uuid.UUID)
         assert data["query"] == "search term"
 
-    def test_optional_id_field(self):
+    def test_missing_consignment_id(self):
         schema = SearchTransferringBodyRequestSchema()
-        data = schema.load({"query": "test"})
-        assert data["_id"] is None
-        assert data["query"] == "test"
+        with pytest.raises(ValidationError) as exc_info:
+            schema.load({})
+        assert "_id" in exc_info.value.messages
 
     def test_invalid_uuid_in_id(self):
         schema = SearchTransferringBodyRequestSchema()
@@ -364,6 +364,9 @@ class TestSearchTransferringBodyRequestSchema:
 
     def test_with_pagination(self):
         schema = SearchTransferringBodyRequestSchema()
-        data = schema.load({"query": "test", "page": 3, "per_page": 10})
+        test_id = str(uuid.uuid4())
+        data = schema.load(
+            {"_id": test_id, "query": "test", "page": 3, "per_page": 10}
+        )
         assert data["page"] == 3
         assert data["per_page"] == 10

--- a/app/tests/test_search_utils.py
+++ b/app/tests/test_search_utils.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 from opensearchpy import OpenSearch
@@ -16,8 +16,6 @@ from app.main.util.search_utils import (
     get_filtered_list,
     get_open_search_fields_to_search_on_and_sorting,
     get_pagination_info,
-    get_param,
-    get_query_and_search_area,
     rearrange_opensearch_results_for_relevant_fields,
     reorder_fields,
     setup_opensearch,
@@ -270,122 +268,6 @@ def test_get_open_search_fields_to_search_on_and_sorting(
     )
     assert sorting == expected_sorting
     assert actual_fields == expected_fields
-
-
-@pytest.mark.parametrize(
-    "form_data, args_data, form_param, args_param, expected_form_param, expected_args_param",
-    [
-        # case where both form and args contain the parameters
-        (
-            {"param_form": "test_form_value"},
-            {"param_args": "test_arg_value"},
-            "param_form",
-            "param_args",
-            "test_form_value",
-            "test_arg_value",
-        ),
-        # case where only form contains the parameter, args is empty
-        (
-            {"param_form": "test_form_only"},
-            {},
-            "param_form",
-            "param_args",
-            "test_form_only",
-            "",
-        ),
-        # case where only args contains the parameter, form is empty
-        (
-            {},
-            {"param_args": "test_arg_only"},
-            "param_form",
-            "param_args",
-            "",
-            "test_arg_only",
-        ),
-        # case where form has an empty value, args has the parameter with value
-        (
-            {"param_form": ""},
-            {"param_args": "test_arg_value"},
-            "param_form",
-            "param_args",
-            "",
-            "test_arg_value",
-        ),
-        # case where args has an empty value, form has the parameter with value
-        (
-            {"param_form": "test_form_value"},
-            {"param_args": ""},
-            "param_form",
-            "param_args",
-            "test_form_value",
-            "",
-        ),
-        # case where both form and args contain the parameter with different values, form should take precedence
-        (
-            {"param_mixed": "form_precedence"},
-            {"param_mixed": "args_value"},
-            "param_mixed",
-            "param_mixed",
-            "form_precedence",
-            "form_precedence",
-        ),
-        # case where neither form nor args contains the parameter
-        ({}, {}, "param_missing", "param_missing", "", ""),
-        # case where parameter is None, should return empty regardless of form or args
-        (
-            {"param_form": "some_value"},
-            {"param_args": "some_value"},
-            None,
-            None,
-            "",
-            "",
-        ),
-    ],
-)
-def test_get_param(
-    form_data,
-    args_data,
-    form_param,
-    args_param,
-    expected_form_param,
-    expected_args_param,
-):
-    # request is an object with attributes and not just a dict
-    request = MagicMock()
-    request.form = form_data
-    request.args = args_data
-    assert get_param(form_param, request) == expected_form_param
-    assert get_param(args_param, request) == expected_args_param
-
-
-@pytest.mark.parametrize(
-    "form_data, args_data, expected_query, expected_search_area",
-    [
-        # case where both query and search_area are in form
-        (
-            {"query": "test_query_form", "search_area": "test_area_form"},
-            {},
-            "test_query_form",
-            "test_area_form",
-        ),
-        # case where both query and search_area are in args
-        (
-            {},
-            {"query": "test_query_args", "search_area": "test_area_args"},
-            "test_query_args",
-            "test_area_args",
-        ),
-    ],
-)
-def test_get_query_and_search_area(
-    form_data, args_data, expected_query, expected_search_area
-):
-    request = MagicMock()
-    request.form = form_data
-    request.args = args_data
-    query, search_area = get_query_and_search_area(request)
-    assert query == expected_query
-    assert search_area == expected_search_area
 
 
 def test_setup_opensearch(app):

--- a/e2e_tests/navigation_journeys/test_search_to_record_journey.py
+++ b/e2e_tests/navigation_journeys/test_search_to_record_journey.py
@@ -25,7 +25,7 @@ def test_search_to_record(aau_user_page: Page):
     aau_user_page.get_by_role("textbox").first.fill("a")
     aau_user_page.get_by_role("button", name="Search").click()
     expect(aau_user_page).to_have_url(
-        "/search_results_summary?search_area=everywhere&query=a"
+        "/search_results_summary?query=a&search_area=everywhere"
     )
 
     aau_user_page.wait_for_selector("#tbl_result")

--- a/e2e_tests/test_pagination.py
+++ b/e2e_tests/test_pagination.py
@@ -41,7 +41,10 @@ class TestPagination:
             == "Pagination"
         )
 
-        url = f"{self.route_url}/{self.transferring_body_id}?page=1&query=a&search_area=everywhere#tbl_result"
+        url = (
+            f"{self.route_url}/{self.transferring_body_id}"
+            "?page=1&query=a&search_area=everywhere&sort=file_name&open_all=&search_filter=#tbl_result"
+        )
         assert (
             aau_user_page.locator("data-testid=pagination-link")
             .first.get_attribute("href")
@@ -103,7 +106,10 @@ class TestPagination:
             )
             == "Pagination"
         )
-        expected_url = f"{self.route_url}/{self.transferring_body_id}?page=1&query=a&search_area=everywhere#tbl_result"
+        expected_url = (
+            f"{self.route_url}/{self.transferring_body_id}"
+            "?page=1&query=a&search_area=everywhere&sort=file_name&open_all=&search_filter=#tbl_result"
+        )
         actual_href = (
             aau_user_page.locator("data-testid=pagination-link")
             .first.get_attribute("href")
@@ -116,7 +122,7 @@ class TestPagination:
         actual_relative_url = aau_user_page.url.split("://", 1)[1].split(
             "/", 1
         )[1]
-        url_params = "page=2&query=a&search_area=everywhere#tbl_result"
+        url_params = "page=2&query=a&search_area=everywhere&sort=file_name&open_all=&search_filter=#tbl_result"
         expected_next_url = (
             f"""{self.route_url}/{self.transferring_body_id}?{url_params}"""
         )
@@ -194,7 +200,10 @@ class TestPagination:
 
         aau_user_page.get_by_label("Page 1", exact=True).click()
 
-        url = f"{self.route_url}/{self.transferring_body_id}?page=1&query=a&search_area=everywhere#tbl_result"
+        url = (
+            f"{self.route_url}/{self.transferring_body_id}"
+            "?page=1&query=a&search_area=everywhere&sort=file_name#tbl_result"
+        )
         expect(aau_user_page).to_have_url(url)
 
     def test_search_transferring_body_pagination_click_next_page_link(
@@ -225,14 +234,12 @@ class TestPagination:
 
         aau_user_page.wait_for_selector(".govuk-pagination")
 
-        # only 2 pages due to increase in table size
-        # links = aau_user_page.locator("data-testid=pagination-link-title").all()
-        # assert links[1].text_content() == "Nextpage"
-        # aau_user_page.get_by_label("Page 3", exact=True).click()
-
         aau_user_page.wait_for_selector(".govuk-pagination")
 
-        url = f"{self.route_url}/{self.transferring_body_id}?page=2&query=a&search_area=everywhere#tbl_result"
+        url = (
+            f"{self.route_url}/{self.transferring_body_id}"
+            "?page=2&query=a&search_area=everywhere&sort=file_name&open_all=&search_filter=#tbl_result"
+        )
         expect(aau_user_page).to_have_url(url)
 
     def test_search_transferring_body_pagination_get_last_page(


### PR DESCRIPTION
https://national-archives.atlassian.net/browse/AYR-1790

## Summary

Replaced remaining direct `request.args` usage with validated `request.validated_data` and `request.validated_data_non_default` and removed deprecated helper functions for improved security and consistency.

## Key Changes
Core Refactoring

- Replaced request.args with request.validated_data across all route handlers
- Removed deprecated helper functions: get_param() and get_query_and_search_area()
- Updated function signatures for build_filters(), build_sorting_orders(), and build_browse_consignment_filters() to use validated data
- Added CallbackRequestSchema for OIDC callback validation

Route Updates

- Browse routes: Now use validated_data instead of request.args
- Search routes: Direct access to validated fields (query, search_area, sort, etc.)
- Callback route: Added proper validation for authorization code parameter
- Filter functions: Updated to accept validated data with proper parameter names

New Features

- validated_data_non_defaults: Filters out default values for cleaner redirect URLs
- Improved error handling: Better logging for missing authorization codes
- Parameter precedence: Simplified logic using validated data instead of manual merging

Test Updates
- Fixed failing tests to align with new validation behaviour
- Updated test expectations to only include valid schema fields
- Schema validation tests updated for required _id field

This refactoring eliminates direct request parameter access, ensuring all input goes through proper validation while maintaining full functionality.