### PR TITLE
Pin playwright in e2e tests dockerfile

### DIFF
--- a/e2e_tests/dockerfile
+++ b/e2e_tests/dockerfile
@@ -2,6 +2,6 @@ FROM mcr.microsoft.com/playwright/python@sha256:640d578aae63cfb632461d1b0aecb014
 
 WORKDIR /e2e_tests
 
-RUN pip install --upgrade pip wheel setuptools numpy scikit-image pillow playwright python-keycloak pytest-playwright-visual pytest-playwright pytest-html PyJWT itsdangerous cryptography
+RUN pip install --upgrade pip wheel setuptools numpy scikit-image pillow playwright==1.55.0 python-keycloak pytest-playwright-visual==2.1.2 pytest-playwright==0.7.1 pytest-html PyJWT itsdangerous cryptography
 
 CMD ["pytest", "-vvv", "-s", ".", "--base-url=https://127.0.0.1:5000", "--browser", "chromium", "--browser", "webkit", "--browser", "firefox", "--update-snapshots", "--html=playwright-report/report.html", "--self-contained-html"]


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

Pin playwright in e2e tests dockerfile to fix failing e2e test runs, due to new version 1.56.0 being released. Dependabot will handle keeping this up to date. I haven't pinned the other dependencies as part of this PR, as this is just a tempoary measure. I am going to streamline the dockerfiles so we just have 1 with multistage builds which is shared between webapp and testing.

## JIRA ticket
NOJIRA