### PR TITLE
chore: add read-only content permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -1,5 +1,8 @@
 name: Run E2E Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/pre_commit.yml
+++ b/.github/workflows/pre_commit.yml
@@ -1,4 +1,7 @@
 name: Pre-commit check
+
+permissions:
+  contents: read
 on:
   pull_request:
   merge_group:

--- a/.github/workflows/trigger_staging_cd.yml
+++ b/.github/workflows/trigger_staging_cd.yml
@@ -1,5 +1,8 @@
 name: Trigger Non Prod Deployment CD
 
+permissions:
+  contents: read
+
 on:
     push:
       branches:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,5 +1,8 @@
 name: Run Unit Tests
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   merge_group:


### PR DESCRIPTION
## Changes in this PR

add read-only content permissions to GitHub Actions workflows

## JIRA ticket
No-ticket

Should fix 5 dependabot security code scanning issues