### PR TITLE
Fix critical vulnerabilities 

### DIFF
--- a/data_management/access_copy_converter/Dockerfile
+++ b/data_management/access_copy_converter/Dockerfile
@@ -2,7 +2,7 @@
 FROM python@sha256:326df678c20c78d465db501563f3492d17c42a4afe33a1f2bf5406a1d56b0e86
 
 # Install system dependencies including LibreOffice
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get -y upgrade && apt-get install -y \
     libreoffice \
     libreoffice-writer \
     libreoffice-calc \

--- a/data_management/opensearch_indexer/Dockerfile
+++ b/data_management/opensearch_indexer/Dockerfile
@@ -2,7 +2,7 @@
 FROM python@sha256:17bc9f1d032a760546802cc4e406401eb5fe99dbcb4602c91628e73672fa749c
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apt-get update && apt-get -y upgrade && apt-get install -y --no-install-recommends \
     python3-dev \
     libxml2-dev libxslt1-dev \
     antiword unrtf poppler-utils tesseract-ocr \


### PR DESCRIPTION
<!-- Amend as appropriate -->
Critical OpenSSL vulnerability (CVE-2025-15467) affecting `openssl` and `openssl-provider-legacy`

**Fix**
Upgraded OS packages during the Docker image build to install patched OpenSSL and legacy provider versions
