### PR TITLE
Do not sort in base query to optimise browse-record query

### DIFF
--- a/app/main/db/queries.py
+++ b/app/main/db/queries.py
@@ -1,7 +1,10 @@
 import uuid
+from typing import Any, Optional
 
 from flask import current_app
 from sqlalchemy import DATE, and_, desc, func
+from sqlalchemy.orm import Query
+from sqlalchemy.sql.elements import ColumnElement
 
 from app.main.db.models import Body, Consignment, File, FileMetadata, Series, db
 
@@ -361,9 +364,11 @@ def _build_date_file_id_filters(date_filter_field, date_from, date_to):
     return [File.FileId.in_(sort_date_ids)]
 
 
-def _apply_base_query_sort(query, sorting_orders):
+def _apply_base_query_sort(
+    query: Query, sorting_orders: Optional[dict[str, str]]
+) -> Query:
     if not sorting_orders:
-        sorting_orders = {"date_of_record": "desc"}
+        return query
 
     if "date_of_record" in sorting_orders:
         sort_sq = (
@@ -435,9 +440,9 @@ def _apply_base_query_sort(query, sorting_orders):
 
 
 def build_browse_records_base_query(
-    accessible_transferring_body_names=None,
-    filters=None,
-    sorting_orders=None,
+    accessible_transferring_body_names: Optional[list[str]] = None,
+    filters: Optional[dict[str, Any]] = None,
+    sorting_orders: Optional[dict[str, str]] = None,
 ):
     """
     Stage-1 query: File/hierarchy only, no FileMetadata join in the main select.
@@ -468,7 +473,7 @@ def build_browse_records_base_query(
     return _apply_base_query_sort(query, sorting_orders)
 
 
-def get_browse_records_metadata_for_files(file_ids):
+def get_browse_records_metadata_for_files(file_ids: list[uuid.UUID]):
     """
     Stage-2 query: fetch and pivot the 4 browse metadata properties for a
     small set of file IDs. Reads only the rows needed for the current page.
@@ -820,7 +825,9 @@ def _get_file_metadata_query(file_id: uuid.UUID):
     return query
 
 
-def _build_date_range_filter(date_field, date_from, date_to):
+def _build_date_range_filter(
+    date_field: ColumnElement, date_from: Optional[str], date_to: Optional[str]
+) -> Optional[ColumnElement]:
     date_filter = None
     if date_from and date_to:
         date_filter = and_(

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -638,7 +638,7 @@ def browse_records():
     data_query = build_browse_records_base_query(
         accessible_transferring_body_names=accessible_body_names,
         filters=filters,
-        sorting_orders=sorting_orders,
+        sorting_orders=sorting_orders or {"date_of_record": "desc"},
     )
     count_query = build_browse_records_base_query(
         accessible_transferring_body_names=accessible_body_names,

--- a/app/tests/test_build_browse_records_base_query.py
+++ b/app/tests/test_build_browse_records_base_query.py
@@ -12,7 +12,7 @@ class TestBrowseRecordsBaseQuery:
         """
         Given a body name the user can access
         When build_browse_records_base_query is called and executed
-        Then it returns flattened records for that body ordered by date_of_record desc
+        Then it returns flattened records for that body
         """
         body_name = browse_consignment_files[0].consignment.series.body.Name
 
@@ -27,7 +27,7 @@ class TestBrowseRecordsBaseQuery:
         series = browse_consignment_files[0].consignment.series
         consignment = browse_consignment_files[0].consignment
 
-        expected_results = [
+        expected_results = {
             (
                 body.BodyId,
                 body.Name,
@@ -83,17 +83,18 @@ class TestBrowseRecordsBaseQuery:
                 "second_file.ppt",
                 browse_consignment_files[1].FilePath,
             ),
-        ]
+        }
 
-        assert results == expected_results
+        assert len(results) == len(expected_results)
+        assert set(results) == expected_results
 
-    def test_build_browse_records_base_query_none_sorting_orders_uses_default_sort(
+    def test_build_browse_records_base_query_none_sorting_orders_leaves_query_unsorted(
         self, client, mock_standard_user, browse_consignment_files
     ):
         """
         Given sorting_orders is None
         When build_browse_records_base_query is executed
-        Then the default date_of_record descending sort is applied
+        Then the helper leaves ordering to the caller
         """
         body_name = browse_consignment_files[0].consignment.series.body.Name
 
@@ -108,7 +109,7 @@ class TestBrowseRecordsBaseQuery:
             query.statement.compile(compile_kwargs={"literal_binds": True})
         )
 
-        assert "ORDER BY" in sql.upper()
+        assert "ORDER BY" not in sql.upper()
 
     def test_build_browse_records_base_query_sorts_by_opening_date_asc(
         self, client, mock_standard_user, browse_consignment_files
@@ -289,10 +290,10 @@ class TestBrowseRecordsBaseQuery:
         )
         results = query.all()
 
-        assert [result[7] for result in results] == [
+        assert sorted(result[7] for result in results) == [
+            "first_file.docx",
             "fourth_file.xls",
             "third_file.docx",
-            "first_file.docx",
         ]
 
     def test_build_browse_records_base_query_filters_by_last_modified_date_range(
@@ -317,7 +318,7 @@ class TestBrowseRecordsBaseQuery:
         )
         results = query.all()
 
-        assert [result[7] for result in results] == [
+        assert sorted(result[7] for result in results) == [
             "fifth_file.doc",
             "fourth_file.xls",
         ]
@@ -364,7 +365,7 @@ class TestBrowseRecordsBaseQuery:
         )
         results = query.all()
 
-        assert [result[7] for result in results] == [
+        assert sorted(result[7] for result in results) == [
             "fifth_file.doc",
             "fourth_file.xls",
         ]


### PR DESCRIPTION
## Changes in this PR

Do not sort in base query to optimise browse-record query
and some typehints

This is the main part for the query optimisation!

## JIRA ticket
https://national-archives.atlassian.net/browse/AYR-2068