### PR TITLE
change to use two coverage files

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -67,13 +67,26 @@ jobs:
       run: |
         docker compose -f docker-compose.test.yml run --rm access_copy_converter_tests
 
-    - name: Copy coverage file from shared volume
+    - name: Copy OpenSearch Indexer coverage file from shared volume
       run: |
-        cp ./test_results/coverage.xml ./coverage.xml || echo "Coverage file not found"
+        cp ./test_results/opensearch_indexer_coverage.xml ./opensearch_indexer_coverage.xml || echo "OpenSearch Indexer coverage file not found"
 
-    - name: Upload coverage to Codecov
+    - name: Upload OpenSearch Indexer coverage to Codecov
       uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
       with:
-        file: ./coverage.xml
+        files: ./opensearch_indexer_coverage.xml
         token: ${{ secrets.CODECOV_TOKEN }}
         slug: ${{ github.repository }}
+        flags: opensearch_indexer
+
+    - name: Copy Access Copy Converter coverage file from shared volume
+      run: |
+        cp ./test_results/access_copy_converter_coverage.xml ./access_copy_converter_coverage.xml || echo "Access Copy Converter coverage file not found"
+
+    - name: Upload Access Copy Converter coverage to Codecov
+      uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de
+      with:
+        files: ./access_copy_converter_coverage.xml
+        token: ${{ secrets.CODECOV_TOKEN }}
+        slug: ${{ github.repository }}
+        flags: access_copy_converter

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,7 +21,7 @@ services:
 
         pytest \
           --cov=data_management/opensearch_indexer/opensearch_indexer \
-          --cov-report=xml:/test_results/coverage.xml \
+          --cov-report=xml:/test_results/opensearch_indexer_coverage.xml \
           --cov-report=term-missing \
           -vvs data_management/opensearch_indexer/tests
     depends_on:
@@ -51,7 +51,7 @@ services:
 
         pytest \
           --cov=data_management/access_copy_converter/access_copy_converter \
-          --cov-report=xml:/test_results/coverage.xml \
+          --cov-report=xml:/test_results/access_copy_converter_coverage.xml \
           --cov-report=term-missing \
           -vvs data_management/access_copy_converter/tests
     depends_on:


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
- Add opensearch_indexer_coverage.xml for codecov

## JIRA ticket
- https://national-archives.atlassian.net/browse/AYR-1921

## Screenshots of UI changes
<img width="1571" height="638" alt="Screenshot 2026-03-05 at 17 28 28" src="https://github.com/user-attachments/assets/195726cc-fde7-406f-a980-7242679c7684" />

### Before

### After

- [ ] Requires env variable(s) to be updated
