### PR TITLE
remove libroffice pin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tesseract-ocr=5.5.0-1+b1 \
     antiword=0.37-17 \
     unrtf \
-    libreoffice=4:25.2.3-2+deb13u5 \
+    libreoffice \
     nodejs=20.19.2+dfsg-1+deb13u2 \
     npm=9.2.0~ds1-3 \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- Amend as appropriate -->

## Changes in this PR
The Dockerfile previously pinned libreoffice to 4:25.2.3-2+deb13u5, which requires libreoffice-core at exactly the same version. When Debian released the +deb13u6 security update for trixie, the older +deb13u5 packages were removed from the archive as Debian only keeps the latest release, so apt could no longer install the pinned version and the image build failed.

## JIRA ticket

## Screenshots of UI changes

### Before

### After

- [ ] Requires env variable(s) to be updated
