### PR TITLE
support additional file types for textraction

### DIFF
--- a/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
@@ -133,7 +133,7 @@ def add_text_content(file: Dict, file_stream: bytes) -> Dict:
                 file_puid
             ]
             target_ext = SUPPORTED_TEXTRACT_PUIDS[target_puid]
-
+            logger.info(f"Converting {file_id} to {target_ext}")
             with tempfile.NamedTemporaryFile(delete=True) as src:
                 src.write(file_stream)
                 src.flush()

--- a/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
@@ -26,7 +26,7 @@ TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP = {
     "fmt/116": "fmt/20",  # .bmp to .pdf
     "x-fmt/258": "fmt/20",  # .vsd to .pdf
     "x-fmt/1510": "fmt/20",  # .vsd to .pdf
-    "x-fmt/443": "fmt/20",  # .vsd to .pdf
+    "fmt/443": "fmt/20",  # .vsd to .pdf
     "x-fmt/255": "fmt/20",  # .pub to .pdf
     "x-fmt/332": "fmt/20",  # .fm3 to .pdf
 }

--- a/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
@@ -111,6 +111,29 @@ SUPPORTED_TEXTRACT_PUIDS = {
 }
 
 
+def convert_file_and_extract_text_in_memory(
+    file_stream: bytes, file_puid: str, file_id: str
+) -> str:
+    target_puid = TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP[file_puid]
+    target_ext = SUPPORTED_TEXTRACT_PUIDS[target_puid]
+    logger.info(f"Converting {file_id} to {target_ext}")
+    with tempfile.NamedTemporaryFile(delete=True) as src:
+        src.write(file_stream)
+        src.flush()
+
+        converted_path = convert_file_with_libreoffice(src.name, target_ext)
+
+        return extract_text(converted_path, target_puid)
+
+
+def extract_text_in_memory(file_stream: bytes, file_puid: str) -> str:
+    ext = SUPPORTED_TEXTRACT_PUIDS[file_puid]
+    with tempfile.NamedTemporaryFile(suffix=f".{ext}", delete=True) as temp:
+        temp.write(file_stream)
+        temp.flush()
+        return extract_text(temp.name, file_puid)
+
+
 def add_text_content(file: Dict, file_stream: bytes) -> Dict:
 
     file_puid = file["file_puid"] if file["file_puid"] else None
@@ -129,28 +152,11 @@ def add_text_content(file: Dict, file_stream: bytes) -> Dict:
             return file
 
         if file_puid in TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP:
-            target_puid = TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP[
-                file_puid
-            ]
-            target_ext = SUPPORTED_TEXTRACT_PUIDS[target_puid]
-            logger.info(f"Converting {file_id} to {target_ext}")
-            with tempfile.NamedTemporaryFile(delete=True) as src:
-                src.write(file_stream)
-                src.flush()
-
-                converted_path = convert_file_with_libreoffice(
-                    src.name, target_ext
-                )
-
-                file["content"] = extract_text(converted_path, target_puid)
+            file["content"] = convert_file_and_extract_text_in_memory(
+                file_stream, file_puid, file_id
+            )
         else:
-            ext = SUPPORTED_TEXTRACT_PUIDS[file_puid]
-            with tempfile.NamedTemporaryFile(
-                suffix=f".{ext}", delete=True
-            ) as temp:
-                temp.write(file_stream)
-                temp.flush()
-                file["content"] = extract_text(temp.name, file_puid)
+            file["content"] = extract_text_in_memory(file_stream, file_puid)
 
         file["text_extraction_status"] = TextExtractionStatus.SUCCEEDED.value
         logger.info(f"Text extraction succeeded for file {file_id}")

--- a/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
+++ b/data_management/opensearch_indexer/opensearch_indexer/text_extraction.py
@@ -16,13 +16,27 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 libreoffice_lock = threading.Lock()
 
+TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP = {
+    "x-fmt/44": "fmt/412",  # .wpd to .docx
+    "x-fmt/45": "fmt/412",  # .dot to .docx
+    "x-fmt/394": "fmt/412",  # .wpd to .docx
+    "fmt/126": "fmt/215",  # .ppt to .pptx
+    "x-fmt/115": "fmt/214",  # .wk3 to .xlsx
+    "x-fmt/116": "fmt/214",  # .wk4 to .xlsx
+    "fmt/116": "fmt/20",  # .bmp to .pdf
+    "x-fmt/258": "fmt/20",  # .vsd to .pdf
+    "x-fmt/1510": "fmt/20",  # .vsd to .pdf
+    "x-fmt/443": "fmt/20",  # .vsd to .pdf
+    "x-fmt/255": "fmt/20",  # .pub to .pdf
+    "x-fmt/332": "fmt/20",  # .fm3 to .pdf
+}
+
 TEXTRACT_FILE_PUIDS_FALLBACK_CONVERSION_MAP = {
-    "fmt/59": "fmt/214",
-    "fmt/61": "fmt/214",
-    "fmt/39": "fmt/412",
-    "fmt/40": "fmt/412",
-    "x-fmt/44": "fmt/412",
-    "x-fmt/45": "fmt/412",
+    "fmt/59": "fmt/214",  # .xls to .xlsx
+    "fmt/61": "fmt/214",  # .xls to .xlsx
+    "fmt/39": "fmt/412",  # .doc to .docx
+    "fmt/40": "fmt/412",  # .doc to .docx
+    "fmt/609": "fmt/412",  # .doc to .docx
 }
 SLACK_CHANNEL = os.getenv("SLACK_CHANNEL")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "local")
@@ -78,7 +92,6 @@ SUPPORTED_TEXTRACT_PUIDS = {
     "fmt/148": "pdf",
     "fmt/157": "pdf",
     "fmt/158": "pdf",
-    "x-fmt/394": "html",
     "fmt/278": "eml",
     "x-fmt/430": "msg",
     "fmt/3": "gif",
@@ -103,63 +116,83 @@ def add_text_content(file: Dict, file_stream: bytes) -> Dict:
     file_puid = file["file_puid"] if file["file_puid"] else None
     file_id = file["file_id"]
 
-    if file_puid not in SUPPORTED_TEXTRACT_PUIDS:
-        logger.info(
-            f"Text extraction skipped for file {file_id} due to unsupported file type: {file_puid}"
-        )
-        file["content"] = ""
-        file["text_extraction_status"] = TextExtractionStatus.SKIPPED.value
-    else:
-        try:
-            file["content"] = extract_text(file_stream, file_puid)
-            logger.info(f"Text extraction succeeded for file {file_id}")
-            file["text_extraction_status"] = (
-                TextExtractionStatus.SUCCEEDED.value
+    try:
+        if (
+            file_puid not in SUPPORTED_TEXTRACT_PUIDS
+            and file_puid not in TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP
+        ):
+            logger.info(
+                f"Text extraction skipped for file {file_id} due to unsupported file type: {file_puid}"
             )
-        except Exception as e:
-            logger.error(f"Text extraction failed for file {file_id}: {e}")
             file["content"] = ""
-            file["text_extraction_status"] = TextExtractionStatus.FAILED.value
+            file["text_extraction_status"] = TextExtractionStatus.SKIPPED.value
+            return file
+
+        if file_puid in TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP:
+            target_puid = TEXTRACT_FILE_PUIDS_CONVERT_TO_SUPPORTED_MAP[
+                file_puid
+            ]
+            target_ext = SUPPORTED_TEXTRACT_PUIDS[target_puid]
+
+            with tempfile.NamedTemporaryFile(delete=True) as src:
+                src.write(file_stream)
+                src.flush()
+
+                converted_path = convert_file_with_libreoffice(
+                    src.name, target_ext
+                )
+
+                file["content"] = extract_text(converted_path, target_puid)
+        else:
+            ext = SUPPORTED_TEXTRACT_PUIDS[file_puid]
+            with tempfile.NamedTemporaryFile(
+                suffix=f".{ext}", delete=True
+            ) as temp:
+                temp.write(file_stream)
+                temp.flush()
+                file["content"] = extract_text(temp.name, file_puid)
+
+        file["text_extraction_status"] = TextExtractionStatus.SUCCEEDED.value
+        logger.info(f"Text extraction succeeded for file {file_id}")
+
+    except Exception as e:
+        logger.error(f"Text extraction failed for file {file_id}: {e}")
+        file["content"] = ""
+        file["text_extraction_status"] = TextExtractionStatus.FAILED.value
+
     return file
 
 
-def extract_text(file_stream: bytes, file_puid: str) -> str:
-    with tempfile.NamedTemporaryFile(
-        suffix=f".{SUPPORTED_TEXTRACT_PUIDS[file_puid]}", delete=True
-    ) as temp:
-        temp.write(file_stream)
-        temp.flush()
-        file_path = temp.name
+def extract_text(file_path: str, file_puid: str) -> str:
+    try:
+        context = textract.process(file_path)
+        return context.decode("utf-8")
+
+    except Exception as e:
+        logger.warning(f"Textract failed on {file_path}: {e}")
+
+        if file_puid not in TEXTRACT_FILE_PUIDS_FALLBACK_CONVERSION_MAP:
+            raise e
+
+        output_file_type = SUPPORTED_TEXTRACT_PUIDS[
+            TEXTRACT_FILE_PUIDS_FALLBACK_CONVERSION_MAP[file_puid]
+        ]
+        logger.info(
+            f"Attempting to convert to {output_file_type} before trying textract again..."
+        )
 
         try:
-            context = textract.process(file_path)
-            return context.decode("utf-8")
-
-        except Exception as e:
-            logger.warning(f"Textract failed on {file_path}: {e}")
-
-            if file_puid not in TEXTRACT_FILE_PUIDS_FALLBACK_CONVERSION_MAP:
-                raise e
-
-            output_file_type = SUPPORTED_TEXTRACT_PUIDS[
-                TEXTRACT_FILE_PUIDS_FALLBACK_CONVERSION_MAP[file_puid]
-            ]
-            logger.info(
-                f"Attempting to convert to {output_file_type} before trying textract again..."
+            converted_path = convert_file_with_libreoffice(
+                file_path, output_file_type
             )
-
-            try:
-                converted_path = convert_file_with_libreoffice(
-                    file_path, output_file_type
-                )
-                logger.info(f"Converted to: {converted_path}")
-                text = textract.process(converted_path)
-                return text.decode("utf-8")
-            except Exception as convert_err:
-                logger.error(f"LibreOffice fallback also failed: {convert_err}")
-                raise Exception(
-                    f"Textract failed on original file: {e}: LibreOffice fallback also failed: {convert_err}"
-                )
+            logger.info(f"Converted to: {converted_path}")
+            text = textract.process(converted_path)
+            return text.decode("utf-8")
+        except Exception as convert_err:
+            logger.error(f"LibreOffice fallback also failed: {convert_err}")
+            raise Exception(
+                f"Textract failed on original file: {e}: LibreOffice fallback also failed: {convert_err}"
+            )
 
 
 def convert_file_with_libreoffice(

--- a/data_management/opensearch_indexer/tests/test_text_extraction.py
+++ b/data_management/opensearch_indexer/tests/test_text_extraction.py
@@ -1,5 +1,6 @@
+import tempfile
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
 import pytest
 from opensearch_indexer.text_extraction import (
@@ -75,10 +76,7 @@ class TestExtractText:
     )
     def test_extract_text(self, file_name, file_type, expected_output):
         path = Path(__file__).parent / f"test_files/{file_name}"
-        with open(path, "rb") as file:
-            file_stream = file.read()
-
-        assert extract_text(file_stream, file_type) == expected_output
+        assert extract_text(str(path), file_type) == expected_output
 
 
 # Mock ENVIRONMENT for slack alerts
@@ -123,7 +121,7 @@ def test_add_text_content_success(mock_extract_text, caplog):
     assert (
         result["text_extraction_status"] == TextExtractionStatus.SUCCEEDED.value
     )
-    mock_extract_text.assert_called_once_with(file_stream, "fmt/276")
+    mock_extract_text.assert_called_once_with(ANY, "fmt/276")
 
     assert "Text extraction succeeded for file 1" in caplog.text
 
@@ -155,7 +153,7 @@ def test_add_text_content_no_ffid_metadata_success(mock_extract_text, caplog):
     assert (
         result["text_extraction_status"] == TextExtractionStatus.SUCCEEDED.value
     )
-    mock_extract_text.assert_called_once_with(file_stream, "fmt/276")
+    mock_extract_text.assert_called_once_with(ANY, "fmt/276")
 
     assert "Text extraction succeeded for file 1" in caplog.text
 
@@ -223,7 +221,7 @@ def test_add_text_content_failure(mock_extract_text, caplog):
     # Then
     assert result["content"] == ""
     assert result["text_extraction_status"] == TextExtractionStatus.FAILED.value
-    mock_extract_text.assert_called_once_with(file_stream, "x-fmt/111")
+    mock_extract_text.assert_called_once_with(ANY, "x-fmt/111")
 
     assert (
         "Text extraction failed for file 3: Text extraction failed"
@@ -307,20 +305,29 @@ def test_extract_text_libreoffice_conversion_failure():
     """
     file_bytes = b"dummy content"
 
-    with patch(
-        "opensearch_indexer.text_extraction.textract.process"
-    ) as mock_textract, patch(
-        "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
-    ) as mock_convert:
+    with tempfile.NamedTemporaryFile(suffix=".xls", delete=True) as temp:
+        temp.write(file_bytes)
+        temp.flush()
 
-        mock_textract.side_effect = Exception("initial textract failed")
-        mock_convert.side_effect = Exception("libreoffice conversion failed")
+        with patch(
+            "opensearch_indexer.text_extraction.textract.process"
+        ) as mock_textract, patch(
+            "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
+        ) as mock_convert:
 
-        with pytest.raises(Exception, match="libreoffice conversion failed"):
-            extract_text(file_bytes, "fmt/59")
+            mock_textract.side_effect = Exception("initial textract failed")
+            mock_convert.side_effect = Exception(
+                "libreoffice conversion failed"
+            )
 
-        mock_textract.assert_called_once()
-        mock_convert.assert_called_once()
+            with pytest.raises(Exception) as exc_info:
+                extract_text(temp.name, "fmt/59")
+
+            assert "initial textract failed" in str(exc_info.value)
+            assert "libreoffice conversion failed" in str(exc_info.value)
+
+            mock_textract.assert_called_once()
+            mock_convert.assert_called_once()
 
 
 def test_extract_text_fallback_conversion_failure():
@@ -331,25 +338,154 @@ def test_extract_text_fallback_conversion_failure():
     file_bytes = b"dummy file content"
     converted_path = "/tmp/converted.xlsx"
 
+    with tempfile.NamedTemporaryFile(suffix=".xls", delete=True) as temp:
+        temp.write(file_bytes)
+        temp.flush()
+
+        with patch(
+            "opensearch_indexer.text_extraction.textract.process"
+        ) as mock_textract, patch(
+            "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
+        ) as mock_convert:
+
+            # Given
+            mock_textract.side_effect = [
+                Exception("initial textract failed"),
+                Exception("converted textract failed"),
+            ]
+            mock_convert.return_value = converted_path
+
+            # Then
+            with pytest.raises(Exception) as exc_info:
+                extract_text(temp.name, "fmt/59")
+
+            assert "initial textract failed" in str(exc_info.value)
+            assert "converted textract failed" in str(exc_info.value)
+
+            assert mock_textract.call_count == 2
+            mock_convert.assert_called_once()
+
+
+def test_add_text_content_proactive_conversion_success(caplog):
+    """
+    Given an unsupported file type that is in the proactive conversion map,
+    When conversion and subsequent extraction succeed,
+    Then the content is extracted from the converted file and status is SUCCEEDED.
+    """
+    # Given a PUID in the convert map (e.g., x-fmt/44: .wpd to .docx)
+    file = {
+        "file_id": 6,
+        "file_name": "example.wpd",
+        "file_extension": "wpd",
+        "file_puid": "x-fmt/44",
+        "content": "",
+        "text_extraction_status": "",
+    }
+    file_stream = b"original wpd content"
+
     with patch(
         "opensearch_indexer.text_extraction.textract.process"
     ) as mock_textract, patch(
         "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
     ) as mock_convert:
+        mock_textract.return_value = b"extracted from docx"
+        mock_convert.return_value = "/tmp/example.docx"
 
-        # Given
-        mock_textract.side_effect = [
-            Exception("initial textract failed"),
-            Exception("converted textract failed"),
-        ]
-        mock_convert.return_value = converted_path
+        # When
+        result = add_text_content(file, file_stream)
 
         # Then
-        with pytest.raises(Exception, match="converted textract failed"):
-            extract_text(file_bytes, "fmt/59")
+        assert result["content"] == "extracted from docx"
+        assert (
+            result["text_extraction_status"]
+            == TextExtractionStatus.SUCCEEDED.value
+        )
+        mock_convert.assert_called_once_with(ANY, "docx")
+        mock_textract.assert_called_once_with("/tmp/example.docx")
+        assert "Converting 6 to docx" in caplog.text
+        assert "Text extraction succeeded for file 6" in caplog.text
 
-        assert mock_textract.call_count == 2
-        mock_convert.assert_called_once()
+
+def test_add_text_content_proactive_conversion_failure(caplog):
+    """
+    Given an unsupported file type that is in the proactive conversion map,
+    When conversion fails,
+    Then the status is set to FAILED and content is empty.
+    """
+    # Given a PUID in the convert map (e.g., fmt/126: .ppt to .pptx)
+    file = {
+        "file_id": 7,
+        "file_name": "example.ppt",
+        "file_extension": "ppt",
+        "file_puid": "fmt/126",
+        "content": "",
+        "text_extraction_status": "",
+    }
+    file_stream = b"original ppt content"
+
+    with patch(
+        "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
+    ) as mock_convert:
+        mock_convert.side_effect = Exception("conversion failed")
+
+        # When
+        result = add_text_content(file, file_stream)
+
+        # Then
+        assert result["content"] == ""
+        assert (
+            result["text_extraction_status"]
+            == TextExtractionStatus.FAILED.value
+        )
+        mock_convert.assert_called_once_with(ANY, "pptx")
+        assert "Converting 7 to pptx" in caplog.text
+        assert (
+            "Text extraction failed for file 7: conversion failed"
+            in caplog.text
+        )
+
+
+def test_add_text_content_proactive_conversion_extract_failure(caplog):
+    """
+    Given an unsupported file type that is in the proactive conversion map,
+    When conversion succeeds but extraction on converted file fails,
+    Then the status is set to FAILED and content is empty.
+    """
+    # Given a PUID in the convert map (e.g., x-fmt/258: .vsd to .pdf)
+    file = {
+        "file_id": 8,
+        "file_name": "example.vsd",
+        "file_extension": "vsd",
+        "file_puid": "x-fmt/258",
+        "content": "",
+        "text_extraction_status": "",
+    }
+    file_stream = b"original vsd content"
+
+    with patch(
+        "opensearch_indexer.text_extraction.textract.process"
+    ) as mock_textract, patch(
+        "opensearch_indexer.text_extraction.convert_file_with_libreoffice"
+    ) as mock_convert:
+        mock_textract.side_effect = Exception("extract after convert failed")
+        mock_convert.return_value = "/tmp/example.pdf"
+
+        # When
+        result = add_text_content(file, file_stream)
+
+        # Then
+        assert result["content"] == ""
+        assert (
+            result["text_extraction_status"]
+            == TextExtractionStatus.FAILED.value
+        )
+        mock_convert.assert_called_once_with(ANY, "pdf")
+        mock_textract.assert_called_once_with("/tmp/example.pdf")
+        assert "Converting 8 to pdf" in caplog.text
+        assert (
+            "Text extraction failed for file 8: extract after convert failed"
+            in caplog.text
+        )
 
 
 # def test_add_text_content_skipped_alert():


### PR DESCRIPTION
<!-- Amend as appropriate -->

Extended text extraction support by converting unsupported but convertible file types into formats supported by Textract using LibreOffice before extraction

## JIRA ticket
[AYR-1887](https://national-archives.atlassian.net/browse/AYR-1887)


[AYR-1887]: https://national-archives.atlassian.net/browse/AYR-1887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ