### PR TITLE
[AYR-2028] update pagination

### DIFF
--- a/app/templates/main/pagination.html
+++ b/app/templates/main/pagination.html
@@ -10,6 +10,7 @@
                 <a data-testid="pagination-link"
                    class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None -%} {{ url_for(view_name, _id=id, page=current_page-1, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=current_page-1, **filtered_params) }} {%- endif %}#tbl_result"
+                   aria-label="Previous, Search results page {{ current_page - 1 }} of {{ pagination.pages|length }}"
                    rel="prev">
                     <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
                          xmlns="http://www.w3.org/2000/svg"
@@ -26,7 +27,7 @@
                 </a>
             </div>
         {% endif %}
-        <ul class="govuk-pagination__list">
+        <ul class="govuk-pagination__list" aria-label="Pagination">
             {% for page in pagination.pages %}
                 <li class="govuk-pagination__item {% if page == current_page %}govuk-pagination__item--current{% endif %} {% if page == 'ellipsis' %}govuk-pagination__item--ellipsis{% endif %} ">
                     {% if page == 'ellipsis' %}
@@ -35,7 +36,7 @@
                         <a data-testid="pagination-link"
                            class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                            href="{% if id != None -%} {{ url_for(view_name, _id=id , page=page, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=page, **filtered_params) }} {%- endif %}#tbl_result"
-                           aria-label="Page {{ page }}">{{ page }}</a>
+                           aria-label="Search results page {{ page }} of {{ pagination.pages|length }}">{{ page }}</a>
                     {% endif %}
                 </li>
             {% endfor %}
@@ -45,6 +46,7 @@
                 <a data-testid="pagination-link"
                    class="govuk-link govuk-link__no-visited-color govuk-pagination__link"
                    href="{% if id != None -%} {{ url_for(view_name, _id=id , page=current_page+1, **filtered_params) }} {%- else -%} {{ url_for(view_name, page=current_page+1, **filtered_params) }}{%- endif %}#tbl_result"
+                   aria-label="Next, Search results page {{ current_page + 1 }} of {{ pagination.pages|length }}"
                    rel="next">
                     <span data-testid="pagination-link-title"
                           class="govuk-pagination__link-title">Next<span class="govuk-visually-hidden">page</span></span>

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -976,7 +976,7 @@ class TestSearchTransferringBody:
         )
 
         assert response.status_code == 200
-        assert b'aria-label="Search results page 2 of 3"' in response.data
+        assert b'aria-label="Search results page 2 of 5"' in response.data
 
         soup = BeautifulSoup(response.data, "html.parser")
 

--- a/app/tests/test_search.py
+++ b/app/tests/test_search.py
@@ -882,10 +882,10 @@ class TestSearchTransferringBody:
         assert b"Records found 15" in response.data
 
         # check pagination
-        assert b'aria-label="Page 1"' in response.data
-        assert b'aria-label="Page 2"' in response.data
-        assert b'aria-label="Page 3"' in response.data
-        assert b'aria-label="Page 4"' not in response.data
+        assert b'aria-label="Search results page 1 of 3"' in response.data
+        assert b'aria-label="Search results page 2 of 3"' in response.data
+        assert b'aria-label="Search results page 3 of 3"' in response.data
+        assert b'aria-label="Search results page 4 of 3"' not in response.data
 
         soup = BeautifulSoup(response.data, "html.parser")
 
@@ -930,7 +930,7 @@ class TestSearchTransferringBody:
         )
 
         assert response.status_code == 200
-        assert b'aria-label="Page 1"' in response.data
+        assert b'aria-label="Search results page 1 of 3"' in response.data
 
         soup = BeautifulSoup(response.data, "html.parser")
 
@@ -976,7 +976,7 @@ class TestSearchTransferringBody:
         )
 
         assert response.status_code == 200
-        assert b'aria-label="Page 2"' in response.data
+        assert b'aria-label="Search results page 2 of 3"' in response.data
 
         soup = BeautifulSoup(response.data, "html.parser")
 
@@ -1027,7 +1027,7 @@ class TestSearchTransferringBody:
         )
 
         assert response.status_code == 200
-        assert b'aria-label="Page 3"' in response.data
+        assert b'aria-label="Search results page 3 of 3"' in response.data
 
         soup = BeautifulSoup(response.data, "html.parser")
 

--- a/app/tests/test_templates/test_pagination_template.py
+++ b/app/tests/test_templates/test_pagination_template.py
@@ -125,7 +125,7 @@ class TestPaginationTemplate:
 
             assert "govuk-pagination__item--ellipsis" in rendered
             assert "..." in rendered
-            assert 'aria-label="Page 5"' in rendered
+            assert 'aria-label="Search results page 5 of 7"' in rendered
 
     def test_template_renders_nothing_when_no_pagination(self, app):
         """Test template renders empty when pagination is None."""


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
This is an update to pagination for the checkbox : screen reader users know they’ve navigated to a different page. For example, ‘Search results (page 1 of 4)’.

As the other checkboxes on the jira ticket were completed in this previous ticket here https://national-archives.atlassian.net/browse/AYR-2053 and this commit https://github.com/nationalarchives/da-ayr-webapp/commit/73909d8e825fef517d0008c82544215b67f333a5

## JIRA ticket
https://national-archives.atlassian.net/jira/software/projects/AYR/boards/66?selectedIssue=AYR-2028
## Screenshots of UI changes

### Before
<img width="1270" height="580" alt="before-1" src="https://github.com/user-attachments/assets/8b36117e-3a67-4f18-b35c-3249eb2ecd02" />
<img width="1270" height="580" alt="before-2" src="https://github.com/user-attachments/assets/928a8d79-ad3a-4e80-829f-8b3eca0f2a59" />
<img width="1270" height="580" alt="before-3" src="https://github.com/user-attachments/assets/71a11293-f4d1-45bb-86f8-7ed07b9bcab3" />
<img width="1270" height="580" alt="before-4" src="https://github.com/user-attachments/assets/ace3fd6f-22c9-4146-b02a-bc90d5da9c99" />


### After
<img width="1270" height="580" alt="after-1" src="https://github.com/user-attachments/assets/9c50e4d0-d47a-460a-9773-b1cc1f9d395f" />
<img width="1270" height="580" alt="after-2" src="https://github.com/user-attachments/assets/4832bb3b-8dc7-494e-b0be-1c5aca0d71c9" />
<img width="1270" height="580" alt="after-3" src="https://github.com/user-attachments/assets/5e841efb-792d-49ea-a3c9-ec60e93a479c" />
<img width="1270" height="580" alt="after-4" src="https://github.com/user-attachments/assets/cb829968-ea71-4642-a0cd-3bfcb380a081" />

- [ ] Requires env variable(s) to be updated
