### PR TITLE
changed logic for status tag colour

### DIFF
--- a/app/templates/main/browse-consignment.html
+++ b/app/templates/main/browse-consignment.html
@@ -100,7 +100,7 @@
                                     </td>
                                 {% endif %}
                                 <td class="govuk-table__cell">
-                                    <strong class="{% if record['closure_type'] == 'Open' %}govuk-tag govuk-tag--green{% elif record['closure_type'] == 'Closed' %}govuk-tag govuk-tag--red{% elif record['closure_type'] is none %}{% endif %}">
+                                    <strong class="{% if record['closure_type'] == 'Open' %}govuk-tag govuk-tag--green {% else %}govuk-tag govuk-tag--red {% endif %}">
                                         {{ record['closure_type'] }}
                                     </strong>
                                 </td>

--- a/app/templates/main/summary_list_items.html
+++ b/app/templates/main/summary_list_items.html
@@ -6,10 +6,10 @@
                 <dd class="govuk-summary-list__value govuk-summary-list__value--record">
                     {% if value %}
                         {% if key == "Status" %}
-                            {% if (value | lower == "closed") %}
-                                <span class="govuk-tag govuk-tag--red">{{ value }}</span>
-                            {% else %}
+                            {% if (value | lower == "open") %}
                                 <span class="govuk-tag govuk-tag--green">{{ value }}</span>
+                            {% else %}
+                                <span class="govuk-tag govuk-tag--red">{{ value }}</span>
                             {% endif %}
                             {% if dict.get("Closure start date") %}
                                 {% if dict.get('opening_date') %}


### PR DESCRIPTION
Updated closure_type status tag colour logic in both the consignment browse and record detail templates to support the new `Access Under Review` status and align the two templates