### PR TITLE
Fix and add description for group which is to Keep Playwright runtime…

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,11 +34,16 @@
       "enabled": false
     },
     {
+      "description": "Keep Playwright runtime and Python deps in lockstep for e2e to avoid CI breakage on partial upgrades",
+      "matchFileNames": [
+        "e2e_tests/dockerfile",
+        "e2e_tests/requirements.txt"
+      ],
       "matchPackageNames": [
         "playwright",
-        "pytest-playwright",
         "mcr.microsoft.com/playwright/python"
       ],
+      "minimumGroupSize": 2,
       "minimumReleaseAgeBehaviour": "timestamp-optional",
       "groupName": "Playwright",
       "groupSlug": "playwright-group"


### PR DESCRIPTION
… and Python deps in lockstep for e2e to avoid CI breakage on partial upgrades

<!-- Amend as appropriate -->

## Changes in this PR

Force Renovate to only raise Playwright e2e updates when both the Playwright Docker base image and Python playwright package can be updated together, preventing CI-breaking partial bumps.

Before, the grouping would still create a PR for one of the dependencies if there wasn't another one vailable for the other dependency. Now we require both via minimumGroupSize": 2.

Also stopped trying to update playwright-pytest in the same group - that isn't coupled in the same way.


## JIRA ticket

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
