### PR TITLE
[AYR-2025] update custom link to align with GDS hover in govuk-table

### DIFF
--- a/app/static/src/scss/includes/_overrides.scss
+++ b/app/static/src/scss/includes/_overrides.scss
@@ -1,3 +1,5 @@
+@use "variables" as *;
+
 legend {
   padding-inline: 0;
 }
@@ -26,5 +28,14 @@ a {
     &--search {
       margin-bottom: 0;
     }
+  }
+}
+
+.govuk-table a,
+.govuk-table__cell a {
+  &:hover,
+  &:visited:hover {
+    color: $colour-link-hover;
+    text-decoration-thickness: 3px;
   }
 }

--- a/app/static/src/scss/includes/_variables.scss
+++ b/app/static/src/scss/includes/_variables.scss
@@ -7,7 +7,7 @@ $breakpoint-desktop: 1056px;
 // colour__component__type
 $colour-link-normal: #0b0c0c;
 $colour-link-default: #1d70b8;
-$colour-link-hover: #0f385c;
+$colour-link-hover: govuk-functional-colour("link-hover");
 $colour-link-visited: #4c2c92;
 $colour-border-normal: #b1b4b6;
 $colour-container-normal: #f3f2f1;


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Add  a hover state/color to align with GDS in **govuk-table**
## JIRA ticket
https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?selectedIssue=AYR-2025
## Screenshots of UI changes

### Before
<img width="721" height="285" alt="Before" src="https://github.com/user-attachments/assets/5d0a996e-dc37-4749-b762-673632fdf2e6" />

### After
<img width="721" height="285" alt="After" src="https://github.com/user-attachments/assets/ef5bcfa2-1740-4ed0-b1b0-987a7ef05244" />

- [ ] Requires env variable(s) to be updated
