### PR TITLE
Add StrictUndefined to Jinja2 environment for better error handling

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -9,7 +9,7 @@ from flask_compress import Compress
 from flask_s3 import FlaskS3
 from flask_talisman import Talisman
 from govuk_frontend_wtf.main import WTFormsHelpers
-from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader
+from jinja2 import ChoiceLoader, PackageLoader, PrefixLoader, StrictUndefined
 
 from app.logger_config import setup_logging
 from app.main.db.models import db
@@ -96,6 +96,7 @@ def create_app(config_class, local_env, database_uri=None):
 
     app.jinja_env.lstrip_blocks = True
     app.jinja_env.trim_blocks = True
+    app.jinja_env.undefined = StrictUndefined
     app.jinja_env.filters["null_to_dash"] = null_to_dash
     app.jinja_env.filters["clean_tags_and_replace_highlight_tag"] = (
         clean_tags_and_replace_highlight_tag

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -9,6 +9,7 @@ from jinja2 import (
     FileSystemLoader,
     PackageLoader,
     PrefixLoader,
+    StrictUndefined,
     select_autoescape,
 )
 from testing.postgresql import PostgresqlFactory
@@ -1228,5 +1229,6 @@ def jinja_env():
             ]
         ),
         autoescape=select_autoescape(["html", "xml"]),
+        undefined=StrictUndefined,
     )
     return env

--- a/app/tests/test_macros.py
+++ b/app/tests/test_macros.py
@@ -1,13 +1,22 @@
 import pytest
 from bs4 import BeautifulSoup
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    select_autoescape,
+)
 
 
 class TestBanners:
     @property
     def template(self):
         """Dynamically load and return the Jinja2 template."""
-        env = Environment(loader=FileSystemLoader("app/templates"))
+        env = Environment(
+            loader=FileSystemLoader("app/templates"),
+            undefined=StrictUndefined,
+            autoescape=select_autoescape(["html", "xml"]),
+        )
         return env.get_template("main/macros/banners.html")
 
     @property

--- a/storybook/render_macros.py
+++ b/storybook/render_macros.py
@@ -1,7 +1,12 @@
 import json
 import os
 
-from jinja2 import Environment, FileSystemLoader, select_autoescape
+from jinja2 import (
+    Environment,
+    FileSystemLoader,
+    StrictUndefined,
+    select_autoescape,
+)
 
 BASE_DIR = os.path.dirname(__file__)
 MACROS_DIR = os.path.join(BASE_DIR, "..", "app", "templates", "main", "macros")
@@ -43,6 +48,7 @@ def render_macros():
     env = Environment(
         loader=FileSystemLoader(MACROS_DIR),
         autoescape=select_autoescape(enabled_extensions=("html", "xml")),
+        undefined=StrictUndefined,
     )
 
     for task in MACRO_RENDER_TASKS:


### PR DESCRIPTION
## Changes in this PR

Add StrictUndefined to Jinja2 environment for better error handling

**Reason:**

During review of a recent pr we noticed that we could reference undefined variables in our templates with no error! This can result in confusing code, so we want to avoid that.



Blogpost with the same feelings I had when I found this out: https://alexwlchan.net/2022/strict-jinja/ 