### PR TITLE
AYR-1418 - start_url warning

### DIFF
--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -9,7 +9,7 @@
         "type": "image/ico"
       }
     ],
-    "start_url": "./",
+    "start_url": "/browse",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#ffffff"

--- a/app/static/manifest.json
+++ b/app/static/manifest.json
@@ -9,7 +9,7 @@
         "type": "image/ico"
       }
     ],
-    "start_url": "/",
+    "start_url": "./",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#ffffff"


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Updated the start_url property in your manifest.json file from "/" to "/browse".

## JIRA ticket
https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?jql=assignee%20%3D%2063c55d4e0385ff0c65460583&selectedIssue=AYR-1418
## Screenshots of UI changes

### Before
<img width="1720" height="718" alt="Screenshot 2025-12-17 at 09 44 55" src="https://github.com/user-attachments/assets/056e0362-9463-43f0-a15f-0ff24b440353" />


### After
<img width="1728" height="755" alt="Screenshot 2025-12-17 at 09 44 33" src="https://github.com/user-attachments/assets/7a666005-d9bc-4118-83e2-84b50f545237" />


- [ ] Requires env variable(s) to be updated
