### PR TITLE
[AYR-2029] align tag text colour with GDS

### DIFF
--- a/app/static/src/scss/includes/_record.scss
+++ b/app/static/src/scss/includes/_record.scss
@@ -209,7 +209,6 @@
   &--red {
     font-size: 1rem;
     text-transform: capitalize;
-    color: $colour-status-closed;
     font-weight: 400;
     letter-spacing: 0;
   }
@@ -217,7 +216,6 @@
   &--green {
     font-size: 1rem;
     text-transform: capitalize;
-    color: $colour-status-open;
     font-weight: 400;
     letter-spacing: 0;
   }

--- a/app/static/src/scss/includes/_variables.scss
+++ b/app/static/src/scss/includes/_variables.scss
@@ -7,13 +7,11 @@ $breakpoint-desktop: 1056px;
 // colour__component__type
 $colour-link-normal: #0b0c0c;
 $colour-link-default: #1d70b8;
-$colour-link-hover: #003078;
+$colour-link-hover: #0f385c;
 $colour-link-visited: #4c2c92;
 $colour-border-normal: #b1b4b6;
 $colour-container-normal: #f3f2f1;
 $colour-timeline-normal: #005ea5;
-$colour-status-closed: #942514;
-$colour-status-open: #005a30;
 $colour-placeholder-normal: #c00;
 
 // font__component__type


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
Align tag text color to align with GDS 
## JIRA ticket
https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?selectedIssue=AYR-2029
## Screenshots of UI changes

### Before
<img width="634" height="230" alt="Before" src="https://github.com/user-attachments/assets/4dd08cec-565a-4011-a2e5-468ed224ac11" />

### After
<img width="634" height="230" alt="After" src="https://github.com/user-attachments/assets/34cf5b9c-2395-438a-9e79-eddb517e7b7e" />

- [ ] Requires env variable(s) to be updated
