### PR TITLE
AYR-1398 - Remove PDF.js in CSP

### DIFF
--- a/app/static/init.uv.js
+++ b/app/static/init.uv.js
@@ -10,7 +10,7 @@ function initUniversalViewer() {
   const uv = UV.init("uv", data);
   uv.on("configure", function ({ config, cb }) {
     config.modules.centerPanel.options = {
-      usePdfJs: true,
+      usePdfJs: false,
     };
     config.modules.footerPanel.options = {
       downloadEnabled: false,

--- a/app/tests/test_config.py
+++ b/app/tests/test_config.py
@@ -93,7 +93,6 @@ def test_local_env_vars_config_initialized(monkeypatch):
     ]
     assert config.CSP_SCRIPT_SRC_ELEM == [
         "'self'",
-        "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
         "https://cdn.jsdelivr.net/npm/universalviewer@4.2.0/",
     ]
     assert config.CSP_STYLE_SRC == ["'self'", "test_flasks3_cdn_domain"]
@@ -335,7 +334,6 @@ def test_aws_secrets_manager_config_initialized(monkeypatch):
     ]
     assert config.CSP_SCRIPT_SRC_ELEM == [
         "'self'",
-        "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
         "https://cdn.jsdelivr.net/npm/universalviewer@4.2.0/",
     ]
     assert config.CSP_STYLE_SRC == ["'self'", "test_flasks3_cdn_domain"]

--- a/configs/base_config.py
+++ b/configs/base_config.py
@@ -259,7 +259,6 @@ class BaseConfig(object):
     def CSP_SCRIPT_SRC_ELEM(self):
         return [
             SELF,
-            "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/",
             "https://cdn.jsdelivr.net/npm/universalviewer@4.2.0/",
         ]
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
PDF.js has been removed, we don't use it anymore and it doesn't have any effect on rendering pdf pages

## JIRA ticket
[AYR-1398](https://national-archives.atlassian.net/browse/AYR-1398)

## Screenshots of UI changes

### Before
<img width="1137" height="927" alt="Screenshot 2025-12-02 at 09 14 52" src="https://github.com/user-attachments/assets/8649be2b-8305-46da-8678-f5e7964f9d0e" />


### After
<img width="1137" height="927" alt="Screenshot 2025-12-02 at 09 14 52" src="https://github.com/user-attachments/assets/0984dbe3-9301-4b7e-885f-17f04c65e13e" />


- [ ] Requires env variable(s) to be updated


[AYR-1398]: https://national-archives.atlassian.net/browse/AYR-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ