### PR TITLE
Fix 405 MethodNotAllowed causing 500 due to missing template

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -6,12 +6,14 @@ from flask import (
     Response,
     abort,
     current_app,
+    jsonify,
     redirect,
     render_template,
     request,
     session,
     url_for,
 )
+from jinja2.exceptions import TemplateNotFound
 from sqlalchemy import func
 from werkzeug.exceptions import HTTPException, NotFound
 
@@ -1031,4 +1033,17 @@ def terms_of_use():
 
 @bp.app_errorhandler(HTTPException)
 def http_exception(error):
-    return render_template(f"{error.code}.html"), error.code
+    try:
+        return render_template(f"{error.code}.html"), error.code
+    except TemplateNotFound:
+        return (
+            jsonify(
+                {
+                    "method": request.method,
+                    "error": error.name,
+                    "message": error.description,
+                    "code": error.code,
+                }
+            ),
+            error.code,
+        )

--- a/app/tests/test_routes.py
+++ b/app/tests/test_routes.py
@@ -571,3 +571,15 @@ class TestRoutes:
 
         assert response.status_code == 200
         assert b"Converted access copy not available." in response.data
+
+    def test_method_not_allowed_returns_json(self, client: FlaskClient):
+        """
+        Test that a POST request to a GET-only route returns 405 JSON
+        instead of crashing with 500 due to missing 405.html template
+        """
+        response = client.post("/")
+        assert response.status_code == 405
+        data = json.loads(response.data)
+        assert data["code"] == 405
+        assert data["error"] == "Method Not Allowed"
+        assert data["method"] == "POST"


### PR DESCRIPTION
Added TemplateNotFound fallback in http_exception error handler to return
JSON response when no template exists for the error code. Prevents false
500 errors and noisy Slack alerts