### PR TITLE
test supress warning

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -56,7 +56,6 @@ from app.main.util.pagination import (
     paginate,
 )
 from app.main.util.render_utils import (
-    PDFOpenError,
     create_presigned_url,
     create_presigned_url_for_access_copy,
     extract_single_page_as_image,
@@ -963,11 +962,6 @@ def get_page_image(record_id: uuid.UUID, page_number: int):
     except ValueError as e:
         current_app.app_logger.error(f"Invalid page number {page_number}: {e}")
         abort(400)
-    except PDFOpenError as e:
-        current_app.app_logger.error(
-            f"Failed to open PDF for page {page_number}: {e}"
-        )
-        abort(500)
     except Exception as e:
         current_app.app_logger.error(
             f"Failed to extract page {page_number} as image: {e}"
@@ -1028,11 +1022,6 @@ def get_page_thumbnail(record_id: uuid.UUID, page_number: int):
             f"Invalid page number {page_number} for thumbnail: {e}"
         )
         abort(400)
-    except PDFOpenError as e:
-        current_app.app_logger.error(
-            f"Failed to open PDF for page {page_number} thumbnail: {e}"
-        )
-        abort(500)
     except Exception as e:
         current_app.app_logger.error(
             f"Failed to extract page {page_number} as thumbnail: {e}"

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -56,6 +56,7 @@ from app.main.util.pagination import (
     paginate,
 )
 from app.main.util.render_utils import (
+    PDFOpenError,
     create_presigned_url,
     create_presigned_url_for_access_copy,
     extract_single_page_as_image,
@@ -962,6 +963,11 @@ def get_page_image(record_id: uuid.UUID, page_number: int):
     except ValueError as e:
         current_app.app_logger.error(f"Invalid page number {page_number}: {e}")
         abort(400)
+    except PDFOpenError as e:
+        current_app.app_logger.error(
+            f"Failed to open PDF for page {page_number}: {e}"
+        )
+        abort(500)
     except Exception as e:
         current_app.app_logger.error(
             f"Failed to extract page {page_number} as image: {e}"
@@ -1022,6 +1028,11 @@ def get_page_thumbnail(record_id: uuid.UUID, page_number: int):
             f"Invalid page number {page_number} for thumbnail: {e}"
         )
         abort(400)
+    except PDFOpenError as e:
+        current_app.app_logger.error(
+            f"Failed to open PDF for page {page_number} thumbnail: {e}"
+        )
+        abort(500)
     except Exception as e:
         current_app.app_logger.error(
             f"Failed to extract page {page_number} as thumbnail: {e}"

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -9,6 +9,8 @@ from botocore.exceptions import ClientError
 from flask import Response, current_app, jsonify, url_for
 from PIL import Image
 
+from app.main.db.models import File
+
 
 @contextlib.contextmanager
 def _open_pdf(pdf_bytes: bytes):
@@ -29,9 +31,6 @@ def _open_pdf(pdf_bytes: bytes):
                 current_app.logger.debug("MuPDF: %s", messages)
             except RuntimeError:
                 pass  # current_app raises RuntimeError outside app context, debug logging is not critical
-
-
-from app.main.db.models import File
 
 
 def generate_breadcrumb_values(file):

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -30,6 +30,7 @@ def _open_pdf(pdf_bytes: bytes):
             except RuntimeError:
                 pass
 
+
 from app.main.db.models import File
 
 

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -1,6 +1,7 @@
 import base64
 import contextlib
 import io
+import logging
 from typing import List
 
 import boto3
@@ -11,6 +12,8 @@ from PIL import Image
 
 from app.main.db.models import File
 
+logger = logging.getLogger(__name__)
+
 
 @contextlib.contextmanager
 def _open_pdf(pdf_bytes: bytes):
@@ -18,16 +21,18 @@ def _open_pdf(pdf_bytes: bytes):
     pymupdf.TOOLS.mupdf_display_errors(False)
     pymupdf.TOOLS.mupdf_display_warnings(False)
     try:
-        with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as doc:
+        try:
+            doc = pymupdf.open("pdf", io.BytesIO(pdf_bytes))
+        except Exception as e:
+            raise ValueError(f"Failed to open PDF: {e}") from e
+        with doc:
             yield doc
-    except Exception as e:
-        raise ValueError(f"Failed to open PDF: {e}") from e
     finally:
         messages = pymupdf.TOOLS.mupdf_warnings(reset=True)
         pymupdf.TOOLS.mupdf_display_errors(True)
         pymupdf.TOOLS.mupdf_display_warnings(True)
         if messages:
-            current_app.logger.debug("MuPDF: %s", messages)
+            logger.debug("MuPDF: %s", messages)
 
 
 def generate_breadcrumb_values(file):

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -1,4 +1,5 @@
 import base64
+import contextlib
 import io
 from typing import List
 
@@ -7,6 +8,27 @@ import pymupdf
 from botocore.exceptions import ClientError
 from flask import Response, current_app, jsonify, url_for
 from PIL import Image
+
+
+@contextlib.contextmanager
+def _open_pdf(pdf_bytes: bytes):
+    """Open a PDF with MuPDF stderr suppressed; log any collected messages at DEBUG."""
+    pymupdf.TOOLS.mupdf_display_errors(False)
+    pymupdf.TOOLS.mupdf_display_warnings(False)
+    try:
+        with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as doc:
+            yield doc
+    except Exception as e:
+        raise ValueError(f"Failed to open PDF: {e}") from e
+    finally:
+        messages = pymupdf.TOOLS.mupdf_warnings(reset=True)
+        pymupdf.TOOLS.mupdf_display_errors(True)
+        pymupdf.TOOLS.mupdf_display_warnings(True)
+        if messages:
+            try:
+                current_app.logger.debug("MuPDF: %s", messages)
+            except RuntimeError:
+                pass
 
 from app.main.db.models import File
 
@@ -68,7 +90,7 @@ def extract_pdf_pages_as_images(pdf_bytes: bytes) -> List[dict]:
     """Extract PDF pages as images and return page info with base64 thumbnails."""
     DPI = 150  # Output DPI for rendering
 
-    with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as pdf_document:
+    with _open_pdf(pdf_bytes) as pdf_document:
         page_data = []
 
         for page_num in range(pdf_document.page_count):
@@ -139,7 +161,7 @@ def extract_single_page_as_image(
     """
     DPI = 150
 
-    with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as pdf_document:
+    with _open_pdf(pdf_bytes) as pdf_document:
         if page_number < 1 or page_number > pdf_document.page_count:
             raise ValueError(
                 f"Invalid page number: {page_number}. PDF has {pdf_document.page_count} pages."
@@ -232,7 +254,7 @@ def generate_pdf_manifest(
 
     canvas_items = []
 
-    with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as pdf_document:
+    with _open_pdf(pdf_bytes) as pdf_document:
         page_count = pdf_document.page_count
         current_app.logger.info(f"PDF has {page_count} pages")
 
@@ -438,7 +460,7 @@ def search_within_pdf(
     hits = []
     annotation_count = 0
 
-    with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as pdf_document:
+    with _open_pdf(pdf_bytes) as pdf_document:
         for page_num in range(pdf_document.page_count):
             page = pdf_document.load_page(page_num)
             rects = page.search_for(query)

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -15,6 +15,10 @@ from app.main.db.models import File
 logger = logging.getLogger(__name__)
 
 
+class PDFOpenError(Exception):
+    """Raised when a PDF cannot be opened/parsed by MuPDF."""
+
+
 @contextlib.contextmanager
 def _open_pdf(pdf_bytes: bytes):
     """Open a PDF with MuPDF stderr suppressed; log any collected messages at DEBUG."""
@@ -23,8 +27,8 @@ def _open_pdf(pdf_bytes: bytes):
     try:
         try:
             doc = pymupdf.open("pdf", io.BytesIO(pdf_bytes))
-        except Exception as e:
-            raise ValueError(f"Failed to open PDF: {e}") from e
+        except pymupdf.FileDataError as e:
+            raise PDFOpenError(f"Failed to open PDF: {e}") from e
         with doc:
             yield doc
     finally:

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -27,10 +27,7 @@ def _open_pdf(pdf_bytes: bytes):
         pymupdf.TOOLS.mupdf_display_errors(True)
         pymupdf.TOOLS.mupdf_display_warnings(True)
         if messages:
-            try:
-                current_app.logger.debug("MuPDF: %s", messages)
-            except RuntimeError:
-                pass  # current_app raises RuntimeError outside app context, debug logging is not critical
+            current_app.logger.debug("MuPDF: %s", messages)
 
 
 def generate_breadcrumb_values(file):

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -15,21 +15,13 @@ from app.main.db.models import File
 logger = logging.getLogger(__name__)
 
 
-class PDFOpenError(Exception):
-    """Raised when a PDF cannot be opened/parsed by MuPDF."""
-
-
 @contextlib.contextmanager
 def _open_pdf(pdf_bytes: bytes):
     """Open a PDF with MuPDF stderr suppressed; log any collected messages at DEBUG."""
     pymupdf.TOOLS.mupdf_display_errors(False)
     pymupdf.TOOLS.mupdf_display_warnings(False)
     try:
-        try:
-            doc = pymupdf.open("pdf", io.BytesIO(pdf_bytes))
-        except pymupdf.FileDataError as e:
-            raise PDFOpenError(f"Failed to open PDF: {e}") from e
-        with doc:
+        with pymupdf.open("pdf", io.BytesIO(pdf_bytes)) as doc:
             yield doc
     finally:
         messages = pymupdf.TOOLS.mupdf_warnings(reset=True)

--- a/app/main/util/render_utils.py
+++ b/app/main/util/render_utils.py
@@ -28,7 +28,7 @@ def _open_pdf(pdf_bytes: bytes):
             try:
                 current_app.logger.debug("MuPDF: %s", messages)
             except RuntimeError:
-                pass
+                pass  # current_app raises RuntimeError outside app context, debug logging is not critical
 
 
 from app.main.db.models import File

--- a/app/tests/test_page_routes.py
+++ b/app/tests/test_page_routes.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from flask.testing import FlaskClient
 from moto import mock_aws
 
+from app.main.util.render_utils import PDFOpenError
 from app.tests.factories import FileFactory
 from app.tests.test_routes import create_mock_s3_bucket_with_object
 from configs.base_config import CONVERTIBLE_PUIDS
@@ -58,6 +61,53 @@ class TestPageImageRoutes:
         response = client.get(f"/record/{file.FileId}/page/99")
 
         assert response.status_code == 400
+
+    @mock_aws
+    @patch("app.main.routes.extract_single_page_as_image")
+    def test_get_page_image_pdf_open_error_returns_500(
+        self, mock_extract, app, client: FlaskClient, mock_all_access_user
+    ):
+        """A PDF that cannot be opened is a server-side data error (500),
+        not a 400 invalid page number error."""
+        mock_all_access_user(client)
+        mock_extract.side_effect = PDFOpenError("Failed to open PDF: broken")
+
+        file = FileFactory(
+            ffid_metadata__PUID="fmt/18",
+            ffid_metadata__Extension="pdf",
+            FileName="test.pdf",
+        )
+
+        bucket_name = "test-bucket"
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+        create_mock_s3_bucket_with_object(bucket_name, file)
+
+        response = client.get(f"/record/{file.FileId}/page/1")
+
+        assert response.status_code == 500
+
+    @mock_aws
+    @patch("app.main.routes.extract_single_page_as_thumbnail")
+    def test_get_page_thumbnail_pdf_open_error_returns_500(
+        self, mock_extract, app, client: FlaskClient, mock_all_access_user
+    ):
+        """A PDF that cannot be opened returns 500 for the thumbnail route."""
+        mock_all_access_user(client)
+        mock_extract.side_effect = PDFOpenError("Failed to open PDF: broken")
+
+        file = FileFactory(
+            ffid_metadata__PUID="fmt/18",
+            ffid_metadata__Extension="pdf",
+            FileName="test.pdf",
+        )
+
+        bucket_name = "test-bucket"
+        app.config["RECORD_BUCKET_NAME"] = bucket_name
+        create_mock_s3_bucket_with_object(bucket_name, file)
+
+        response = client.get(f"/record/{file.FileId}/page/1/thumbnail")
+
+        assert response.status_code == 500
 
     @mock_aws
     def test_get_page_image_file_not_found(

--- a/app/tests/test_page_routes.py
+++ b/app/tests/test_page_routes.py
@@ -1,9 +1,9 @@
 from unittest.mock import patch
 
+import pymupdf
 from flask.testing import FlaskClient
 from moto import mock_aws
 
-from app.main.util.render_utils import PDFOpenError
 from app.tests.factories import FileFactory
 from app.tests.test_routes import create_mock_s3_bucket_with_object
 from configs.base_config import CONVERTIBLE_PUIDS
@@ -70,7 +70,9 @@ class TestPageImageRoutes:
         """A PDF that cannot be opened is a server-side data error (500),
         not a 400 invalid page number error."""
         mock_all_access_user(client)
-        mock_extract.side_effect = PDFOpenError("Failed to open PDF: broken")
+        mock_extract.side_effect = pymupdf.FileDataError(
+            "Failed to open PDF: broken"
+        )
 
         file = FileFactory(
             ffid_metadata__PUID="fmt/18",
@@ -93,7 +95,9 @@ class TestPageImageRoutes:
     ):
         """A PDF that cannot be opened returns 500 for the thumbnail route."""
         mock_all_access_user(client)
-        mock_extract.side_effect = PDFOpenError("Failed to open PDF: broken")
+        mock_extract.side_effect = pymupdf.FileDataError(
+            "Failed to open PDF: broken"
+        )
 
         file = FileFactory(
             ffid_metadata__PUID="fmt/18",

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -1,9 +1,12 @@
+import logging
 from unittest.mock import Mock, patch
 
 import pymupdf
+import pytest
 from flask import Flask
 
 from app.main.util.render_utils import (
+    _open_pdf,
     create_presigned_url,
     extract_pdf_pages_as_images,
     extract_single_page_as_image,
@@ -14,6 +17,8 @@ from app.main.util.render_utils import (
     get_file_puid,
     search_within_pdf,
 )
+
+RENDER_UTILS_LOGGER = "app.main.util.render_utils"
 
 
 def _make_pdf_with_text(text: str) -> bytes:
@@ -167,21 +172,21 @@ def test_extract_single_page_as_image_second_page():
 
 def test_extract_single_page_as_image_invalid_page_zero():
     """Test that page number 0 raises ValueError."""
-    try:
+    with pytest.raises(ValueError) as exc_info:
         extract_single_page_as_image(MINIMAL_VALID_PDF_TWO_PAGES, 0)
-        assert False, "Expected ValueError"
-    except ValueError as e:
-        assert "Invalid page number" in str(e)
+    message = str(exc_info.value)
+    assert message.startswith("Invalid page number")
+    assert "Failed to open PDF" not in message
 
 
 def test_extract_single_page_as_image_invalid_page_too_high():
     """Test that page number beyond PDF page count raises ValueError."""
-    try:
+    with pytest.raises(ValueError) as exc_info:
         extract_single_page_as_image(MINIMAL_VALID_PDF_TWO_PAGES, 99)
-        assert False, "Expected ValueError"
-    except ValueError as e:
-        assert "Invalid page number" in str(e)
-        assert "2 pages" in str(e)
+    message = str(exc_info.value)
+    assert message.startswith("Invalid page number")
+    assert "2 pages" in message
+    assert "Failed to open PDF" not in message
 
 
 # Tests for extract_single_page_as_thumbnail
@@ -239,3 +244,79 @@ def test_search_within_pdf_returns_annotations_for_matches(
     hit = data["hits"][0]
     assert hit["@type"] == "search:Hit"
     assert hit["match"] == "hello"
+
+
+def _mupdf_messages(records):
+    return [r.message for r in records if r.message.startswith("MuPDF:")]
+
+
+def test_open_pdf_logs_recoverable_messages_at_debug(caplog):
+    """A repairable PDF opens fine and its MuPDF messages are logged at DEBUG."""
+    with caplog.at_level(logging.DEBUG, logger=RENDER_UTILS_LOGGER):
+        with _open_pdf(MINIMAL_VALID_PDF_TWO_PAGES) as doc:
+            assert doc.page_count == 2
+
+    messages = _mupdf_messages(caplog.records)
+    assert messages, "expected MuPDF repair messages to be logged"
+    assert "repairing PDF document" in messages[0]
+    assert all(
+        r.levelno == logging.DEBUG
+        for r in caplog.records
+        if r.message.startswith("MuPDF:")
+    )
+
+
+def test_open_pdf_clean_pdf_logs_nothing(caplog):
+    """A well formed PDF produces no MuPDF messages, so nothing is logged."""
+    clean_pdf = _make_pdf_with_text("hello")
+    with caplog.at_level(logging.DEBUG, logger=RENDER_UTILS_LOGGER):
+        with _open_pdf(clean_pdf) as doc:
+            assert doc.page_count == 1
+
+    assert _mupdf_messages(caplog.records) == []
+
+
+def test_open_pdf_empty_bytes_raises_value_error():
+    """Genuine open failures are normalised to ValueError."""
+    with pytest.raises(ValueError, match="Failed to open PDF"):
+        with _open_pdf(b""):
+            pass
+
+
+def test_open_pdf_garbage_raises_value_error():
+    with pytest.raises(ValueError, match="Failed to open PDF"):
+        with _open_pdf(b"this is not a pdf"):
+            pass
+
+
+def test_open_pdf_propagates_body_exceptions_untouched():
+    """Errors raised inside the with body must keep their type and message."""
+    with pytest.raises(KeyError, match="unrelated"):
+        with _open_pdf(MINIMAL_VALID_PDF_TWO_PAGES):
+            raise KeyError("unrelated")
+
+
+def test_open_pdf_restores_mupdf_display_flags():
+    """The context manager re-enables MuPDF stderr display on exit."""
+    pymupdf.TOOLS.mupdf_display_errors(True)
+    pymupdf.TOOLS.mupdf_display_warnings(True)
+
+    with _open_pdf(MINIMAL_VALID_PDF_TWO_PAGES):
+        assert pymupdf.TOOLS.mupdf_display_errors() is False
+        assert pymupdf.TOOLS.mupdf_display_warnings() is False
+
+    assert pymupdf.TOOLS.mupdf_display_errors() is True
+    assert pymupdf.TOOLS.mupdf_display_warnings() is True
+
+
+def test_open_pdf_restores_mupdf_display_flags_on_failure():
+    """Flags are restored even when opening fails."""
+    pymupdf.TOOLS.mupdf_display_errors(True)
+    pymupdf.TOOLS.mupdf_display_warnings(True)
+
+    with pytest.raises(ValueError):
+        with _open_pdf(b""):
+            pass
+
+    assert pymupdf.TOOLS.mupdf_display_errors() is True
+    assert pymupdf.TOOLS.mupdf_display_warnings() is True

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -6,7 +6,6 @@ import pytest
 from flask import Flask
 
 from app.main.util.render_utils import (
-    PDFOpenError,
     _open_pdf,
     create_presigned_url,
     extract_pdf_pages_as_images,
@@ -277,15 +276,15 @@ def test_open_pdf_clean_pdf_logs_nothing(caplog):
     assert _mupdf_messages(caplog.records) == []
 
 
-def test_open_pdf_empty_bytes_raises_pdf_open_error():
-    """Genuine open failures are normalised to PDFOpenError."""
-    with pytest.raises(PDFOpenError, match="Failed to open PDF"):
+def test_open_pdf_empty_bytes_raises_file_data_error():
+    """Genuine open failures propagate as pymupdf.FileDataError."""
+    with pytest.raises(pymupdf.FileDataError):
         with _open_pdf(b""):
             pass
 
 
-def test_open_pdf_garbage_raises_pdf_open_error():
-    with pytest.raises(PDFOpenError, match="Failed to open PDF"):
+def test_open_pdf_garbage_raises_file_data_error():
+    with pytest.raises(pymupdf.FileDataError):
         with _open_pdf(b"this is not a pdf"):
             pass
 
@@ -315,7 +314,7 @@ def test_open_pdf_restores_mupdf_display_flags_on_failure():
     pymupdf.TOOLS.mupdf_display_errors(True)
     pymupdf.TOOLS.mupdf_display_warnings(True)
 
-    with pytest.raises(PDFOpenError):
+    with pytest.raises(pymupdf.FileDataError):
         with _open_pdf(b""):
             pass
 

--- a/app/tests/test_render_utils.py
+++ b/app/tests/test_render_utils.py
@@ -6,6 +6,7 @@ import pytest
 from flask import Flask
 
 from app.main.util.render_utils import (
+    PDFOpenError,
     _open_pdf,
     create_presigned_url,
     extract_pdf_pages_as_images,
@@ -276,15 +277,15 @@ def test_open_pdf_clean_pdf_logs_nothing(caplog):
     assert _mupdf_messages(caplog.records) == []
 
 
-def test_open_pdf_empty_bytes_raises_value_error():
-    """Genuine open failures are normalised to ValueError."""
-    with pytest.raises(ValueError, match="Failed to open PDF"):
+def test_open_pdf_empty_bytes_raises_pdf_open_error():
+    """Genuine open failures are normalised to PDFOpenError."""
+    with pytest.raises(PDFOpenError, match="Failed to open PDF"):
         with _open_pdf(b""):
             pass
 
 
-def test_open_pdf_garbage_raises_value_error():
-    with pytest.raises(ValueError, match="Failed to open PDF"):
+def test_open_pdf_garbage_raises_pdf_open_error():
+    with pytest.raises(PDFOpenError, match="Failed to open PDF"):
         with _open_pdf(b"this is not a pdf"):
             pass
 
@@ -314,7 +315,7 @@ def test_open_pdf_restores_mupdf_display_flags_on_failure():
     pymupdf.TOOLS.mupdf_display_errors(True)
     pymupdf.TOOLS.mupdf_display_warnings(True)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(PDFOpenError):
         with _open_pdf(b""):
             pass
 


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Change MuPDF logs to use flask debug logs when a malformed PDF is detected. MuPDF logs a non blocking structure tree warning and continues. A similar message occurs for structure tree validation warnings that MuPDF emits for non conforming PDFs.

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-2042

## Screenshots of UI changes
N/A

### Before

### After

- [ ] Requires env variable(s) to be updated
