### PR TITLE
Fix routes with pagination due to extra _id arg being passed to url_route

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -246,7 +246,9 @@ def browse():
             sorting_orders=sorting_orders,
             num_records_found=num_records_found,
             query_string_parameters={
-                k: v for k, v in validated_data.items() if k not in "page"
+                k: v
+                for k, v in validated_data.items()
+                if k not in "page" and k != "_id"
             },
             id=None,
         )
@@ -339,7 +341,9 @@ def browse_transferring_body(_id: uuid.UUID):
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
         query_string_parameters={
-            k: v for k, v in validated_data.items() if k not in "page"
+            k: v
+            for k, v in validated_data.items()
+            if k not in "page" and k != "_id"
         },
     )
 
@@ -436,7 +440,9 @@ def browse_series(_id: uuid.UUID):
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
         query_string_parameters={
-            k: v for k, v in validated_data.items() if k not in "page"
+            k: v
+            for k, v in validated_data.items()
+            if k not in "page" and k != "_id"
         },
     )
 
@@ -533,7 +539,9 @@ def browse_consignment(_id: uuid.UUID):
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
         query_string_parameters={
-            k: v for k, v in validated_data.items() if k not in "page"
+            k: v
+            for k, v in validated_data.items()
+            if k not in "page" and k != "_id"
         },
     )
 
@@ -623,7 +631,9 @@ def search_results_summary():
         pagination=pagination,
         num_records_found=num_records_found,
         query_string_parameters={
-            k: v for k, v in validated_data.items() if k not in "page"
+            k: v
+            for k, v in validated_data.items()
+            if k not in "page" and k != "_id"
         },
         id=None,
     )

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -245,11 +245,7 @@ def browse():
             date_filters=date_filters,
             sorting_orders=sorting_orders,
             num_records_found=num_records_found,
-            query_string_parameters={
-                k: v
-                for k, v in validated_data.items()
-                if k not in "page" and k != "_id"
-            },
+            query_string_parameters=validated_data,
             id=None,
         )
 
@@ -340,11 +336,7 @@ def browse_transferring_body(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v
-            for k, v in validated_data.items()
-            if k not in "page" and k != "_id"
-        },
+        query_string_parameters=validated_data,
     )
 
 
@@ -439,11 +431,7 @@ def browse_series(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v
-            for k, v in validated_data.items()
-            if k not in "page" and k != "_id"
-        },
+        query_string_parameters=validated_data,
     )
 
 
@@ -538,11 +526,7 @@ def browse_consignment(_id: uuid.UUID):
         date_filters=date_filters,
         sorting_orders=sorting_orders,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v
-            for k, v in validated_data.items()
-            if k not in "page" and k != "_id"
-        },
+        query_string_parameters=validated_data,
     )
 
 
@@ -630,11 +614,7 @@ def search_results_summary():
         results=paginated_results,
         pagination=pagination,
         num_records_found=num_records_found,
-        query_string_parameters={
-            k: v
-            for k, v in validated_data.items()
-            if k not in "page" and k != "_id"
-        },
+        query_string_parameters=validated_data,
         id=None,
     )
 
@@ -714,9 +694,6 @@ def search_transferring_body(_id: uuid.UUID):
         )
         num_records_found = total_records
 
-    query_string_parameters = validated_data.copy()
-    query_string_parameters.pop("page", None)
-    query_string_parameters.pop("_id", None)
     return render_template(
         "search-transferring-body.html",
         form=form,
@@ -731,7 +708,7 @@ def search_transferring_body(_id: uuid.UUID):
         pagination=pagination,
         open_all=open_all,
         highlight_tag=highlight_tag,
-        query_string_parameters=query_string_parameters,
+        query_string_parameters=validated_data,
     )
 
 

--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -1,4 +1,7 @@
 {% if pagination %}
+    {% set filtered_params = query_string_parameters.copy() %}
+    {% set _ = filtered_params.pop('page', None) %}
+    {% set _ = filtered_params.pop('_id', None) %}
     <nav class="govuk-pagination govuk-pagination--centred"
          role="navigation"
          aria-label="Pagination">
@@ -6,7 +9,7 @@
             <div class="govuk-pagination__prev">
                 <a data-testid="pagination-link"
                    class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
-                   href="{% if id != None -%} {{ url_for(view_name, _id=id, page=current_page-1, **query_string_parameters) }} {%- else -%} {{ url_for(view_name, page=current_page-1, **query_string_parameters) }} {%- endif %}#tbl_result"
+                   href="{% if id != None -%} {{ url_for(view_name, _id=id, page=current_page-1, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=current_page-1, **filtered_params) }} {%- endif %}#tbl_result"
                    rel="prev">
                     <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
                          xmlns="http://www.w3.org/2000/svg"
@@ -31,7 +34,7 @@
                     {% else %}
                         <a data-testid="pagination-link"
                            class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
-                           href="{% if id != None -%} {{ url_for(view_name, _id=id , page=page, **query_string_parameters) }} {%- else -%} {{ url_for(view_name, page=page, **query_string_parameters) }} {%- endif %}#tbl_result"
+                           href="{% if id != None -%} {{ url_for(view_name, _id=id , page=page, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=page, **filtered_params) }} {%- endif %}#tbl_result"
                            aria-label="Page {{ page }}">{{ page }}</a>
                     {% endif %}
                 </li>
@@ -41,7 +44,7 @@
             <div class="govuk-pagination__next">
                 <a data-testid="pagination-link"
                    class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
-                   href="{% if id != None -%} {{ url_for(view_name, _id=id , page=current_page+1, **query_string_parameters) }} {%- else -%} {{ url_for(view_name, page=current_page+1, **query_string_parameters) }}{%- endif %}#tbl_result"
+                   href="{% if id != None -%} {{ url_for(view_name, _id=id , page=current_page+1, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=current_page+1, **filtered_params) }}{%- endif %}#tbl_result"
                    rel="next">
                     <span data-testid="pagination-link-title"
                           class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden">page</span></span>

--- a/app/tests/test_templates/test_pagination_template.py
+++ b/app/tests/test_templates/test_pagination_template.py
@@ -1,0 +1,97 @@
+from flask import render_template
+
+
+class TestPaginationTemplate:
+    """Test the pagination template by rendering it and checking actual HTML output."""
+
+    def test_template_filters_out_page_and_id_from_query_params(self, app):
+        """Test that page=999 and _id=bad-id are filtered out of pagination links."""
+        with app.test_request_context("/browse"):
+            rendered = render_template(
+                "main/pagination.html",
+                pagination={"previous": 1, "next": 3, "pages": [1, 2, 3]},
+                current_page=2,
+                view_name="main.browse",
+                id=None,
+                query_string_parameters={
+                    "search": "documents",
+                    "sort": "date",
+                    "page": 999,  # This should be filtered out
+                    "_id": "bad-id",  # This should be filtered out
+                    "filter": "pdf",
+                },
+            )
+
+            # Should contain pagination HTML
+            assert "govuk-pagination" in rendered
+
+            # Should contain our preserved parameters
+            assert "search=documents" in rendered
+            assert "sort=date" in rendered
+            assert "filter=pdf" in rendered
+
+            # Should NOT contain the filtered parameters
+            assert "page=999" not in rendered
+            assert "_id=bad-id" not in rendered
+
+            # Should contain explicit pagination page numbers (1 and 3)
+            assert "page=1" in rendered  # Previous page
+            assert "page=3" in rendered  # Next page
+
+    def test_template_uses_explicit_id_not_query_param_id(self, app):
+        """Test that explicit id parameter overrides _id in query_string_parameters."""
+        explicit_id = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+
+        with app.test_request_context("/browse"):
+            rendered = render_template(
+                "main/pagination.html",
+                pagination={"previous": 1, "next": 3, "pages": [1, 2, 3]},
+                current_page=2,
+                view_name="main.browse_transferring_body",
+                id=explicit_id,  # This should be used
+                query_string_parameters={
+                    "search": "test",
+                    "_id": "wrong-id-from-params",  # This should be ignored
+                    "page": 42,  # This should be ignored
+                },
+            )
+
+            # Should use the explicit ID in the URL path (not as _id query param)
+            assert f"/transferring_body/{explicit_id}" in rendered
+
+            # Should NOT use the query param ID
+            assert "_id=wrong-id-from-params" not in rendered
+            assert "page=42" not in rendered
+
+            # Should preserve other query params
+            assert "search=test" in rendered
+
+    def test_template_works_with_empty_query_params(self, app):
+        """Test template renders correctly with no query parameters."""
+        with app.test_request_context("/browse"):
+            rendered = render_template(
+                "main/pagination.html",
+                pagination={"previous": None, "next": 2, "pages": [1, 2]},
+                current_page=1,
+                view_name="main.browse",
+                id=None,
+                query_string_parameters={},
+            )
+
+            assert "govuk-pagination" in rendered
+            assert "page=2" in rendered  # Next page link
+
+    def test_template_renders_nothing_when_no_pagination(self, app):
+        """Test template renders empty when pagination is None."""
+        with app.test_request_context("/browse"):
+            rendered = render_template(
+                "main/pagination.html",
+                pagination=None,
+                current_page=1,
+                view_name="main.browse",
+                id=None,
+                query_string_parameters={"search": "test"},
+            )
+
+            # Should be empty - no pagination HTML
+            assert rendered.strip() == ""


### PR DESCRIPTION

Fix routes with pagination due to extra _id arg being passed to url_route

## Changes in this PR

- Refactored so that pagination template filters out _id and page from query_string_parameters, rather than every route that uses it. Also added test for the pagination template

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-1790