### PR TITLE
Simplify renovate to automerge everything apart from majors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ],
   "minimumReleaseAge": "7 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days",
+    "labels": ["security"]
+  },
   "packageRules": [
     {
       "matchUpdateTypes": [

--- a/renovate.json
+++ b/renovate.json
@@ -1,16 +1,32 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>nationalarchives/renovate-config",
-    "github>nationalarchives/renovate-config:github-actions",
-    "github>nationalarchives/renovate-config:python-packages",
-    "github>nationalarchives/renovate-config:pre-commit"
+    "config:recommended"
   ],
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "lockFileMaintenance",
+        "rollback",
+        "bump",
+        "replacement"
+      ],
+      "automerge": true
+    },
+    {
       "description": "Pin Python to 3.13 in GitHub Actions workflows; project requires >=3.13,<3.14",
-      "matchManagers": ["github-actions"],
-      "matchDepNames": ["python"],
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchDepNames": [
+        "python"
+      ],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## Changes in this PR

Simplify renovate to automerge everything apart from majors

Note we aren't using https://github.com/nationalarchives/renovate-config anymore. Eventually, it would be good to go back to it but our use case is simple enough that I don't feel it is worth overcomplicating for now.

In particular, our poetry updates weren't working because the Python ruleset with automerging only covered pip_requirements and not the poetry package manager also. Of course we could have proposed a change to that repo to include poetry in the list of package managers wherever it referenced pip_requirements but I have some more general feedback incoming on renovate-config repo. After that discussion, we can hopefully go back to using it to make use of org wide settings for security best practices.

## JIRA ticket

https://national-archives.atlassian.net/browse/AYR-2085
