### PR TITLE
updated access-copy-conversion to use PUID instead of Extension

### DIFF
--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -36,6 +36,12 @@ def get_file_extension(file):
     return file_extension
 
 
+def get_file_puid(file):
+    """Extract file PUID from FFIDMetadata"""
+    puid = file.ffid_metadata.PUID.lower()
+    return puid
+
+
 def get_download_filename(file):
     """Generate download filename for a file."""
     if file.CiteableReference:

--- a/app/tests/test_record.py
+++ b/app/tests/test_record.py
@@ -306,7 +306,7 @@ class TestRecord:
         Then the alert banner responsible with alerting the user should NOT be visible
         """
 
-        file = FileFactory(ffid_metadata__Extension="doc")
+        file = FileFactory(ffid_metadata__PUID="fmt/40")
         bucket_name = "test_bucket"
 
         app.config["ACCESS_COPY_BUCKET"] = bucket_name

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -8,6 +8,7 @@ from app.main.util.render_utils import (
     generate_breadcrumb_values,
     get_download_filename,
     get_file_extension,
+    get_file_puid,
 )
 
 
@@ -18,6 +19,13 @@ def test_get_file_extension_with_ffid_extension():
 
     ext = get_file_extension(mock_file)
     assert ext == "pdf"
+
+
+def test_get_file_puid_with_ffid_puid():
+    mock_file = Mock()
+    mock_file.ffid_metadata.PUID = "fmt/40"
+    puid = get_file_puid(mock_file)
+    assert puid == "fmt/40"
 
 
 def test_get_file_extension_with_ffid_extension_none_uses_filename():

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -433,7 +433,7 @@ class TestRoutes:
     @mock_aws
     @patch("app.main.routes.boto3.client")
     @patch("app.main.routes.generate_pdf_manifest")
-    def test_generate_manifest_pdf_for_convertible_file_extensions(
+    def test_generate_manifest_pdf_for_convertible_file_puids(
         self,
         mock_pdf,
         mock_boto_client,
@@ -446,7 +446,7 @@ class TestRoutes:
         When file_extension is in CONVERTIBLE_EXTENSIONS
         """
         mock_all_access_user(client)
-        file = FileFactory(ffid_metadata__Extension="doc")
+        file = FileFactory(ffid_metadata__PUID="fmt/40")
         bucket_name = "test_bucket"
         app.config["ACCESS_COPY_BUCKET"] = bucket_name
 
@@ -531,11 +531,10 @@ class TestRoutes:
         mock_all_access_user,
     ):
         mock_all_access_user(client)
-        file = FileFactory(ffid_metadata__Extension="doc")
+        file = FileFactory(ffid_metadata__PUID="fmt/40")
         bucket_name = "test-bucket"
         app.config["ACCESS_COPY_BUCKET"] = bucket_name
         app.config["SUPPORTED_RENDER_EXTENSIONS"] = ["pdf", "png"]
-        create_mock_s3_bucket_with_object(bucket_name, file)
 
         mock_create_presigned_url.side_effect = Exception(
             "failed to create access copy"
@@ -544,4 +543,5 @@ class TestRoutes:
         response = client.get(f"/record/{file.FileId}")
 
         assert response.status_code == 200
+
         assert b"Converted access copy not available." in response.data

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -11,20 +11,21 @@ UNIVERSAL_VIEWER_SUPPORTED_IMAGE_TYPES = {
 }
 UNIVERSAL_VIEWER_SUPPORTED_APPLICATION_TYPES = {"pdf": "application/pdf"}
 
-CONVERTIBLE_EXTENSIONS = {
-    "doc",
-    "docx",
-    "ppt",
-    "pptx",
-    "wk1",
-    "wpd",
-    "rtf",
-    "xls",
-    "xlsx",
-    "xml",
-    "odt",
-    "html",
-    "wk4",
+CONVERTIBLE_PUIDS = {
+    "fmt/40",
+    "fmt/61",
+    "x-fmt/44",
+    "x-fmt/394",
+    "fmt/412",
+    "fmt/126",
+    "fmt/50",
+    "x-fmt/116",
+    "fmt/214",
+    "fmt/39",
+    "fmt/355",
+    "fmt/59",
+    "fmt/215",
+    "x-fmt/111" "x-fmt/45",
 }
 
 

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -25,7 +25,8 @@ CONVERTIBLE_PUIDS = {
     "fmt/355",
     "fmt/59",
     "fmt/215",
-    "x-fmt/111" "x-fmt/45",
+    "x-fmt/111",
+    "x-fmt/45",
 }
 
 

--- a/data_management/access_copy_converter/access_copy_converter/main.py
+++ b/data_management/access_copy_converter/access_copy_converter/main.py
@@ -24,7 +24,8 @@ CONVERTIBLE_PUIDS = {
     "fmt/355",
     "fmt/59",
     "fmt/215",
-    "x-fmt/111" "x-fmt/45",
+    "x-fmt/111",
+    "x-fmt/45",
 }
 
 EXCEL_PUIDS = {"fmt/214", "fmt/59", "fmt/61"}


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR

- Use PUIDs instead of Extensions 
  - for access-copy-converter
  - for app To determine which files can be rendered
- Updated related tests

## JIRA ticket
[AYR-1823](https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?jql=assignee%20%3D%2060ba6c41f8a90b006f65b5fb&selectedIssue=AYR-1823)


[AYR-1823]: https://national-archives.atlassian.net/browse/AYR-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ